### PR TITLE
fix(RPS-1312): Limit TCP default velocity to 50mm/s

### DIFF
--- a/nova/auth/authorization.py
+++ b/nova/auth/authorization.py
@@ -118,8 +118,7 @@ class Auth0DeviceAuthorization:
             self.device_code_info = Auth0DeviceCodeInfo(**response.json())
             self.interval = self.device_code_info.interval
             return self.device_code_info
-        else:
-            raise Exception("Error requesting device code:", response.json())
+        raise Exception("Error requesting device code:", response.json())
 
     def get_device_code_info(self) -> Auth0DeviceCodeInfo | None:
         """
@@ -175,7 +174,7 @@ class Auth0DeviceAuthorization:
                     token_info = Auth0TokenInfo(**token_response.json())
                     self.refresh_token = token_info.refresh_token
                     return token_info.access_token
-                elif token_response.status_code == 400:
+                if token_response.status_code == 400:
                     # If the response status is 400, check the error type.
                     error = token_response.json().get("error")
                     if error == "authorization_pending":
@@ -221,5 +220,4 @@ class Auth0DeviceAuthorization:
         if response.status_code == 200:
             token_info = Auth0TokenInfo(**response.json())
             return token_info.access_token
-        else:
-            raise Exception("Error refreshing access token:", response.json())
+        raise Exception("Error refreshing access token:", response.json())

--- a/nova/core/robot_cell.py
+++ b/nova/core/robot_cell.py
@@ -302,7 +302,7 @@ class AbstractRobot(Device):
         ) -> MotionState:
             if isinstance(movement_response, api.models.ExecuteTrajectoryResponse):
                 return movement_to_motion_state(movement_response.actual_instance)
-            elif isinstance(movement_response, api.models.StreamMoveResponse):
+            if isinstance(movement_response, api.models.StreamMoveResponse):
                 return movement_to_motion_state(movement_response)
             assert False, f"Unexpected movement response: {movement_response}"
 

--- a/nova/types/motion_settings.py
+++ b/nova/types/motion_settings.py
@@ -39,7 +39,7 @@ class MotionSettings(pydantic.BaseModel):
     position_zone_radius: float | None = pydantic.Field(default=None)
     joint_velocity_limits: tuple[float, ...] | None = pydantic.Field(default=None)
     joint_acceleration_limits: tuple[float, ...] | None = pydantic.Field(default=None)
-    tcp_velocity_limit: float | None = pydantic.Field(default=None)
+    tcp_velocity_limit: float | None = pydantic.Field(default=50)
     tcp_acceleration_limit: float | None = pydantic.Field(default=None)
     tcp_orientation_velocity_limit: float | None = pydantic.Field(default=None)
     tcp_orientation_acceleration_limit: float | None = pydantic.Field(default=None)

--- a/nova/types/pose.py
+++ b/nova/types/pose.py
@@ -29,11 +29,10 @@ def _parse_args(*args):
     if len(args) == 6:
         x1, y1, z1, x2, y2, z2 = args
         return {"position": Vector3d(x=x1, y=y1, z=z1), "orientation": Vector3d(x=x2, y=y2, z=z2)}
-    elif len(args) == 3:
+    if len(args) == 3:
         x1, y1, z1 = args
         return {"position": Vector3d(x=x1, y=y1, z=z1), "orientation": Vector3d(x=0, y=0, z=0)}
-    else:
-        raise ValueError("Invalid number of arguments for Pose")
+    raise ValueError("Invalid number of arguments for Pose")
 
 
 class Pose(pydantic.BaseModel, Sized):
@@ -166,12 +165,11 @@ class Pose(pydantic.BaseModel, Sized):
         if isinstance(other, Pose):
             transformed_matrix = np.dot(self.matrix, other.matrix)
             return self._matrix_to_pose(transformed_matrix)
-        elif isinstance(other, Iterable):
+        if isinstance(other, Iterable):
             seq = tuple(other)
             return self.__matmul__(Pose(seq))
 
-        else:
-            raise ValueError(f"Cannot multiply Pose with {type(other)}")
+        raise ValueError(f"Cannot multiply Pose with {type(other)}")
 
     def __array__(self, dtype=None):
         """Convert Pose to a 6-element numpy array: [pos.x, pos.y, pos.z, ori.x, ori.y, ori.z].

--- a/nova_rerun_bridge/minimal_example/main.py
+++ b/nova_rerun_bridge/minimal_example/main.py
@@ -6,13 +6,6 @@ import asyncio
 
 import numpy as np
 import rerun as rr
-from wandelbots_api_client.models import (
-    CoordinateSystem,
-    RotationAngles,
-    RotationAngleTypes,
-    Vector3d,
-)
-
 from nova import MotionSettings
 from nova.actions import cartesian_ptp, collision_free
 from nova.api import models
@@ -20,6 +13,12 @@ from nova.core.exceptions import PlanTrajectoryFailed
 from nova.core.nova import Nova
 from nova.types import Pose
 from nova_rerun_bridge import NovaRerunBridge
+from wandelbots_api_client.models import (
+    CoordinateSystem,
+    RotationAngles,
+    RotationAngleTypes,
+    Vector3d,
+)
 
 
 async def build_collision_world(


### PR DESCRIPTION
Tested via wandelscript's CLI tool `ws` and a modified default script; 

Kicks in when `velocity()` is not specified in the Wandelscript program. When `velocity()` is set inside the program, the setting picks up accordingly.