### PR TITLE
chore: upgrade major version to 1.x.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wandelbots-nova"
-version = "0.47.11"
+version = "1.47.11"
 description = "Official Python SDK for the Wandelbots"
 authors = [
     "Wandelbots GmbH",


### PR DESCRIPTION
To better distinguish between v1 & v2 compatibility we agreed on aligning the major version of the SDK to the Nova API version.