### PR TITLE
feat(RPS-1311): Add pretty string repr for `PlanTrajectoryFailed` errors

### DIFF
--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: 'Validate PR Title'
         shell: bash
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_TITLE='${{ github.event.pull_request.title }}'
           echo "PR Title: $PR_TITLE"
 
           # Define the allowed pattern

--- a/nova/core/exceptions.py
+++ b/nova/core/exceptions.py
@@ -13,6 +13,12 @@ class PlanTrajectoryFailed(Exception):
         self._error = error
         super().__init__(f"Plan trajectory failed: {json.dumps(error.to_dict(), indent=2)}")
 
+    def to_pretty_string(self) -> str:
+        """Give a more lightweight representation of the error, omitting some gritty details."""
+        error_dict = self._error.to_dict()
+        del error_dict["joint_trajectory"]
+        return f"Plan trajectory failed: {json.dumps(error_dict, indent=2)}"
+
     @property
     def error(self) -> wb.models.PlanTrajectoryFailedResponse:
         """Return the original PlanTrajectoryFailedResponse object."""


### PR DESCRIPTION
To be used in wandelscript as a next-level pendant to the recent change to make `MotionErrors` more readable (https://code.wabo.run/ai/wandelbrain/-/merge_requests/1202)

This builds the foundation for the more "meaty" companion PR in the wandelscript repo, https://github.com/wandelbotsgmbh/wandelscript/pull/13

Looks like:
![rps-1311-plantrajectoryerror](https://github.com/user-attachments/assets/18d16b26-6749-4441-8c01-6f2d8fa136a3)
