### PR TITLE
fix(RPS-155): Provide motion group / robot ID on `PlanTrajectoryFailed` exceptions

### DIFF
--- a/nova/core/exceptions.py
+++ b/nova/core/exceptions.py
@@ -9,15 +9,27 @@ class ControllerNotFound(Exception):
 
 
 class PlanTrajectoryFailed(Exception):
-    def __init__(self, error: wb.models.PlanTrajectoryFailedResponse):
+    def __init__(self, error: wb.models.PlanTrajectoryFailedResponse, motion_group_id: str):
+        """
+        Create a PlanTrajectoryFailed exception.
+
+        Args:
+            error:           The failure response.
+            motion_group_id: The ID of the motion group that caused the exception, e.g. `0@controller`
+        """
         self._error = error
-        super().__init__(f"Plan trajectory failed: {json.dumps(error.to_dict(), indent=2)}")
+        self._motion_group_id = motion_group_id
+        super().__init__(
+            f"Plan trajectory on {motion_group_id} failed: {json.dumps(error.to_dict(), indent=2)}"
+        )
 
     def to_pretty_string(self) -> str:
         """Give a more lightweight representation of the error, omitting some gritty details."""
         error_dict = self._error.to_dict()
         del error_dict["joint_trajectory"]
-        return f"Plan trajectory failed: {json.dumps(error_dict, indent=2)}"
+        return (
+            f"Plan trajectory on {self._motion_group_id} failed: {json.dumps(error_dict, indent=2)}"
+        )
 
     @property
     def error(self) -> wb.models.PlanTrajectoryFailedResponse:

--- a/nova/core/motion_group.py
+++ b/nova/core/motion_group.py
@@ -195,7 +195,9 @@ class MotionGroup(AbstractRobot):
             wb.models.PlanTrajectoryFailedResponse,
         ):
             # TODO: handle partially executable path
-            raise PlanTrajectoryFailed(plan_trajectory_response.response.actual_instance)
+            raise PlanTrajectoryFailed(
+                plan_trajectory_response.response.actual_instance, self.motion_group_id
+            )
         return plan_trajectory_response.response.actual_instance
 
     def _validate_collision_scenes(self, actions: list[Action]) -> list[models.CollisionScene]:
@@ -283,7 +285,7 @@ class MotionGroup(AbstractRobot):
         )
 
         if isinstance(plan_result.response.actual_instance, wb.models.PlanTrajectoryFailedResponse):
-            raise PlanTrajectoryFailed(plan_result.response.actual_instance)
+            raise PlanTrajectoryFailed(plan_result.response.actual_instance, self.motion_group_id)
         return plan_result.response.actual_instance
 
     async def _plan(


### PR DESCRIPTION
Also add this in the error message and pretty string function. This way, downstream clients may display the motion group ID in order to denote the robot that caused the exception.

Tested via Wandelscript CLI. Looks like:
![2025-03-20-11-28-50-clipboard](https://github.com/user-attachments/assets/b2490541-8ce8-4b02-81c8-a9ca9d697477)
note the mention of `0@controller`. That's the new stuff