### PR TITLE
feat(RPS-1027): separated plan and execute in motion group

### DIFF
--- a/examples/02_plan_and_execute.py
+++ b/examples/02_plan_and_execute.py
@@ -4,8 +4,6 @@ from nova.types import Pose
 from math import pi
 import asyncio
 
-from nova.core.movement_controller import move_forward
-
 
 async def main():
     nova = Nova()
@@ -39,7 +37,8 @@ async def main():
             jnt(home_joints),
         ]
 
-        await motion_group.run(actions, tcp=tcp, movement_controller=move_forward)
+        joint_trajectory = await motion_group.plan(actions, tcp)
+        await motion_group.execute(joint_trajectory, tcp, actions=actions)
 
 
 if __name__ == "__main__":

--- a/examples/03_move_and_set_ios.py
+++ b/examples/03_move_and_set_ios.py
@@ -11,12 +11,13 @@ async def main():
     nova = Nova()
     cell = nova.cell()
     controllers = await cell.controllers()
+    controller = controllers[0]
 
     # Define a home position
     home_joints = (0, -pi / 4, -pi / 4, -pi / 4, pi / 4, 0)
 
     # Connect to the controller and activate motion groups
-    async with controllers[0] as motion_group:
+    async with controller[0] as motion_group:
         tcp_names = await motion_group.tcp_names()
         tcp = tcp_names[0]
 
@@ -32,16 +33,7 @@ async def main():
         ]
 
         # io_value = await controller.read_io("digital_out[0]")
-
-        # plan_response = await motion_group.plan(trajectory, tcp="Flange")
-        # print(plan_response)
-
-        def print_motion(motion):
-            print(motion)
-
-        await motion_group.run(actions, tcp=tcp, initial_movement_consumer=print_motion)
-        await motion_group.run(actions, tcp=tcp)
-        await motion_group.run(ptp(target_pose), tcp=tcp)
+        await motion_group.plan_and_execute(actions, tcp)
 
 
 if __name__ == "__main__":

--- a/examples/04_move_multiple_robots.py
+++ b/examples/04_move_multiple_robots.py
@@ -1,4 +1,4 @@
-from nova import Nova, Controller, speed_up_movement_controller
+from nova import Nova, Controller
 from nova.actions import ptp, jnt
 from math import pi
 import asyncio
@@ -15,7 +15,7 @@ async def move_robot(controller: Controller):
         target_pose = current_pose @ (100, 0, 0, 0, 0, 0)
         actions = [jnt(home_joints), ptp(target_pose), jnt(home_joints)]
 
-        await motion_group.run(actions, tcp=tcp, movement_controller=speed_up_movement_controller)
+        await motion_group.plan_and_execute(actions, tcp)
 
 
 async def main():

--- a/examples/05_selection_motion_group_activation.py
+++ b/examples/05_selection_motion_group_activation.py
@@ -27,7 +27,7 @@ async def move_robot(motion_group: MotionGroup, tcp: str):
         ptp(home_pose),
     ]
 
-    await motion_group.run(actions, tcp=tcp)
+    await motion_group.plan_and_execute(actions, tcp=tcp)
 
 
 async def main():
@@ -37,7 +37,7 @@ async def main():
     kuka = await cell.controller("kuka")
     tcp = "Flange"
 
-    flange_state = await ur[0].get_state(tcp=tcp)
+    flange_state = await ur[0].get_state(tcp)
     print(flange_state)
 
     # activate all motion groups
@@ -46,11 +46,11 @@ async def main():
 
     # activate motion group 0
     async with ur.motion_group(0) as mg_0:
-        await move_robot(mg_0)
+        await move_robot(mg_0, tcp)
 
     # activate motion group 0
     async with ur[0] as mg_0:
-        await move_robot(mg_0)
+        await move_robot(mg_0, tcp)
 
     # activate motion group 0 from two different controllers
     async with ur[0] as ur_0_mg, kuka[0] as kuka_0_mg:

--- a/tests/core/test_motion_group.py
+++ b/tests/core/test_motion_group.py
@@ -21,8 +21,9 @@ async def test_motion_group():
 
     async with controller:
         motion_group = controller[0]
-        state = await motion_group.get_state("Flange")
+        tcp = "Flange"
+        state = await motion_group.get_state(tcp)
         print(state)
 
-        await motion_group.run(actions=actions, tcp="Flange")
+        await motion_group.plan_and_execute(actions, tcp)
         assert True


### PR DESCRIPTION
- separated plan & execute
- plan now returns JointTrajectory which enables further usage of that data type
- execute takes JointTrajectory and does not plan itself
- added `plan_and_execute` as convenience
- updated examples