### PR TITLE
fix(RPS-1595)!: tcp_pose is returned with the correct TCP reference now

### DIFF
--- a/nova/core/motion_group.py
+++ b/nova/core/motion_group.py
@@ -424,13 +424,13 @@ class MotionGroup(AbstractRobot):
         """
         Returns the motion group state.
         Args:
-            tcp (str | None, optional): The reference TCP for the cartesian pose part of the robot state. Defaults to None.
+            tcp (str | None): The reference TCP for the cartesian pose part of the robot state. Defaults to None.
                                         If None, the current active/selected TCP of the motion group is used.
         """
         response = await self._api_gateway.get_motion_group_state(
             cell=self._cell, motion_group_id=self.motion_group_id, tcp=tcp
         )
-        pose = Pose(response.tcp_pose if response.tcp_pose is not None else response.state.tcp_pose)
+        pose = Pose(response.tcp_pose or response.state.tcp_pose)
         return RobotState(pose=pose, joints=tuple(response.state.joint_position.joints))
 
     async def joints(self) -> tuple:
@@ -446,7 +446,7 @@ class MotionGroup(AbstractRobot):
         """
         Returns the current TCP pose of the motion group.
         Args:
-            tcp (str | None, optional): The reference TCP for the returned pose. Defaults to None.
+            tcp (str | None): The reference TCP for the returned pose. Defaults to None.
                                         If None, the current active/selected TCP of the motion group is used.
         """
         state = await self.get_state(tcp=tcp)

--- a/nova/core/motion_group.py
+++ b/nova/core/motion_group.py
@@ -443,7 +443,8 @@ class MotionGroup(AbstractRobot):
         return state.joints
 
     async def tcp_pose(self, tcp: str | None = None) -> Pose:
-        """Returns the current TCP pose of the motion group.
+        """
+        Returns the current TCP pose of the motion group.
         Args:
             tcp (str | None, optional): The reference TCP for the returned pose. Defaults to None.
                                         If None, the current active/selected TCP of the motion group is used.

--- a/nova/core/motion_group.py
+++ b/nova/core/motion_group.py
@@ -421,14 +421,20 @@ class MotionGroup(AbstractRobot):
             logger.debug(f"No motion to stop for {self}: {e}")
 
     async def get_state(self, tcp: str | None = None) -> RobotState:
+        """
+        Returns the motion group state.
+        Args:
+            tcp (str | None, optional): The reference TCP for the cartesian pose part of the robot state. Defaults to None.
+                                        If None, the current active/selected TCP of the motion group is used.
+        """
         response = await self._api_gateway.get_motion_group_state(
             cell=self._cell, motion_group_id=self.motion_group_id, tcp=tcp
         )
-        return RobotState(
-            pose=Pose(response.state.tcp_pose), joints=tuple(response.state.joint_position.joints)
-        )
+        pose = Pose(response.tcp_pose if response.tcp_pose is not None else response.state.tcp_pose)
+        return RobotState(pose=pose, joints=tuple(response.state.joint_position.joints))
 
     async def joints(self) -> tuple:
+        """Returns the current joint positions of the motion group."""
         state = await self.get_state()
         if state.joints is None:
             raise ValueError(
@@ -437,6 +443,11 @@ class MotionGroup(AbstractRobot):
         return state.joints
 
     async def tcp_pose(self, tcp: str | None = None) -> Pose:
+        """Returns the current TCP pose of the motion group.
+        Args:
+            tcp (str | None, optional): The reference TCP for the returned pose. Defaults to None.
+                                        If None, the current active/selected TCP of the motion group is used.
+        """
         state = await self.get_state(tcp=tcp)
         return state.pose
 

--- a/uv.lock
+++ b/uv.lock
@@ -1739,7 +1739,7 @@ wheels = [
 
 [[package]]
 name = "wandelbots-nova"
-version = "0.48.1"
+version = "0.52.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiostream" },


### PR DESCRIPTION
The `MotionGroupStateResponse` of the `MotionGroupInfosApi` has two places where it provides `tcp_pose` information.
The one inside of the `state` field may or may not be the current selected TCP of the robot (the description is contradictory there). The other is only present if a TCP was given to the `MotionGroupInfosApi.get_current_motion_group_state()` call and then is at the top level of the response object giving the TPC pose of the provided TCP.
`MotionGroup.get_state()` wrongly always used `tcp_pose` field inside of `state`. Now it uses the other one if a TCP was provided, mirroring the underlying behaviour, but uses `state.tcp_pose` if no TCP was given.