### PR TITLE
feat: add wait action

### DIFF
--- a/nova/actions/__init__.py
+++ b/nova/actions/__init__.py
@@ -1,6 +1,7 @@
 from nova.actions.base import Action
 from nova.actions.container import CombinedActions, MovementController, MovementControllerContext
 from nova.actions.io import io_write
+from nova.actions.mock import wait
 from nova.actions.motions import (
     cartesian_ptp,
     cir,
@@ -26,6 +27,7 @@ __all__ = [
     "jnt",
     "linear",
     "lin",
+    "wait",
     "MovementController",
     "MovementControllerContext",
 ]

--- a/nova/actions/mock.py
+++ b/nova/actions/mock.py
@@ -1,0 +1,25 @@
+from typing import Literal
+
+import pydantic
+from pydantic import StrictFloat
+
+from nova.actions.base import Action
+
+
+class WaitAction(Action):
+    type: Literal["Wait"] = "Wait"
+    wait_for_in_seconds: StrictFloat = 0.0
+
+    @pydantic.model_serializer
+    def serialize_model(self):
+        return self.model_dump()
+
+    def is_motion(self) -> bool:
+        return False
+
+    def to_api_model(self):
+        return {"type": self.type, "wait_for_in_seconds": self.wait_for_in_seconds}
+
+
+def wait(wait_for_in_seconds: StrictFloat) -> WaitAction:
+    return WaitAction(wait_for_in_seconds=wait_for_in_seconds)

--- a/nova/actions/mock.py
+++ b/nova/actions/mock.py
@@ -1,14 +1,13 @@
 from typing import Literal
 
 import pydantic
-from pydantic import StrictFloat
 
 from nova.actions.base import Action
 
 
 class WaitAction(Action):
     type: Literal["Wait"] = "Wait"
-    wait_for_in_seconds: StrictFloat = 0.0
+    wait_for_in_seconds: float = 0.0
 
     @pydantic.model_serializer
     def serialize_model(self):
@@ -21,5 +20,5 @@ class WaitAction(Action):
         return {"type": self.type, "wait_for_in_seconds": self.wait_for_in_seconds}
 
 
-def wait(wait_for_in_seconds: StrictFloat) -> WaitAction:
+def wait(wait_for_in_seconds: float) -> WaitAction:
     return WaitAction(wait_for_in_seconds=wait_for_in_seconds)

--- a/nova/core/motion_group.py
+++ b/nova/core/motion_group.py
@@ -305,8 +305,6 @@ class MotionGroup(AbstractRobot):
                 # the last joint position of this trajectory is the starting point for the next one
                 current_joints = tuple(trajectory.joint_positions[-1].joints)
             elif isinstance(batch[0], WaitAction):
-                # Waits generate a trajectory with the same start and end position
-                # so we can just use the last joint position of the previous trajectory
                 # Waits generate a trajectory with the same joint position at each timestep
                 # Use 50ms timesteps from 0 to wait_for_in_seconds
                 wait_time = batch[0].wait_for_in_seconds
@@ -324,7 +322,9 @@ class MotionGroup(AbstractRobot):
                 locations = [0] * num_steps
 
                 trajectory = wb.models.JointTrajectory(
-                    joint_positions=joint_positions, times=times, locations=locations
+                    joint_positions=joint_positions,
+                    times=times,
+                    locations=[float(loc) for loc in locations],
                 )
                 all_trajectories.append(trajectory)
                 # the last joint position of this trajectory is the starting point for the next one

--- a/nova_rerun_bridge/examples/19_wait_action.py
+++ b/nova_rerun_bridge/examples/19_wait_action.py
@@ -1,0 +1,57 @@
+import asyncio
+
+from nova import MotionSettings
+from nova.actions import cartesian_ptp, joint_ptp
+from nova.actions.mock import wait
+from nova.actions.motions import Motion
+from nova.api import models
+from nova.core.nova import Nova
+from nova.types import Pose
+from nova_rerun_bridge import NovaRerunBridge
+
+
+async def test():
+    async with Nova() as nova, NovaRerunBridge(nova) as bridge:
+        await bridge.setup_blueprint()
+        cell = nova.cell()
+        controller = await cell.ensure_virtual_robot_controller(
+            "ur10",
+            models.VirtualControllerTypes.UNIVERSALROBOTS_MINUS_UR10E,
+            models.Manufacturer.UNIVERSALROBOTS,
+        )
+
+        # Connect to the controller and activate motion groups
+        async with controller[0] as motion_group:
+            await bridge.log_saftey_zones(motion_group)
+
+            home_joints = await motion_group.joints()
+            tcp_names = await motion_group.tcp_names()
+            tcp = tcp_names[0]
+
+            # Get current TCP pose and offset it slightly along the x-axis
+            current_pose = await motion_group.tcp_pose(tcp)
+            actions = [
+                wait(2),
+                joint_ptp(home_joints),
+                cartesian_ptp(current_pose @ [100, 0, 0, 0, 0, 0]),
+                joint_ptp(home_joints),
+                wait(2),
+                cartesian_ptp(current_pose @ Pose((100, 100, 0, 0, 0, 0))),
+                joint_ptp(home_joints),
+                cartesian_ptp(current_pose @ Pose((0, 100, 0, 0, 0, 0))),
+                joint_ptp(home_joints),
+            ]
+
+            # you can update the settings of the action
+            for action in actions:
+                if isinstance(action, Motion):
+                    action.settings = MotionSettings(tcp_velocity_limit=200)
+
+            joint_trajectory = await motion_group.plan(actions, tcp)
+
+            await bridge.log_actions(actions)
+            await bridge.log_trajectory(joint_trajectory, tcp, motion_group)
+
+
+if __name__ == "__main__":
+    asyncio.run(test())

--- a/tests/actions/test_action_wait.py
+++ b/tests/actions/test_action_wait.py
@@ -1,0 +1,67 @@
+import wandelbots_api_client as wb
+
+from nova.actions.mock import wait
+
+
+def test_wait_action_trajectory_duration():
+    """Test that wait action generates trajectories with the correct duration."""
+    # Create wait actions with different durations
+    wait_action_1 = wait(2.5)  # 2.5 seconds
+    wait_action_2 = wait(0.1)  # 0.1 seconds - edge case
+    wait_action_3 = wait(10)  # 10 seconds - long wait
+
+    # Mock current_joints for trajectory generation
+    current_joints = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+    # Generate trajectories for testing
+    def generate_wait_trajectory(wait_action):
+        # Replicate trajectory generation logic from motion_group.py
+        wait_time = wait_action.wait_for_in_seconds
+        timestep = 0.050  # 50ms timestep
+        num_steps = max(2, int(wait_time / timestep) + 1)
+
+        joint_positions = [wb.models.Joints(joints=list(current_joints)) for _ in range(num_steps)]
+        times = [i * timestep for i in range(num_steps)]
+        # Ensure the last timestep is exactly the wait duration
+        times[-1] = wait_time
+        locations = [0] * num_steps
+
+        return wb.models.JointTrajectory(
+            joint_positions=joint_positions, times=times, locations=locations
+        )
+
+    # Generate trajectories
+    trajectory_1 = generate_wait_trajectory(wait_action_1)
+    trajectory_2 = generate_wait_trajectory(wait_action_2)
+    trajectory_3 = generate_wait_trajectory(wait_action_3)
+
+    # Test trajectory 1 (2.5 seconds)
+    assert len(trajectory_1.times) >= 2
+    assert trajectory_1.times[-1] == 2.5
+    assert trajectory_1.times[-1] - trajectory_1.times[0] >= 2.0, (
+        "Wait trajectory should be longer than 2 seconds"
+    )
+
+    # Test trajectory 2 (edge case - 0.1 seconds)
+    assert len(trajectory_2.times) >= 2
+    assert trajectory_2.times[-1] == 0.1
+
+    # Test trajectory 3 (long wait - 10 seconds)
+    assert len(trajectory_3.times) >= 2
+    assert trajectory_3.times[-1] == 10.0
+    assert trajectory_3.times[-1] - trajectory_3.times[0] >= 2.0, (
+        "Wait trajectory should be longer than 2 seconds"
+    )
+
+    # Check that all joint positions are identical
+    for trajectory in [trajectory_1, trajectory_2, trajectory_3]:
+        for i in range(1, len(trajectory.joint_positions)):
+            assert trajectory.joint_positions[i].joints == trajectory.joint_positions[0].joints
+
+    # Check timestep spacing (approximately 50ms)
+    for trajectory in [trajectory_1, trajectory_3]:  # Skip the short trajectory
+        for i in range(1, len(trajectory.times) - 1):  # Skip last point which might be adjusted
+            time_diff = trajectory.times[i] - trajectory.times[i - 1]
+            assert 0.049 <= time_diff <= 0.051, (
+                f"Timestep should be approximately 50ms but was {time_diff * 1000}ms"
+            )


### PR DESCRIPTION
adds a wait action which waits
```
actions = [
    wait(2),
    joint_ptp(home_joints),
    cartesian_ptp(current_pose @ [100, 0, 0, 0, 0, 0]),
    joint_ptp(home_joints),
    wait(2),
    cartesian_ptp(current_pose @ Pose((100, 100, 0, 0, 0, 0))),
    joint_ptp(home_joints),
    cartesian_ptp(current_pose @ Pose((0, 100, 0, 0, 0, 0))),
    joint_ptp(home_joints),
]
```

The wait action generate a trajectory with the same joint position at each timestep it used 50ms timesteps from 0 to wait_for_in_seconds