### PR TITLE
feat: streaming execution first draft

### DIFF
--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -28,6 +28,9 @@ jobs:
       - name: Check formatting with ruff
         run: poetry run ruff format --check .
 
+      - name: Check import order
+        run: poetry run ruff check --select I
+
       - name: Check ruff for linting
         run: poetry run ruff check .
 

--- a/examples/02_plan_and_execute.py
+++ b/examples/02_plan_and_execute.py
@@ -52,7 +52,8 @@ async def main():
             action.settings = MotionSettings(tcp_velocity_limit=200)
 
         joint_trajectory = await motion_group.plan(actions, tcp)
-        await motion_group.execute(joint_trajectory, tcp, actions=actions)
+        async for _ in motion_group.execute(joint_trajectory, tcp, actions=actions):
+            pass
 
         await cell.delete_robot_controller(controller.controller_id)
 

--- a/examples/02_plan_and_execute.py
+++ b/examples/02_plan_and_execute.py
@@ -1,8 +1,8 @@
 import asyncio
 
-from nova.api import models
-from nova import Nova, MotionSettings
+from nova import MotionSettings, Nova
 from nova.actions import jnt, ptp
+from nova.api import models
 from nova.types import Pose
 
 """

--- a/examples/03_move_and_set_ios.py
+++ b/examples/03_move_and_set_ios.py
@@ -18,9 +18,6 @@ Prerequisites:
 
 
 async def main():
-    def on_movement(motion_state):
-        print(motion_state)
-
     async with Nova() as nova:
         cell = nova.cell()
         controller = await cell.ensure_virtual_robot_controller(
@@ -45,7 +42,8 @@ async def main():
                 jnt(home_joints),
             ]
 
-            await motion_group.plan_and_execute(actions, tcp, on_movement=on_movement)
+            async for motion_state in motion_group.plan_and_execute(actions, tcp):
+                print(motion_state)
 
             io_value = await controller.read("tool_out[0]")
             print(io_value)

--- a/examples/03_move_and_set_ios.py
+++ b/examples/03_move_and_set_ios.py
@@ -1,10 +1,9 @@
 import asyncio
 
 from nova import Nova
-from nova.api import models
 from nova.actions import WriteAction, jnt, ptp
+from nova.api import models
 from nova.types import Pose
-
 
 """
 Example: Move the robot and set I/Os on the path.

--- a/examples/04_move_multiple_robots.py
+++ b/examples/04_move_multiple_robots.py
@@ -25,7 +25,8 @@ async def move_robot(controller: Controller):
         target_pose = current_pose @ (100, 0, 0, 0, 0, 0)
         actions = [jnt(home_joints), ptp(target_pose), jnt(home_joints)]
 
-        await motion_group.plan_and_execute(actions, tcp)
+        async for _ in motion_group.plan_and_execute(actions, tcp):
+            pass
 
 
 async def main():

--- a/examples/04_move_multiple_robots.py
+++ b/examples/04_move_multiple_robots.py
@@ -1,8 +1,8 @@
 import asyncio
 
 from nova import Controller, Nova
-from nova.api import models
 from nova.actions import jnt, ptp
+from nova.api import models
 
 """
 Example: Move multiple robots simultaneously.

--- a/examples/05_selection_motion_group_activation.py
+++ b/examples/05_selection_motion_group_activation.py
@@ -1,9 +1,9 @@
 import asyncio
 from math import pi
 
-from nova.api import models
 from nova import MotionGroup, Nova
 from nova.actions import ptp
+from nova.api import models
 from nova.types import Pose
 
 """

--- a/examples/05_selection_motion_group_activation.py
+++ b/examples/05_selection_motion_group_activation.py
@@ -28,7 +28,8 @@ async def move_robot(motion_group: MotionGroup, tcp: str):
         ptp(home_pose),
     ]
 
-    await motion_group.plan_and_execute(actions, tcp=tcp)
+    async for _ in motion_group.plan_and_execute(actions, tcp=tcp):
+        pass
 
 
 async def main():

--- a/examples/07_auth0_with_device_code.py
+++ b/examples/07_auth0_with_device_code.py
@@ -1,5 +1,6 @@
-from nova.auth.authorization import Auth0DeviceAuthorization
 import asyncio
+
+from nova.auth.authorization import Auth0DeviceAuthorization
 
 """
 Example: Perform device authorization with Auth0.

--- a/nova/__init__.py
+++ b/nova/__init__.py
@@ -2,8 +2,8 @@ from nova import actions, api, types
 from nova.core.controller import Controller
 from nova.core.motion_group import MotionGroup
 from nova.core.movement_controller import speed_up as speed_up_movement_controller
-from nova.motion_settings import MotionSettings
 from nova.core.nova import Cell, Nova
+from nova.motion_settings import MotionSettings
 
 __all__ = [
     "Nova",

--- a/nova/actions.py
+++ b/nova/actions.py
@@ -3,6 +3,7 @@ from typing import Annotated, Any, AsyncGenerator, Callable, Literal, Union
 
 import pydantic
 import wandelbots_api_client as wb
+
 from nova.motion_settings import MotionSettings
 from nova.types.collision_scene import CollisionScene
 from nova.types.pose import Pose
@@ -510,5 +511,5 @@ MovementControllerFunction = Callable[
     [ExecuteTrajectoryResponseStream], ExecuteTrajectoryRequestStream
 ]
 MovementController = Callable[
-    [MovementControllerContext, Callable[[MotionState], None] | None], MovementControllerFunction
+    [MovementControllerContext, Callable[[MotionState | None], None]], MovementControllerFunction
 ]

--- a/nova/auth/authorization.py
+++ b/nova/auth/authorization.py
@@ -1,5 +1,6 @@
-import httpx
 import asyncio
+
+import httpx
 import pydantic
 
 

--- a/nova/core/controller.py
+++ b/nova/core/controller.py
@@ -1,19 +1,19 @@
-from typing import Sized, Literal
+from typing import Literal, Sized
 
 from loguru import logger
 
-from nova.core.motion_group import MotionGroup
 from nova.api import models
-from nova.gateway import ApiGateway
+from nova.core.io import IOAccess
+from nova.core.motion_group import MotionGroup
 from nova.core.robot_cell import (
     AbstractController,
+    AbstractRobot,
     ConfigurablePeriphery,
     Device,
     IODevice,
-    AbstractRobot,
     ValueType,
 )
-from nova.core.io import IOAccess
+from nova.gateway import ApiGateway
 
 
 # TODO: Device is not associated to IODevice so it is pretty confusing and we should change it

--- a/nova/core/io.py
+++ b/nova/core/io.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-from nova.api import models
+from enum import Enum
 
+from nova.api import models
 from nova.core.robot_cell import Device, ValueType
 from nova.gateway import ApiGateway
-from enum import Enum
 
 
 class IOType(Enum):

--- a/nova/core/motion_group.py
+++ b/nova/core/motion_group.py
@@ -1,13 +1,14 @@
+from typing import Callable
+
 import wandelbots_api_client as wb
 from loguru import logger
 
 from nova.actions import Action, CombinedActions, MovementController, MovementControllerContext
 from nova.core.exceptions import LoadPlanFailed, PlanTrajectoryFailed
-from nova.core.movement_controller import move_forward, motion_group_state_to_motion_state
-from nova.gateway import ApiGateway
-from nova.types import InitialMovementStream, LoadPlanResponse, Pose, MotionState
+from nova.core.movement_controller import motion_group_state_to_motion_state, move_forward
 from nova.core.robot_cell import AbstractRobot
-from typing import Callable
+from nova.gateway import ApiGateway
+from nova.types import InitialMovementStream, LoadPlanResponse, MotionState, Pose
 
 MAX_JOINT_VELOCITY_PREPARE_MOVE = 0.2
 START_LOCATION_OF_MOTION = 0.0

--- a/nova/core/motion_group.py
+++ b/nova/core/motion_group.py
@@ -71,7 +71,7 @@ class MotionGroup(AbstractRobot):
         joint_trajectory: wb.models.JointTrajectory,
         tcp: str,
         actions: list[Action],
-        on_movement: Callable[[MotionState], None],
+        on_movement: Callable[[MotionState | None], None],
         movement_controller: MovementController | None,
     ):
         if movement_controller is None:

--- a/nova/core/movement_controller.py
+++ b/nova/core/movement_controller.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 import wandelbots_api_client as wb
 from loguru import logger
 
@@ -7,9 +9,8 @@ from nova.actions import (
     MovementControllerContext,
     MovementControllerFunction,
 )
-from nova.types import MotionState, Pose, RobotState
 from nova.core.exceptions import InitMovementFailed
-from typing import Callable
+from nova.types import MotionState, Pose, RobotState
 
 
 def movement_to_motion_state(movement: wb.models.Movement) -> MotionState | None:
@@ -42,7 +43,7 @@ def motion_group_state_to_motion_state(
 
 
 def move_forward(
-    context: MovementControllerContext, on_movement: Callable[[MotionState | None], None] | None
+    context: MovementControllerContext, on_movement: Callable[[MotionState | None], None]
 ) -> MovementControllerFunction:
     """
     movement_controller is an async function that yields requests to the server.
@@ -76,7 +77,7 @@ def move_forward(
             instance = execute_trajectory_response.actual_instance
 
             # Send the current location to the consumer
-            if isinstance(instance, wb.models.Movement) and instance.movement and on_movement:
+            if isinstance(instance, wb.models.Movement) and instance.movement:
                 motion_state = movement_to_motion_state(instance)
                 if motion_state:
                     on_movement(motion_state)
@@ -91,7 +92,7 @@ def move_forward(
 
 
 def speed_up(
-    context: MovementControllerContext, on_movement: Callable[[MotionState | None], None] | None
+    context: MovementControllerContext, on_movement: Callable[[MotionState | None], None]
 ) -> MovementControllerFunction:
     async def movement_controller(
         response_stream: ExecuteTrajectoryResponseStream,
@@ -120,8 +121,8 @@ def speed_up(
         async for execute_trajectory_response in response_stream:
             counter += 1
             instance = execute_trajectory_response.actual_instance
-            # Send the current location to the consumer
-            if isinstance(instance, wb.models.Movement) and on_movement:
+            # Send the current location to the consume
+            if isinstance(instance, wb.models.Movement):
                 motion_state = movement_to_motion_state(instance)
                 if motion_state:
                     on_movement(motion_state)

--- a/nova/core/movement_controller.py
+++ b/nova/core/movement_controller.py
@@ -42,7 +42,7 @@ def motion_group_state_to_motion_state(
 
 
 def move_forward(
-    context: MovementControllerContext, on_movement: Callable[[MotionState], None] | None
+    context: MovementControllerContext, on_movement: Callable[[MotionState | None], None] | None
 ) -> MovementControllerFunction:
     """
     movement_controller is an async function that yields requests to the server.
@@ -84,13 +84,14 @@ def move_forward(
             # Stop when standstill indicates motion ended
             if isinstance(instance, wb.models.Standstill):
                 if instance.standstill.reason == wb.models.StandstillReason.REASON_MOTION_ENDED:
+                    on_movement(None)
                     return
 
     return movement_controller
 
 
 def speed_up(
-    context: MovementControllerContext, on_movement: Callable[[MotionState], None] | None
+    context: MovementControllerContext, on_movement: Callable[[MotionState | None], None] | None
 ) -> MovementControllerFunction:
     async def movement_controller(
         response_stream: ExecuteTrajectoryResponseStream,
@@ -128,6 +129,7 @@ def speed_up(
             # Terminate the generator
             if isinstance(instance, wb.models.Standstill):
                 if instance.standstill.reason == wb.models.StandstillReason.REASON_MOTION_ENDED:
+                    on_movement(None)
                     return
 
             if isinstance(instance, wb.models.PlaybackSpeedResponse):

--- a/nova/core/nova.py
+++ b/nova/core/nova.py
@@ -1,12 +1,13 @@
-from decouple import config
 import asyncio
 
+from decouple import config
+from loguru import logger
+
+from nova.api import models
 from nova.core.controller import Controller
 from nova.core.exceptions import ControllerNotFound
 from nova.core.logging_setup import configure_logging
 from nova.gateway import ApiGateway
-from nova.api import models
-from loguru import logger
 
 
 class Nova:

--- a/nova/types/__init__.py
+++ b/nova/types/__init__.py
@@ -5,8 +5,8 @@ import wandelbots_api_client as wb
 
 from nova.types.collision_scene import CollisionScene
 from nova.types.pose import Pose
-from nova.types.vector3d import Vector3d
 from nova.types.state import MotionState, RobotState
+from nova.types.vector3d import Vector3d
 
 LoadPlanResponse = wb.models.PlanSuccessfulResponse
 InitialMovementStream = AsyncGenerator[wb.models.StreamMoveResponse, None]

--- a/nova/utils.py
+++ b/nova/utils.py
@@ -1,0 +1,22 @@
+import asyncio
+from typing import Callable, Generic, TypeVar
+
+T = TypeVar("T")
+
+class Callerator(Generic[T]):
+    def __init__(self, callback: Callable[[T | None], None] | None):
+        self._q: asyncio.Queue[T | None] = asyncio.Queue()
+        self.callback = callback
+
+    def __call__(self, value: T | None):
+        if self.callback:
+            self.callback(value)
+        self._q.put_nowait(value)
+
+    async def stream(self):
+        while True:
+            value = await self._q.get()
+            if value is None:
+                break
+            yield value
+

--- a/tests/core/test_io.py
+++ b/tests/core/test_io.py
@@ -1,6 +1,8 @@
-from nova.core.io import IOAccess, IOType, IOValueType
-from nova import Nova
 import pytest
+
+from nova import Nova
+from nova.core.io import IOAccess, IOType, IOValueType
+
 # from decouple import config
 
 NOVA_API = "http://172.30.1.41"  # config("NOVA_API")


### PR DESCRIPTION
This is the first draft to make `execute()` and `plan_and_execute()` AsyncGenerators i.e. streaming.
It is intended as a quick and somewhat dirty solution to enable porting wandelscript execution as is.