### PR TITLE
feat: add catalog entry update step to image push workflows

### DIFF
--- a/.github/workflows/push_nova_rerun_bridge_image.yaml
+++ b/.github/workflows/push_nova_rerun_bridge_image.yaml
@@ -115,6 +115,7 @@ jobs:
           GH_TOKEN: ${{ secrets.CATALOG_TOKEN }}
           IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
           VERSION: "${{ steps.version.outputs.version }}"
+          CATALOG_ENTRY_NAME: "nova_rerun_bridge"
         run: |
           curl -L \
             -X POST \

--- a/.github/workflows/push_nova_rerun_bridge_image.yaml
+++ b/.github/workflows/push_nova_rerun_bridge_image.yaml
@@ -108,3 +108,23 @@ jobs:
           echo "Checking built image..."
           echo "Version: ${{ steps.version.outputs.version }}"
           docker images | grep ${{ env.IMAGE_NAME }}
+      
+      - name: Update Catalog Entry
+        if: steps.version.outputs.version != ''
+        env:
+          GH_TOKEN: ${{ secrets.CATALOG_TOKEN }}
+          IMAGE:  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+          VERSION: "${{ steps.version.outputs.version }}"
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            https://api.github.com/repos/wandelbotsgmbh/catalog/dispatches \
+            -d "{\"event_type\": \"update-entry\",
+                 \"client_payload\": {
+                   \"image\":\"${IMAGE}\",
+                   \"version\":\"${VERSION}\",
+                   \"entry\":\"${CATALOG_ENTRY_NAME}\"
+                }
+              }"

--- a/.github/workflows/push_nova_rerun_bridge_image.yaml
+++ b/.github/workflows/push_nova_rerun_bridge_image.yaml
@@ -113,7 +113,7 @@ jobs:
         if: steps.version.outputs.version != ''
         env:
           GH_TOKEN: ${{ secrets.CATALOG_TOKEN }}
-          IMAGE:  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
           VERSION: "${{ steps.version.outputs.version }}"
         run: |
           curl -L \

--- a/.github/workflows/push_nova_rerun_bridge_image.yaml
+++ b/.github/workflows/push_nova_rerun_bridge_image.yaml
@@ -108,7 +108,7 @@ jobs:
           echo "Checking built image..."
           echo "Version: ${{ steps.version.outputs.version }}"
           docker images | grep ${{ env.IMAGE_NAME }}
-      
+
       - name: Update Catalog Entry
         if: steps.version.outputs.version != ''
         env:

--- a/.github/workflows/push_rerun_image.yaml
+++ b/.github/workflows/push_rerun_image.yaml
@@ -98,6 +98,7 @@ jobs:
           GH_TOKEN: ${{ secrets.CATALOG_TOKEN }}
           IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
           VERSION: "${{ steps.version.outputs.version }}"
+          CATALOG_ENTRY_NAME: "rerun"
         run: |
           curl -L \
             -X POST \

--- a/.github/workflows/push_rerun_image.yaml
+++ b/.github/workflows/push_rerun_image.yaml
@@ -91,3 +91,23 @@ jobs:
           echo "Checking built image..."
           echo "Version: ${{ steps.version.outputs.version }}"
           docker images | grep ${{ env.IMAGE_NAME }}
+      
+      - name: Update Catalog Entry
+        if: steps.version.outputs.version != ''
+        env:
+          GH_TOKEN: ${{ secrets.CATALOG_TOKEN }}
+          IMAGE:  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+          VERSION: "${{ steps.version.outputs.version }}"
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            https://api.github.com/repos/wandelbotsgmbh/catalog/dispatches \
+            -d "{\"event_type\": \"update-entry\",
+                 \"client_payload\": {
+                   \"image\":\"${IMAGE}\",
+                   \"version\":\"${VERSION}\",
+                   \"entry\":\"${CATALOG_ENTRY_NAME}\"
+                }
+              }"

--- a/.github/workflows/push_rerun_image.yaml
+++ b/.github/workflows/push_rerun_image.yaml
@@ -91,12 +91,12 @@ jobs:
           echo "Checking built image..."
           echo "Version: ${{ steps.version.outputs.version }}"
           docker images | grep ${{ env.IMAGE_NAME }}
-      
+
       - name: Update Catalog Entry
         if: steps.version.outputs.version != ''
         env:
           GH_TOKEN: ${{ secrets.CATALOG_TOKEN }}
-          IMAGE:  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
           VERSION: "${{ steps.version.outputs.version }}"
         run: |
           curl -L \

--- a/README.md
+++ b/README.md
@@ -140,6 +140,19 @@ To install the development dependencies, run the following command
 poetry install
 ```
 
+### Formatting
+
+```bash
+poetry run ruff format
+poetry run ruff check --select I --fix
+```
+
+### Yaml Linting
+
+```bash
+docker run --rm -it -v $(pwd):/data cytopia/yamllint -d .yamllint .
+```
+
 ### Using Branch Versions For Testing
 
 When having feature branches or forks, or might be helpful to test the library as dependency in other projects first.


### PR DESCRIPTION
With that change, the https://github.com/wandelbotsgmbh/catalog will be updated automatically with the new versions of the rerun-bridge and rerun app