### PR TITLE
chore(RPS-1310): verbosify action names

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,11 @@
     "notebook.source.fixAll": "explicit"
   },
   "notebook.formatOnSave.enabled": true,
-  "ruff.importStrategy": "fromEnvironment"
+  "ruff.importStrategy": "fromEnvironment",
+  "workbench.colorCustomizations": {
+    "statusBar.background": "#7C21D7",
+    "statusBar.debuggingBackground": "#7C21D7",
+    "statusBar.noFolderBackground": "#7C21D7",
+    "statussBar.prominentBackground": "#7C21D7"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ NOVA_ACCESS_TOKEN="your-access-token"
 from nova_rerun_bridge import NovaRerunBridge
 from nova import Nova
 from nova import api
-from nova.actions import jnt, ptp
+from nova.actions import joint_ptp, cartesian_ptp
 from nova.types import Pose
 import asyncio
 
@@ -80,9 +80,9 @@ async def main():
       target_pose = current_pose @ Pose((1, 0, 0, 0, 0, 0))
 
       actions = [
-          jnt(home_joints),
-          ptp(target_pose),
-          jnt(home_joints),
+          joint_ptp(home_joints),
+          cartesian_ptp(target_pose),
+          joint_ptp(home_joints),
       ]
 
       # Plan trajectory
@@ -168,16 +168,16 @@ async def main():
 
 ```python
 from nova import Nova
-from nova.actions import ptp, jnt
+from nova.actions import cartesian_ptp, joint_ptp
 from nova.types import Pose
 
 async def main():
     async with Nova() as nova:
         # ... setup code ...
         actions = [
-            jnt(home_joints),
-            ptp(current_pose @ Pose((100, 0, 0, 0, 0, 0))),  # Move 100mm in X
-            jnt(home_joints)
+            joint_ptp(home_joints),
+            cartesian_ptp(current_pose @ Pose((100, 0, 0, 0, 0, 0))),  # Move 100mm in X
+            joint_ptp(home_joints)
         ]
         trajectory = await motion_group.plan(actions, tcp)
 ```
@@ -217,10 +217,10 @@ async def move_robots():
 from nova.actions import io_write
 
 actions = [
-    jnt(home_joints),
+    joint_ptp(home_joints),
     io_write(key="digital_out[0]", value=False),  # Set digital output
-    ptp(target_pose),
-    jnt(home_joints)
+    cartesian_ptp(target_pose),
+    joint_ptp(home_joints)
 ]
 ```
 
@@ -278,7 +278,7 @@ async def setup_tcp():
         async with controller[0] as motion_group:
             current_pose = await motion_group.tcp_pose("vacuum_gripper")
             # Plan motions using the new TCP
-            actions = [ptp(current_pose @ Pose((100, 0, 0, 0, 0, 0)))]
+            actions = [cartesian_ptp(current_pose @ Pose((100, 0, 0, 0, 0, 0)))]
             trajectory = await motion_group.plan(actions, "vacuum_gripper")
 ```
 <img width="100%" alt="trajectory" src="https://github.com/user-attachments/assets/649de0b7-d90a-4095-ad51-d38d3ac2e716" />
@@ -345,8 +345,8 @@ async def setup_coordinated_robots():
         async with robot1[0] as mg1, robot2[0] as mg2:
             # Movements will be relative to world coordinates
             await asyncio.gather(
-                mg1.plan([ptp(Pose((0, 100, 0, 0, 0, 0)))], "tcp1"),
-                mg2.plan([ptp(Pose((0, -100, 0, 0, 0, 0)))], "tcp2")
+                mg1.plan([cartesian_ptp(Pose((0, 100, 0, 0, 0, 0)))], "tcp1"),
+                mg2.plan([cartesian_ptp(Pose((0, -100, 0, 0, 0, 0)))], "tcp2")
             )
 ```
 <img width="100%" alt="thumbnail" src="https://github.com/user-attachments/assets/6f0c441e-b133-4a3a-bf0e-0e947d3efad4" />

--- a/examples/02_plan_and_execute.py
+++ b/examples/02_plan_and_execute.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from nova import MotionSettings, Nova
-from nova.actions import jnt, ptp
+from nova.actions import cartesian_ptp, joint_ptp
 from nova.api import models
 from nova.types import Pose
 
@@ -36,15 +36,15 @@ async def main():
             target_pose = current_pose @ Pose((1, 0, 0, 0, 0, 0))
 
             actions = [
-                jnt(home_joints),
-                ptp(target_pose),
-                jnt(home_joints),
-                ptp(target_pose @ [50, 0, 0, 0, 0, 0]),
-                jnt(home_joints),
-                ptp(target_pose @ (50, 100, 0, 0, 0, 0)),
-                jnt(home_joints),
-                ptp(target_pose @ Pose((0, 50, 0, 0, 0, 0))),
-                jnt(home_joints),
+                joint_ptp(home_joints),
+                cartesian_ptp(target_pose),
+                joint_ptp(home_joints),
+                cartesian_ptp(target_pose @ [50, 0, 0, 0, 0, 0]),
+                joint_ptp(home_joints),
+                cartesian_ptp(target_pose @ (50, 100, 0, 0, 0, 0)),
+                joint_ptp(home_joints),
+                cartesian_ptp(target_pose @ Pose((0, 50, 0, 0, 0, 0))),
+                joint_ptp(home_joints),
             ]
 
         # you can update the settings of the action

--- a/examples/03_move_and_set_ios.py
+++ b/examples/03_move_and_set_ios.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from nova import Nova
-from nova.actions import io_write, jnt, ptp
+from nova.actions import cartesian_ptp, io_write, joint_ptp
 from nova.api import models
 from nova.types import Pose
 
@@ -35,10 +35,10 @@ async def main():
             current_pose = await motion_group.tcp_pose(tcp)
             target_pose = current_pose @ Pose((100, 0, 0, 0, 0, 0))
             actions = [
-                jnt(home_joints),
+                joint_ptp(home_joints),
                 io_write(key="tool_out[0]", value=False),
-                ptp(target_pose),
-                jnt(home_joints),
+                cartesian_ptp(target_pose),
+                joint_ptp(home_joints),
             ]
 
             async for motion_state in motion_group.stream_plan_and_execute(actions, tcp):

--- a/examples/04_move_multiple_robots.py
+++ b/examples/04_move_multiple_robots.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from nova import Controller, Nova
-from nova.actions import jnt, ptp
+from nova.actions import cartesian_ptp, joint_ptp
 from nova.api import models
 
 """
@@ -23,7 +23,7 @@ async def move_robot(controller: Controller):
 
         current_pose = await motion_group.tcp_pose(tcp)
         target_pose = current_pose @ (100, 0, 0, 0, 0, 0)
-        actions = [jnt(home_joints), ptp(target_pose), jnt(home_joints)]
+        actions = [joint_ptp(home_joints), cartesian_ptp(target_pose), joint_ptp(home_joints)]
 
         await motion_group.plan_and_execute(actions, tcp)
 

--- a/examples/05_selection_motion_group_activation.py
+++ b/examples/05_selection_motion_group_activation.py
@@ -2,7 +2,7 @@ import asyncio
 from math import pi
 
 from nova import MotionGroup, Nova
-from nova.actions import ptp
+from nova.actions import cartesian_ptp
 from nova.api import models
 from nova.types import Pose
 
@@ -21,11 +21,11 @@ async def move_robot(motion_group: MotionGroup, tcp: str):
     home_pose = Pose((200, 200, 600, 0, pi, 0))
     target_pose = home_pose @ (100, 0, 0, 0, 0, 0)
     actions = [
-        ptp(home_pose),
-        ptp(target_pose),
-        ptp(target_pose @ (0, 0, 100, 0, 0, 0)),
-        ptp(target_pose @ (0, 100, 0, 0, 0, 0)),
-        ptp(home_pose),
+        cartesian_ptp(home_pose),
+        cartesian_ptp(target_pose),
+        cartesian_ptp(target_pose @ (0, 0, 100, 0, 0, 0)),
+        cartesian_ptp(target_pose @ (0, 100, 0, 0, 0, 0)),
+        cartesian_ptp(home_pose),
     ]
 
     await motion_group.plan_and_execute(actions, tcp=tcp)  # type: ignore

--- a/examples/08_multi_step_movement_with_collision_free.py
+++ b/examples/08_multi_step_movement_with_collision_free.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from nova import MotionSettings, Nova
-from nova.actions import collision_free, io_write, jnt, ptp
+from nova.actions import cartesian_ptp, collision_free, io_write, joint_ptp
 from nova.api import models
 from nova.types import Pose
 
@@ -38,15 +38,15 @@ async def main():
             target_pose = current_pose @ Pose((100, 0, 0, 0, 0, 0))
 
             actions = [
-                ptp(target_pose),
+                cartesian_ptp(target_pose),
                 collision_free(home_joints),
-                ptp(target_pose @ [50, 0, 0, 0, 0, 0]),
+                cartesian_ptp(target_pose @ [50, 0, 0, 0, 0, 0]),
                 io_write(key="digital_out[0]", value=True),
-                jnt(home_joints),
-                ptp(target_pose @ (50, 100, 0, 0, 0, 0)),
+                joint_ptp(home_joints),
+                cartesian_ptp(target_pose @ (50, 100, 0, 0, 0, 0)),
                 collision_free(home_pose),
-                ptp(target_pose @ Pose((0, 50, 0, 0, 0, 0))),
-                jnt(home_joints),
+                cartesian_ptp(target_pose @ Pose((0, 50, 0, 0, 0, 0))),
+                joint_ptp(home_joints),
             ]
 
         # you can update the settings of the action

--- a/nova/actions/__init__.py
+++ b/nova/actions/__init__.py
@@ -1,17 +1,31 @@
 from nova.actions.base import Action
 from nova.actions.container import CombinedActions, MovementController, MovementControllerContext
 from nova.actions.io import io_write
-from nova.actions.motions import cir, collision_free, jnt, lin, ptp
+from nova.actions.motions import (
+    cartesian_ptp,
+    cir,
+    circular,
+    collision_free,
+    jnt,
+    joint_ptp,
+    lin,
+    linear,
+    ptp,
+)
 
 __all__ = [
     "Action",
-    "lin",
+    "cartesian_ptp",
     "ptp",
+    "circular",
     "cir",
-    "jnt",
     "collision_free",
-    "io_write",
-    "MovementController",
     "CombinedActions",
+    "io_write",
+    "joint_ptp",
+    "jnt",
+    "linear",
+    "lin",
+    "MovementController",
     "MovementControllerContext",
 ]

--- a/nova/actions/motions.py
+++ b/nova/actions/motions.py
@@ -15,9 +15,7 @@ PoseOrVectorTuple = (
 
 
 class CollisionFreeMotion(Action):
-    """
-    A motion that is collision free.
-    """
+    """A motion that is collision free"""
 
     type: Literal["collision_free_ptp"] = "collision_free_ptp"
     target: Pose | tuple[float, ...]

--- a/nova_rerun_bridge/benchmark/run_ptp_benchmark.py
+++ b/nova_rerun_bridge/benchmark/run_ptp_benchmark.py
@@ -1,9 +1,9 @@
-from nova.actions.motions import ptp
+from nova.actions.motions import cartesian_ptp
 from nova_rerun_bridge.benchmark.benchmark_base import BenchmarkStrategy, run_benchmark
 
 
 class PtpStrategy(BenchmarkStrategy):
-    name = "ptp"
+    name = "cartesian_ptp"
 
     async def plan(
         self,
@@ -16,7 +16,7 @@ class PtpStrategy(BenchmarkStrategy):
         start_joint_position,
     ):
         return await motion_group.plan(
-            [ptp(target=target, collision_scene=collision_scene)], tcp=tcp
+            [cartesian_ptp(target=target, collision_scene=collision_scene)], tcp=tcp
         )
 
 

--- a/nova_rerun_bridge/examples/02_plan_and_execute.py
+++ b/nova_rerun_bridge/examples/02_plan_and_execute.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from nova import MotionSettings
-from nova.actions import jnt, ptp
+from nova.actions import cartesian_ptp, joint_ptp
 from nova.api import models
 from nova.core.nova import Nova
 from nova.types import Pose
@@ -31,15 +31,15 @@ async def test():
             target_pose = current_pose @ Pose((1, 0, 0, 0, 0, 0))
 
             actions = [
-                jnt(home_joints),
-                ptp(target_pose),
-                jnt(home_joints),
-                ptp(target_pose @ [100, 0, 0, 0, 0, 0]),
-                jnt(home_joints),
-                ptp(target_pose @ (100, 100, 0, 0, 0, 0)),
-                jnt(home_joints),
-                ptp(target_pose @ Pose((0, 100, 0, 0, 0, 0))),
-                jnt(home_joints),
+                joint_ptp(home_joints),
+                cartesian_ptp(target_pose),
+                joint_ptp(home_joints),
+                cartesian_ptp(target_pose @ [100, 0, 0, 0, 0, 0]),
+                joint_ptp(home_joints),
+                cartesian_ptp(target_pose @ (100, 100, 0, 0, 0, 0)),
+                joint_ptp(home_joints),
+                cartesian_ptp(target_pose @ Pose((0, 100, 0, 0, 0, 0))),
+                joint_ptp(home_joints),
             ]
 
             # you can update the settings of the action

--- a/nova_rerun_bridge/examples/03_move_and_set_ios.py
+++ b/nova_rerun_bridge/examples/03_move_and_set_ios.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from nova import Nova
-from nova.actions import io_write, jnt, ptp
+from nova.actions import cartesian_ptp, io_write, joint_ptp
 from nova.api import models
 from nova.types import Pose
 from nova_rerun_bridge import NovaRerunBridge
@@ -39,10 +39,10 @@ async def main():
             current_pose = await motion_group.tcp_pose(tcp)
             target_pose = current_pose @ Pose((100, 0, 0, 0, 0, 0))
             actions = [
-                jnt(home_joints),
+                joint_ptp(home_joints),
                 io_write(key="digital_out[0]", value=False),
-                ptp(target_pose),
-                jnt(home_joints),
+                cartesian_ptp(target_pose),
+                joint_ptp(home_joints),
             ]
 
             # io_value = await controller.read_io("digital_out[0]")

--- a/nova_rerun_bridge/examples/04_move_multiple_robots.py
+++ b/nova_rerun_bridge/examples/04_move_multiple_robots.py
@@ -8,7 +8,7 @@ from wandelbots_api_client.models import (
 )
 
 from nova import Controller, Nova
-from nova.actions import jnt, ptp
+from nova.actions import cartesian_ptp, joint_ptp
 from nova.api import models
 from nova_rerun_bridge import NovaRerunBridge
 from nova_rerun_bridge.trajectory import TimingMode
@@ -31,7 +31,7 @@ async def move_robot(controller: Controller, bridge: NovaRerunBridge):
 
         current_pose = await motion_group.tcp_pose(tcp)
         target_pose = current_pose @ (100, 0, 0, 0, 0, 0)
-        actions = [jnt(home_joints), ptp(target_pose), jnt(home_joints)]
+        actions = [joint_ptp(home_joints), cartesian_ptp(target_pose), joint_ptp(home_joints)]
 
         trajectory = await motion_group.plan(actions, tcp)
         await bridge.log_trajectory(trajectory, tcp, motion_group, timing_mode=TimingMode.SYNC)

--- a/nova_rerun_bridge/examples/05_selection_motion_group_activation.py
+++ b/nova_rerun_bridge/examples/05_selection_motion_group_activation.py
@@ -2,7 +2,7 @@ import asyncio
 from math import pi
 
 from nova import MotionGroup, Nova
-from nova.actions import Action, ptp
+from nova.actions import Action, cartesian_ptp
 from nova.api import models
 from nova.types import Pose
 from nova_rerun_bridge import NovaRerunBridge
@@ -27,11 +27,11 @@ async def move_robot(
     home_pose = Pose((200, 200, 600, 0, pi, 0))
     target_pose = home_pose @ (100, 0, 0, 0, 0, 0)
     actions: list[Action] = [
-        ptp(home_pose),
-        ptp(target_pose),
-        ptp(target_pose @ (0, 0, 100, 0, 0, 0)),
-        ptp(target_pose @ (0, 100, 0, 0, 0, 0)),
-        ptp(home_pose),
+        cartesian_ptp(home_pose),
+        cartesian_ptp(target_pose),
+        cartesian_ptp(target_pose @ (0, 0, 100, 0, 0, 0)),
+        cartesian_ptp(target_pose @ (0, 100, 0, 0, 0, 0)),
+        cartesian_ptp(home_pose),
     ]
 
     trajectory = await motion_group.plan(actions, tcp)

--- a/nova_rerun_bridge/examples/08_stream_robot.py
+++ b/nova_rerun_bridge/examples/08_stream_robot.py
@@ -8,7 +8,7 @@ import signal
 from contextlib import asynccontextmanager
 
 from nova import MotionSettings
-from nova.actions import jnt, ptp
+from nova.actions import cartesian_ptp, joint_ptp
 from nova.api import models
 from nova.core.nova import Nova
 from nova.types import Pose
@@ -61,15 +61,15 @@ async def test():
             target_pose = current_pose @ Pose((1, 0, 0, 0, 0, 0))
 
             actions = [
-                jnt(home_joints),
-                ptp(target_pose),
-                jnt(home_joints),
-                ptp(target_pose @ [100, 0, 0, 0, 0, 0]),
-                jnt(home_joints),
-                ptp(target_pose @ (100, 100, 0, 0, 0, 0)),
-                jnt(home_joints),
-                ptp(target_pose @ Pose((0, 100, 0, 0, 0, 0))),
-                jnt(home_joints),
+                joint_ptp(home_joints),
+                cartesian_ptp(target_pose),
+                joint_ptp(home_joints),
+                cartesian_ptp(target_pose @ [100, 0, 0, 0, 0, 0]),
+                joint_ptp(home_joints),
+                cartesian_ptp(target_pose @ (100, 100, 0, 0, 0, 0)),
+                joint_ptp(home_joints),
+                cartesian_ptp(target_pose @ Pose((0, 100, 0, 0, 0, 0))),
+                joint_ptp(home_joints),
             ]
 
             # you can update the settings of the action

--- a/nova_rerun_bridge/examples/09_plan_and_execute_failed.py
+++ b/nova_rerun_bridge/examples/09_plan_and_execute_failed.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from nova import MotionSettings
-from nova.actions import jnt, ptp
+from nova.actions import cartesian_ptp, joint_ptp
 from nova.api import models
 from nova.core.exceptions import PlanTrajectoryFailed
 from nova.core.nova import Nova
@@ -33,12 +33,12 @@ async def test():
             target_pose = current_pose @ Pose((1, 0, 0, 0, 0, 0))
 
             actions = [
-                jnt(home_joints),
-                ptp(target_pose @ [-100, 0, 0, 0, 0, 0]),
-                ptp(target_pose @ [-200, 0, 0, 0, 0, 0]),
-                ptp(target_pose @ [-500, 0, 0, 0, 0, 0]),
-                ptp(target_pose @ [-2000, 0, 0, 0, 0, 0]),
-                jnt(home_joints),
+                joint_ptp(home_joints),
+                cartesian_ptp(target_pose @ [-100, 0, 0, 0, 0, 0]),
+                cartesian_ptp(target_pose @ [-200, 0, 0, 0, 0, 0]),
+                cartesian_ptp(target_pose @ [-500, 0, 0, 0, 0, 0]),
+                cartesian_ptp(target_pose @ [-2000, 0, 0, 0, 0, 0]),
+                joint_ptp(home_joints),
             ]
 
             # you can update the settings of the action

--- a/nova_rerun_bridge/examples/10_import_ply.py
+++ b/nova_rerun_bridge/examples/10_import_ply.py
@@ -5,7 +5,7 @@ import rerun as rr
 import trimesh
 
 from nova import MotionSettings
-from nova.actions import jnt, ptp
+from nova.actions import cartesian_ptp, joint_ptp
 from nova.api import models
 from nova.core.nova import Nova
 from nova.types import Pose
@@ -70,7 +70,11 @@ async def test():
             greenTargetPose = Pose(
                 (green_target_point[0], green_target_point[1], green_target_point[2], np.pi, 0, 0)
             )
-            actions = [jnt(home_joints), ptp(greenTargetPose), jnt(home_joints)]
+            actions = [
+                joint_ptp(home_joints),
+                cartesian_ptp(greenTargetPose),
+                joint_ptp(home_joints),
+            ]
 
             # you can update the settings of the action
             for action in actions:

--- a/nova_rerun_bridge/examples/11_standard_skill.py
+++ b/nova_rerun_bridge/examples/11_standard_skill.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from nova import MotionSettings
-from nova.actions import lin, ptp
+from nova.actions import cartesian_ptp, linear
 from nova.api import models
 from nova.core.exceptions import PlanTrajectoryFailed
 from nova.core.nova import Nova
@@ -32,11 +32,11 @@ async def test():
                 action
                 for _ in range(3)
                 for action in [
-                    ptp(home),
-                    lin(target=Pose((50, 20, 30, 0, 0, 0)) @ home),
-                    lin(target=Pose((100, 20, 30, 0, 0, 0)) @ home),
-                    lin(target=Pose((50, 20, 30, 0, 0, 0)) @ home),
-                    ptp(home),
+                    cartesian_ptp(home),
+                    linear(target=Pose((50, 20, 30, 0, 0, 0)) @ home),
+                    linear(target=Pose((100, 20, 30, 0, 0, 0)) @ home),
+                    linear(target=Pose((50, 20, 30, 0, 0, 0)) @ home),
+                    cartesian_ptp(home),
                 ]
             ]
 

--- a/nova_rerun_bridge/examples/12_external_axis.py
+++ b/nova_rerun_bridge/examples/12_external_axis.py
@@ -5,7 +5,7 @@ import os
 from numpy import pi
 
 from nova import Controller, Nova
-from nova.actions import jnt, ptp
+from nova.actions import cartesian_ptp, joint_ptp
 from nova.api import models
 from nova.types import MotionSettings, Pose
 from nova_rerun_bridge import NovaRerunBridge
@@ -31,10 +31,10 @@ async def move_robot(controller: Controller, bridge: NovaRerunBridge):
         current_pose = await motion_group.tcp_pose(tcp)
 
         actions = [
-            jnt(home_joints),
-            ptp(current_pose @ Pose((0, 0, -100, 0, -pi / 2, 0))),
-            ptp(current_pose @ Pose((-500, 0, 0, 0, -pi / 2, 0))),
-            jnt(home_joints),
+            joint_ptp(home_joints),
+            cartesian_ptp(current_pose @ Pose((0, 0, -100, 0, -pi / 2, 0))),
+            cartesian_ptp(current_pose @ Pose((-500, 0, 0, 0, -pi / 2, 0))),
+            joint_ptp(home_joints),
         ]
 
         for action in actions:
@@ -46,7 +46,12 @@ async def move_robot(controller: Controller, bridge: NovaRerunBridge):
 
 async def move_positioner(controller: Controller, bridge: NovaRerunBridge):
     async with controller[16] as motion_group:
-        actions = [jnt((0, 0)), jnt((pi / 4, pi / 4)), jnt((-pi / 4, -pi / 4)), jnt((0, 0))]
+        actions = [
+            joint_ptp((0, 0)),
+            joint_ptp((pi / 4, pi / 4)),
+            joint_ptp((-pi / 4, -pi / 4)),
+            joint_ptp((0, 0)),
+        ]
 
         trajectory = await motion_group.plan(actions, "")
         await bridge.log_trajectory(trajectory, "", motion_group, timing_mode=TimingMode.SYNC)

--- a/nova_rerun_bridge/examples/13_collision_free_p2p.py
+++ b/nova_rerun_bridge/examples/13_collision_free_p2p.py
@@ -10,7 +10,7 @@ from wandelbots_api_client.models import (
 )
 
 from nova import MotionSettings
-from nova.actions.motions import collision_free, ptp
+from nova.actions.motions import cartesian_ptp, collision_free
 from nova.api import models
 from nova.core.exceptions import PlanTrajectoryFailed
 from nova.core.nova import Nova
@@ -115,7 +115,10 @@ async def test():
 
             # Use default planner to move to the right of the sphere
             home = await motion_group.tcp_pose(tcp)
-            actions = [ptp(home), ptp(target=Pose((300, -400, 200, np.pi, 0, 0)))]
+            actions = [
+                cartesian_ptp(home),
+                cartesian_ptp(target=Pose((300, -400, 200, np.pi, 0, 0))),
+            ]
 
             for action in actions:
                 action.settings = MotionSettings(tcp_velocity_limit=200)
@@ -138,7 +141,7 @@ async def test():
             # Use default planner to move to the left of the sphere
             # -> this will collide
             # only plan don't move
-            actions = [ptp(target=Pose((-500, -400, 200, np.pi, 0, 0)))]
+            actions = [cartesian_ptp(target=Pose((-500, -400, 200, np.pi, 0, 0)))]
 
             for action in actions:
                 action.settings = MotionSettings(tcp_velocity_limit=200)

--- a/nova_rerun_bridge/examples/14_welding_example.py
+++ b/nova_rerun_bridge/examples/14_welding_example.py
@@ -12,7 +12,7 @@ from wandelbots_api_client.models import (
 )
 
 from nova import MotionSettings
-from nova.actions import collision_free, lin
+from nova.actions import collision_free, linear
 from nova.api import models
 from nova.core.exceptions import PlanTrajectoryFailed
 from nova.core.nova import Nova
@@ -270,15 +270,15 @@ async def test():
                         collision_scene=collision_scene,
                         settings=MotionSettings(tcp_velocity_limit=30),
                     ),
-                    lin(
+                    linear(
                         target=seam1_start,
                         settings=MotionSettings(tcp_velocity_limit=30, blend_radius=10),
                     ),
-                    lin(
+                    linear(
                         target=seam1_end,
                         settings=MotionSettings(tcp_velocity_limit=30, blend_radius=10),
                     ),
-                    lin(
+                    linear(
                         target=seam1_departure,
                         settings=MotionSettings(tcp_velocity_limit=30, blend_radius=10),
                     ),
@@ -289,15 +289,15 @@ async def test():
                         settings=MotionSettings(tcp_velocity_limit=30),
                     ),
                     # Second seam with collision checking
-                    lin(
+                    linear(
                         target=seam2_start,
                         settings=MotionSettings(tcp_velocity_limit=30, blend_radius=10),
                     ),
-                    lin(
+                    linear(
                         target=seam2_end,
                         settings=MotionSettings(tcp_velocity_limit=30, blend_radius=10),
                     ),
-                    lin(
+                    linear(
                         target=seam2_departure,
                         settings=MotionSettings(tcp_velocity_limit=30, blend_radius=10),
                     ),

--- a/nova_rerun_bridge/examples/16_reachability_check.py
+++ b/nova_rerun_bridge/examples/16_reachability_check.py
@@ -7,7 +7,7 @@ from wandelbots_api_client.models.all_joint_positions_request import AllJointPos
 from wandelbots_api_client.models.all_joint_positions_response import AllJointPositionsResponse
 
 from nova import MotionSettings
-from nova.actions import ptp
+from nova.actions import cartesian_ptp
 from nova.api import models
 from nova.core.exceptions import PlanTrajectoryFailed
 from nova.core.nova import Nova
@@ -115,7 +115,7 @@ async def test():
 
             home = await motion_group.tcp_pose(tcp)
 
-            actions = [ptp(home)]
+            actions = [cartesian_ptp(home)]
 
             for action in actions:
                 action.settings = MotionSettings(tcp_velocity_limit=200)

--- a/nova_rerun_bridge/examples/17_visualize_tool.py
+++ b/nova_rerun_bridge/examples/17_visualize_tool.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 
 from nova import MotionSettings, api
-from nova.actions import jnt, ptp
+from nova.actions import cartesian_ptp, joint_ptp
 from nova.api import models
 from nova.core.nova import Nova
 from nova.types import Pose
@@ -54,7 +54,7 @@ async def test():
             current_pose = await motion_group.tcp_pose(tcp_id)
             target_pose = current_pose @ Pose((0, 0, 500, 0, -1.75, 0))
 
-            actions = [jnt(home_joints), ptp(target_pose), jnt(home_joints)]
+            actions = [joint_ptp(home_joints), cartesian_ptp(target_pose), joint_ptp(home_joints)]
 
             # you can update the settings of the action
             for action in actions:

--- a/nova_rerun_bridge/examples/18_robocore.py
+++ b/nova_rerun_bridge/examples/18_robocore.py
@@ -18,8 +18,7 @@ from wandelbots_api_client.models import (
 )
 
 from nova import Controller, Nova
-from nova.actions import Action, jnt
-from nova.actions.motions import ptp
+from nova.actions import Action, cartesian_ptp, joint_ptp
 from nova.api import models
 from nova.core.exceptions import PlanTrajectoryFailed
 from nova_rerun_bridge import NovaRerunBridge
@@ -120,10 +119,16 @@ async def pick_and_pass_cube(
 
         # Define actions based on robot state
         actions_map: dict[str, list[Action]] = {
-            "pickup_and_handover": [ptp(pos_config.cube_position), ptp(handover_target)],
-            "go_to_handover": [ptp(handover_target)],
-            "go_home_with_cube": [jnt(pos_config.home_position)],
-            "place_cube": [ptp(pos_config.cube_position), jnt(pos_config.home_position)],
+            "pickup_and_handover": [
+                cartesian_ptp(pos_config.cube_position),
+                cartesian_ptp(handover_target),
+            ],
+            "go_to_handover": [cartesian_ptp(handover_target)],
+            "go_home_with_cube": [joint_ptp(pos_config.home_position)],
+            "place_cube": [
+                cartesian_ptp(pos_config.cube_position),
+                joint_ptp(pos_config.home_position),
+            ],
         }
 
         try:
@@ -156,7 +161,7 @@ async def move_to_initial_positions(
                 tcp = tcp_names[0]
 
                 # Move to home, then to cube position
-                actions: list[Action] = [jnt(pos_config.home_position)]
+                actions: list[Action] = [joint_ptp(pos_config.home_position)]
 
                 try:
                     joint_trajectory = await motion_group.plan(actions, tcp)

--- a/nova_rerun_bridge/examples/timing_mode.py
+++ b/nova_rerun_bridge/examples/timing_mode.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from nova import Controller, MotionSettings, Nova
-from nova.actions import jnt, ptp
+from nova.actions import cartesian_ptp, joint_ptp
 from nova.types import Pose
 from nova_rerun_bridge import NovaRerunBridge
 from nova_rerun_bridge.trajectory import TimingMode
@@ -22,7 +22,7 @@ async def move_robot(controller: Controller, bridge: NovaRerunBridge):
 
         current_pose = await motion_group.tcp_pose(tcp)
         target_pose = current_pose @ (100, 0, 0, 0, 0, 0)
-        actions = [jnt(home_joints), ptp(target_pose), jnt(home_joints)]
+        actions = [joint_ptp(home_joints), cartesian_ptp(target_pose), joint_ptp(home_joints)]
 
         trajectory = await motion_group.plan(actions, tcp)
         await bridge.log_trajectory(trajectory, tcp, motion_group, timing_mode=TimingMode.SYNC)
@@ -50,15 +50,15 @@ async def main():
         target_pose = current_pose @ Pose((1, 0, 0, 0, 0, 0))
 
         actions = [
-            jnt(home_joints),
-            ptp(target_pose),
-            jnt(home_joints),
-            ptp(target_pose @ [100, 0, 0, 0, 0, 0]),
-            jnt(home_joints),
-            ptp(target_pose @ (100, 100, 0, 0, 0, 0)),
-            jnt(home_joints),
-            ptp(target_pose @ Pose((0, 100, 0, 0, 0, 0))),
-            jnt(home_joints),
+            joint_ptp(home_joints),
+            cartesian_ptp(target_pose),
+            joint_ptp(home_joints),
+            cartesian_ptp(target_pose @ [100, 0, 0, 0, 0, 0]),
+            joint_ptp(home_joints),
+            cartesian_ptp(target_pose @ (100, 100, 0, 0, 0, 0)),
+            joint_ptp(home_joints),
+            cartesian_ptp(target_pose @ Pose((0, 100, 0, 0, 0, 0))),
+            joint_ptp(home_joints),
         ]
 
         # you can update the settings of the action
@@ -88,15 +88,15 @@ async def main():
         target_pose = current_pose @ Pose((1, 0, 0, 0, 0, 0))
 
         actions = [
-            jnt(home_joints),
-            ptp(target_pose),
-            jnt(home_joints),
-            ptp(target_pose @ [100, 0, 0, 0, 0, 0]),
-            jnt(home_joints),
-            ptp(target_pose @ (100, 100, 0, 0, 0, 0)),
-            jnt(home_joints),
-            ptp(target_pose @ Pose((0, 100, 0, 0, 0, 0))),
-            jnt(home_joints),
+            joint_ptp(home_joints),
+            cartesian_ptp(target_pose),
+            joint_ptp(home_joints),
+            cartesian_ptp(target_pose @ [100, 0, 0, 0, 0, 0]),
+            joint_ptp(home_joints),
+            cartesian_ptp(target_pose @ (100, 100, 0, 0, 0, 0)),
+            joint_ptp(home_joints),
+            cartesian_ptp(target_pose @ Pose((0, 100, 0, 0, 0, 0))),
+            joint_ptp(home_joints),
         ]
 
         # you can update the settings of the action

--- a/nova_rerun_bridge/minimal_example/main.py
+++ b/nova_rerun_bridge/minimal_example/main.py
@@ -6,19 +6,20 @@ import asyncio
 
 import numpy as np
 import rerun as rr
-from nova import MotionSettings
-from nova.actions import collision_free, ptp
-from nova.api import models
-from nova.core.exceptions import PlanTrajectoryFailed
-from nova.core.nova import Nova
-from nova.types import Pose
-from nova_rerun_bridge import NovaRerunBridge
 from wandelbots_api_client.models import (
     CoordinateSystem,
     RotationAngles,
     RotationAngleTypes,
     Vector3d,
 )
+
+from nova import MotionSettings
+from nova.actions import cartesian_ptp, collision_free
+from nova.api import models
+from nova.core.exceptions import PlanTrajectoryFailed
+from nova.core.nova import Nova
+from nova.types import Pose
+from nova_rerun_bridge import NovaRerunBridge
 
 
 async def build_collision_world(
@@ -114,7 +115,10 @@ async def test():
 
             # Use default planner to move to the right of the sphere
             home = await motion_group.tcp_pose(tcp)
-            actions = [ptp(home), ptp(target=Pose((300, -400, 200, np.pi, 0, 0)))]
+            actions = [
+                cartesian_ptp(home),
+                cartesian_ptp(target=Pose((300, -400, 200, np.pi, 0, 0))),
+            ]
 
             for action in actions:
                 action.settings = MotionSettings(tcp_velocity_limit=200)
@@ -137,7 +141,7 @@ async def test():
             # Use default planner to move to the left of the sphere
             # -> this will collide
             # only plan don't move
-            actions = [ptp(target=Pose((-500, -400, 200, np.pi, 0, 0)))]
+            actions = [cartesian_ptp(target=Pose((-500, -400, 200, np.pi, 0, 0)))]
 
             for action in actions:
                 action.settings = MotionSettings(tcp_velocity_limit=200)

--- a/tests/core/test_motion_group.py
+++ b/tests/core/test_motion_group.py
@@ -1,7 +1,7 @@
 import pytest
 
 from nova import Nova
-from nova.actions import lin, ptp
+from nova.actions import cartesian_ptp, linear
 from nova.actions.motions import CollisionFreeMotion
 from nova.core.motion_group import split_actions_into_batches
 from nova.types import Pose
@@ -16,11 +16,11 @@ async def test_motion_group(nova_api):
 
     actions = [
         # from the default script for ur10
-        ptp((-91.4, -662.0, 851.3, 2.14, 2.14, -0.357)),
-        lin((-160.4, -652.0, 851.3, 2.14, 2.14, -0.357)),
-        ptp((-91.4, -462.0, 851.3, 2.14, 2.14, -0.357)),
-        lin((-60.4, -652.0, 851.3, 2.14, 2.14, -0.357)),
-        ptp((-91.4, -662.0, 851.3, 2.14, 2.14, -0.357)),
+        cartesian_ptp((-91.4, -662.0, 851.3, 2.14, 2.14, -0.357)),
+        linear((-160.4, -652.0, 851.3, 2.14, 2.14, -0.357)),
+        cartesian_ptp((-91.4, -462.0, 851.3, 2.14, 2.14, -0.357)),
+        linear((-60.4, -652.0, 851.3, 2.14, 2.14, -0.357)),
+        cartesian_ptp((-91.4, -662.0, 851.3, 2.14, 2.14, -0.357)),
     ] * 5
 
     async with controller:
@@ -44,9 +44,9 @@ async def test_empty_list():
 @pytest.mark.asyncio
 async def test_only_actions():
     # Create only normal actions.
-    a1 = lin((-60.4, -652.0, 851.3, 2.14, 2.14, -0.357))
-    a2 = ptp((-91.4, -462.0, 851.3, 2.14, 2.14, -0.357))
-    a3 = lin((10, 20, 30, 1, 2, 3))
+    a1 = linear((-60.4, -652.0, 851.3, 2.14, 2.14, -0.357))
+    a2 = cartesian_ptp((-91.4, -462.0, 851.3, 2.14, 2.14, -0.357))
+    a3 = linear((10, 20, 30, 1, 2, 3))
     # Expect a single batch containing all the actions.
     assert split_actions_into_batches([a1, a2, a3]) == [[a1, a2, a3]]
 
@@ -64,8 +64,8 @@ async def test_only_collision_free():
 async def test_collision_free_first():
     # Collision free motion comes first.
     cfm1 = CollisionFreeMotion(target=Pose(1, 2, 3, 4, 5, 6))
-    a1 = lin((0, 0, 0, 0, 0, 0))
-    a2 = ptp((1, 1, 1, 1, 1, 1))
+    a1 = linear((0, 0, 0, 0, 0, 0))
+    a2 = cartesian_ptp((1, 1, 1, 1, 1, 1))
     # Expect: first the collision free motion, then the batch of actions.
     assert split_actions_into_batches([cfm1, a1, a2]) == [[cfm1], [a1, a2]]
 
@@ -73,8 +73,8 @@ async def test_collision_free_first():
 @pytest.mark.asyncio
 async def test_collision_free_last():
     # Collision free motion comes last.
-    a1 = lin((0, 0, 0, 0, 0, 0))
-    a2 = ptp((1, 1, 1, 1, 1, 1))
+    a1 = linear((0, 0, 0, 0, 0, 0))
+    a2 = cartesian_ptp((1, 1, 1, 1, 1, 1))
     cfm1 = CollisionFreeMotion(target=Pose(1, 2, 3, 4, 5, 6))
     # Expect: first a batch of actions, then the collision free motion.
     assert split_actions_into_batches([a1, a2, cfm1]) == [[a1, a2], [cfm1]]
@@ -83,9 +83,9 @@ async def test_collision_free_last():
 @pytest.mark.asyncio
 async def test_interleaved():
     # Test interleaved actions and collision free motions.
-    a1 = lin((0, 0, 0, 0, 0, 0))
-    a2 = ptp((1, 1, 1, 1, 1, 1))
-    a3 = lin((2, 2, 2, 2, 2, 2))
+    a1 = linear((0, 0, 0, 0, 0, 0))
+    a2 = cartesian_ptp((1, 1, 1, 1, 1, 1))
+    a3 = linear((2, 2, 2, 2, 2, 2))
     cfm1 = CollisionFreeMotion(target=Pose(10, 20, 30, 40, 50, 60))
     cfm2 = CollisionFreeMotion(target=Pose(70, 80, 90, 100, 110, 120))
 
@@ -97,8 +97,8 @@ async def test_interleaved():
 @pytest.mark.asyncio
 async def test_multiple_collision_free_in_row():
     # Sequence: [action, collision free, collision free, action]
-    a1 = lin((0, 0, 0, 0, 0, 0))
-    a2 = ptp((1, 1, 1, 1, 1, 1))
+    a1 = linear((0, 0, 0, 0, 0, 0))
+    a2 = cartesian_ptp((1, 1, 1, 1, 1, 1))
     cfm1 = CollisionFreeMotion(target=Pose(10, 20, 30, 40, 50, 60))
     cfm2 = CollisionFreeMotion(target=Pose(70, 80, 90, 100, 110, 120))
     # Simulation:
@@ -117,9 +117,9 @@ async def test_multiple_collision_free_in_row():
 async def test_complex_sequence():
     # A more complex sequence mixing several patterns:
     # Sequence: [a1, cfm1, cfm2, a2, a3, cfm3]
-    a1 = lin((0, 0, 0, 0, 0, 0))
-    a2 = ptp((1, 1, 1, 1, 1, 1))
-    a3 = lin((2, 2, 2, 2, 2, 2))
+    a1 = linear((0, 0, 0, 0, 0, 0))
+    a2 = cartesian_ptp((1, 1, 1, 1, 1, 1))
+    a3 = linear((2, 2, 2, 2, 2, 2))
     cfm1 = CollisionFreeMotion(target=Pose(10, 20, 30, 40, 50, 60))
     cfm2 = CollisionFreeMotion(target=Pose(70, 80, 90, 100, 110, 120))
     cfm3 = CollisionFreeMotion(target=Pose(130, 140, 150, 160, 170, 180))


### PR DESCRIPTION
Still have aliases to their short counterparts.

Also rename string literals that are not directly tied to logic to
remain unambiguous, e.g. in `run_ptp_benchmark.py`.

plus, some minor commits