### PR TITLE
chore: Towards passing tests

### DIFF
--- a/.github/workflows/nova-run-examples.yaml
+++ b/.github/workflows/nova-run-examples.yaml
@@ -1,5 +1,5 @@
 ---
-name: "[nova] Run examples"
+name: "[nova] Run integration tests & examples"
 on:
   pull_request:
     branches:
@@ -8,21 +8,33 @@ concurrency:
   group: run-examples-workflow
   cancel-in-progress: false
 jobs:
-  run-examples:
+  test-integration:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       max-parallel: 1
       matrix:
-        example_file:
-          - "examples/01_basic.py"
-          - "examples/02_plan_and_execute.py"
-          - "examples/03_move_and_set_ios.py"
-          - "examples/04_move_multiple_robots.py"
-          - "examples/05_selection_motion_group_activation.py"
-          - "examples/06_api_usage.py"
-          - "examples/08_multi_step_movement_with_collision_free.py"
-          - "nova_rerun_bridge/examples/14_welding_example.py"
+        include:
+          # single entry for the whole integration‑test batch
+          - id: integration
+            run_cmd: "pytest -rs -v -m integration"
+          # each example gets its own matrix entry
+          - id: 01_basic
+            run_cmd: "python examples/01_basic.py"
+          - id: 02_plan_and_execute
+            run_cmd: "python examples/02_plan_and_execute.py"
+          - id: 03_move_and_set_ios
+            run_cmd: "python examples/03_move_and_set_ios.py"
+          - id: 04_move_multiple_robots
+            run_cmd: "python examples/04_move_multiple_robots.py"
+          - id: 05_selection_motion_group_activation
+            run_cmd: "python examples/05_selection_motion_group_activation.py"
+          - id: 06_api_usage
+            run_cmd: "python examples/06_api_usage.py"
+          - id: 08_multi_step_movement_with_collision_free
+            run_cmd: "python examples/08_multi_step_movement_with_collision_free.py"
+          - id: 14_welding_example
+            run_cmd: "python nova_rerun_bridge/examples/14_welding_example.py"
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -54,33 +66,24 @@ jobs:
         run: |
           pip install uv
           uv sync --extra "nova-rerun-bridge"
-      - name: Run integration tests
+      - name: "Run ${{ matrix.id }} suite"
         run: |
-          echo "NOVA_API=https://${{ env.PORTAL_STG_HOST }}" >> ./.env
-          echo "NOVA_ACCESS_TOKEN=${{ env.PORTAL_STG_ACCESS_TOKEN }}" >> ./.env
-          echo "CELL_NAME=cell" >> ./.env
-
-          PYTHONPATH=. uv run pytest -rs -v -m "integration"
-      - name: "Run example: examples/${{ matrix.example_file }}"
-        run: |
-          echo "NOVA_API=https://${{ env.PORTAL_STG_HOST }}" >> ./.env
-          echo "NOVA_ACCESS_TOKEN=${{ env.PORTAL_STG_ACCESS_TOKEN }}" >> ./.env
-          echo "CELL_NAME=cell" >> ./.env
-
+          # generic retry wrapper for *all* commands
           n=0
-          max_retries=3
-          until [ $n -ge $max_retries ]
-          do
-            echo "Attempt $((n+1)) to run ${{ matrix.example_file }}..."
-            PYTHONPATH=. uv run python ${{ matrix.example_file }} && break
-
+          max=3
+          until [ "$n" -ge "$max" ]; do
+            echo "\nAttempt $((n+1))/$(($max)) : ${{ matrix.run_cmd }}"
+            if PYTHONPATH=. uv run ${{ matrix.run_cmd }}; then
+              echo "Succeeded on attempt $((n+1))"
+              break
+            fi
             n=$((n+1))
-            echo "Failed attempt $n. Retrying in 5s..."
+            echo "Retrying in 5s..."
             sleep 5
           done
 
-          if [ $n -ge $max_retries ]; then
-            echo "Failed after $max_retries attempts."
+          if [ "$n" -ge "$max" ]; then
+            echo "Command failed after $max attempts." >&2
             exit 1
           fi
       - name: Download diagnose package

--- a/.github/workflows/nova-run-examples.yaml
+++ b/.github/workflows/nova-run-examples.yaml
@@ -68,7 +68,10 @@ jobs:
           uv sync --extra "nova-rerun-bridge"
       - name: "Run ${{ matrix.id }} suite"
         run: |
-          echo $PORTAL_STG_HOST
+          # export the environment variables for the run command
+          echo "NOVA_API=https://${{ env.PORTAL_STG_HOST }}" >> ./.env
+          echo "NOVA_ACCESS_TOKEN=${{ env.PORTAL_STG_ACCESS_TOKEN }}" >> ./.env
+          echo "CELL_NAME=cell" >> ./.env
 
           # generic retry wrapper for *all* commands
           n=0

--- a/.github/workflows/nova-run-examples.yaml
+++ b/.github/workflows/nova-run-examples.yaml
@@ -68,6 +68,8 @@ jobs:
           uv sync --extra "nova-rerun-bridge"
       - name: "Run ${{ matrix.id }} suite"
         run: |
+          echo $PORTAL_STG_HOST
+
           # generic retry wrapper for *all* commands
           n=0
           max=3

--- a/examples/09_state_stream.py
+++ b/examples/09_state_stream.py
@@ -7,7 +7,7 @@ from argparse import ArgumentParser
 from contextlib import suppress
 
 from nova import Nova
-from nova.core.robot_cell import RobotCell
+from nova.cell.robot_cell import RobotCell
 
 
 async def main(controller_name: str = "controller") -> None:

--- a/nova/runtime/runner.py
+++ b/nova/runtime/runner.py
@@ -14,6 +14,7 @@ from typing import Any
 import anyio
 from anyio import from_thread, to_thread
 from anyio.abc import TaskStatus
+from exceptiongroup import ExceptionGroup
 from loguru import logger
 from pydantic import BaseModel, Field
 

--- a/nova/runtime/utils.py
+++ b/nova/runtime/utils.py
@@ -3,6 +3,7 @@ from collections.abc import Awaitable
 from typing import TextIO
 
 import anyio
+from exceptiongroup import ExceptionGroup
 
 
 class Tee(io.StringIO):
@@ -36,7 +37,7 @@ async def stoppable_run(run: Awaitable[None], stop: Awaitable[None]) -> None:
 
     try:
         await group()
-    except ExceptionGroup as eg:  # type: ignore  # noqa: F821
+    except ExceptionGroup as eg:
         # since we only have two tasks, we can be sure that the first exception is the one we want to raise
         # in case of debugging, one might want to log all exceptions
         raise eg.exceptions[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "numpy >1.1.19",
     "asyncua >=1.1.5,<2",
     "docstring-parser >=0.16.0",
+    "exceptiongroup>=1.2.2",
 ]
 
 [project.optional-dependencies]

--- a/tests/runtime/test_runner.py
+++ b/tests/runtime/test_runner.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 
 from nova.runtime.exceptions import NotPlannableError

--- a/uv.lock
+++ b/uv.lock
@@ -1764,7 +1764,7 @@ wheels = [
 
 [[package]]
 name = "wandelbots-nova"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiostream" },
@@ -1772,6 +1772,7 @@ dependencies = [
     { name = "asyncstdlib" },
     { name = "asyncua" },
     { name = "docstring-parser" },
+    { name = "exceptiongroup" },
     { name = "httpx" },
     { name = "loguru" },
     { name = "numpy" },
@@ -1817,6 +1818,7 @@ requires-dist = [
     { name = "asyncstdlib", specifier = ">=3.13.0,<4" },
     { name = "asyncua", specifier = ">=1.1.5,<2" },
     { name = "docstring-parser", specifier = ">=0.16.0" },
+    { name = "exceptiongroup", specifier = ">=1.2.2" },
     { name = "httpx", specifier = ">=0.28.0,<0.29" },
     { name = "loguru", specifier = ">=0.7.2,<0.8" },
     { name = "numpy", specifier = ">1.1.19" },


### PR DESCRIPTION
Fix a missing `ExceptionGroup`s under Python 3.10; we seem to use them since commit 

`0838520 feat(RPS-1615): implemented program runner for Python program (#153)`

Also fix a broken import for `RobotCell`.

There are other issues related to recently added `TestProgramRunner`. I refrain from touching them since they've seen to be put there deliberately just a few days ago