### PR TITLE
fix: Install `pdoc` into the venv on `autodocs.yml`

### DIFF
--- a/.github/workflows/autodocs.yml
+++ b/.github/workflows/autodocs.yml
@@ -27,8 +27,10 @@ jobs:
         run: uv run pip install "wandelbots-nova[nova-rerun-bridge]"
       - name: Install dependencies
         run: uv sync
+      - name: Install pdoc
+        run: uv run pip install pdoc
       - name: Generate documentation
-        run: uvx pdoc --docformat google nova nova_rerun_bridge -o ./docs
+        run: uv run pdoc --docformat google nova nova_rerun_bridge -o ./docs
       - name: Setup GitHub Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact


### PR DESCRIPTION
`uvx` runs `pdoc` in a segregated environment, making it unable to find the modules in the venv of the project.
Instead, install pdoc into the venv and use it via `uv run`.