### PR TITLE
feat(nova_app_template): register DI components by interface

### DIFF
--- a/nova_app_template/api/runs.py
+++ b/nova_app_template/api/runs.py
@@ -14,11 +14,11 @@ from pydantic import BaseModel
 
 from nova_app_template.container import NovaContainer
 from nova_app_template.interfaces import (
+    ProgramExecutionServiceInterface,
     ProgramInstanceStoreInterface,
     ProgramRunAPIServiceInterface,
     ProgramRunStoreInterface,
 )
-from nova_app_template.services import ProgramExecutionService
 
 
 # Request/Response models
@@ -119,7 +119,7 @@ async def create_program_run(
     instance_store: ProgramInstanceStoreInterface = Depends(
         Provide[NovaContainer.stores.program_instance_store]
     ),
-    execution_service: ProgramExecutionService = Depends(
+    execution_service: ProgramExecutionServiceInterface = Depends(
         Provide[NovaContainer.services.program_execution_service]
     ),
 ):

--- a/nova_app_template/interfaces.py
+++ b/nova_app_template/interfaces.py
@@ -6,32 +6,31 @@ to customize the behavior of the framework.
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Any, Callable
 from contextlib import contextmanager
+from typing import Any, Optional
 
 # Import the processor interface from the processors package
-from .processors.interface import ProgramRunProcessorInterface
 
 
 class DatabaseConnectionInterface(ABC):
     """Interface for database connections"""
-    
+
     @abstractmethod
     def init_database(self) -> None:
         """Initialize the database schema"""
         pass
-    
+
     @abstractmethod
     @contextmanager
     def get_connection(self):
         """Get a database connection context manager"""
         pass
-    
+
     @abstractmethod
-    def get_database_stats(self) -> Dict[str, int]:
+    def get_database_stats(self) -> dict[str, int]:
         """Get database statistics"""
         pass
-    
+
     @abstractmethod
     def backup_database(self, backup_path: str) -> bool:
         """Create a backup of the database"""
@@ -40,22 +39,22 @@ class DatabaseConnectionInterface(ABC):
 
 class ProgramTemplateStoreInterface(ABC):
     """Interface for program template storage"""
-    
+
     @abstractmethod
     def save(self, template: Any) -> bool:
         """Save or update a program template"""
         pass
-    
+
     @abstractmethod
-    def get(self, name: str) -> Optional[Dict[str, Any]]:
+    def get(self, name: str) -> Optional[dict[str, Any]]:
         """Get a program template by name"""
         pass
-    
+
     @abstractmethod
-    def get_all(self) -> List[Dict[str, Any]]:
+    def get_all(self) -> list[dict[str, Any]]:
         """Get all program templates"""
         pass
-    
+
     @abstractmethod
     def delete(self, name: str) -> bool:
         """Delete a program template"""
@@ -64,66 +63,66 @@ class ProgramTemplateStoreInterface(ABC):
 
 class ProgramInstanceStoreInterface(ABC):
     """Interface for program instance storage"""
-    
+
     @abstractmethod
     def save(self, instance: Any) -> bool:
         """Save or update a program instance"""
         pass
-    
+
     @abstractmethod
-    def get(self, name: str) -> Optional[Dict[str, Any]]:
+    def get(self, name: str) -> Optional[dict[str, Any]]:
         """Get a program instance by name"""
         pass
-    
+
     @abstractmethod
-    def get_all(self) -> List[Dict[str, Any]]:
+    def get_all(self) -> list[dict[str, Any]]:
         """Get all program instances"""
         pass
-    
+
     @abstractmethod
-    def get_by_template(self, template_name: str) -> List[Dict[str, Any]]:
+    def get_by_template(self, template_name: str) -> list[dict[str, Any]]:
         """Get all program instances for a specific template"""
         pass
-    
+
     @abstractmethod
     def delete(self, name: str) -> bool:
         """Delete a program instance"""
         pass
-    
+
     @abstractmethod
-    def update_data(self, name: str, data: Dict[str, Any]) -> bool:
+    def update_data(self, name: str, data: dict[str, Any]) -> bool:
         """Update only the data field of a program instance"""
         pass
 
 
 class ProgramRunStoreInterface(ABC):
     """Interface for program run storage"""
-    
+
     @abstractmethod
     def save(self, run: Any) -> bool:
         """Save or update a program run"""
         pass
-    
+
     @abstractmethod
-    def get(self, run_id: str) -> Optional[Dict[str, Any]]:
+    def get(self, run_id: str) -> Optional[dict[str, Any]]:
         """Get a program run by ID"""
         pass
-    
+
     @abstractmethod
-    def get_all(self) -> List[Dict[str, Any]]:
+    def get_all(self) -> list[dict[str, Any]]:
         """Get all program runs"""
         pass
-    
+
     @abstractmethod
-    def get_by_program(self, program_name: str) -> List[Dict[str, Any]]:
+    def get_by_program(self, program_name: str) -> list[dict[str, Any]]:
         """Get all runs for a specific program"""
         pass
-    
+
     @abstractmethod
     def update_status(self, run_id: str, status: str, **kwargs) -> bool:
         """Update the status of a program run"""
         pass
-    
+
     @abstractmethod
     def delete(self, run_id: str) -> bool:
         """Delete a program run"""
@@ -132,7 +131,7 @@ class ProgramRunStoreInterface(ABC):
 
 class APIServiceInterface(ABC):
     """Interface for API services that handle business logic"""
-    
+
     @abstractmethod
     def initialize(self) -> None:
         """Initialize the service"""
@@ -141,27 +140,27 @@ class APIServiceInterface(ABC):
 
 class ProgramAPIServiceInterface(APIServiceInterface):
     """Interface for program API service"""
-    
+
     @abstractmethod
-    def get_programs(self) -> List[Dict[str, Any]]:
+    def get_programs(self) -> list[dict[str, Any]]:
         """Get all programs"""
         pass
-    
+
     @abstractmethod
-    def get_program(self, name: str) -> Optional[Dict[str, Any]]:
+    def get_program(self, name: str) -> Optional[dict[str, Any]]:
         """Get a specific program"""
         pass
-    
+
     @abstractmethod
-    def create_program(self, program_data: Dict[str, Any]) -> bool:
+    def create_program(self, program_data: dict[str, Any]) -> bool:
         """Create a new program"""
         pass
-    
+
     @abstractmethod
-    def update_program(self, name: str, program_data: Dict[str, Any]) -> bool:
+    def update_program(self, name: str, program_data: dict[str, Any]) -> bool:
         """Update an existing program"""
         pass
-    
+
     @abstractmethod
     def delete_program(self, name: str) -> bool:
         """Delete a program"""
@@ -170,72 +169,87 @@ class ProgramAPIServiceInterface(APIServiceInterface):
 
 class ProgramRunAPIServiceInterface(APIServiceInterface):
     """Interface for program run API service"""
-    
+
     @abstractmethod
-    def get_runs(self, program_name: Optional[str] = None) -> List[Dict[str, Any]]:
+    def get_runs(self, program_name: Optional[str] = None) -> list[dict[str, Any]]:
         """Get runs, optionally filtered by program name"""
         pass
-    
+
     @abstractmethod
-    def get_run(self, run_id: str) -> Optional[Dict[str, Any]]:
+    def get_run(self, run_id: str) -> Optional[dict[str, Any]]:
         """Get a specific run"""
         pass
-    
+
     @abstractmethod
-    def create_run(self, run_data: Dict[str, Any]) -> Optional[str]:
+    def create_run(self, run_data: dict[str, Any]) -> Optional[str]:
         """Create a new run"""
         pass
-    
+
     @abstractmethod
     def update_run_status(self, run_id: str, status: str, **kwargs) -> bool:
         """Update run status"""
         pass
 
 
+class ProgramExecutionServiceInterface(ABC):
+    """Interface for program execution service"""
+
+    @abstractmethod
+    async def execute_program(
+        self,
+        program_name: str,
+        run_id: str,
+        parameters: dict[str, Any],
+        environment_variables: dict[str, str],
+    ) -> dict[str, Any]:
+        """Execute a program using the configured processor"""
+        pass
+
+
 class ProgramDiscoveryServiceInterface(ABC):
     """Interface for program discovery services"""
-    
+
     @abstractmethod
     def discover_programs(self, package_name: Optional[str] = None) -> int:
         """
         Discover programs from a specified package or use default.
-        
+
         Args:
             package_name: Package name to discover from, None for default
-            
+
         Returns:
             Number of programs discovered
         """
         pass
-    
+
     @abstractmethod
     def sync_discovered_programs(self) -> int:
         """
         Sync discovered programs to persistent storage.
-        
+
         Returns:
             Number of programs synced
         """
         pass
-    
+
     @abstractmethod
     def initialize_discovery(self, package_name: Optional[str] = None) -> bool:
         """
         Initialize program discovery during application startup.
-        
+
         Args:
             package_name: Package name to discover from, None for default
-            
+
         Returns:
             True if discovery completed successfully
         """
         pass
-    
+
     @abstractmethod
-    def get_discovered_programs(self) -> Dict[str, Any]:
+    def get_discovered_programs(self) -> dict[str, Any]:
         """
         Get currently discovered programs.
-        
+
         Returns:
             Dictionary of discovered program templates
         """

--- a/nova_app_template/services/program_execution_service.py
+++ b/nova_app_template/services/program_execution_service.py
@@ -4,77 +4,81 @@ Program Execution Service
 Service for executing programs using different processors.
 """
 
-from typing import Dict, Any
-from ..interfaces import (
-    ProgramRunProcessorInterface,
-    ProgramTemplateStoreInterface,
-    ProgramInstanceStoreInterface,
-    ProgramRunStoreInterface,
-)
+from typing import Any
+
 from ..decorators import REGISTERED_PROGRAM_TEMPLATES
+from ..interfaces import (
+    ProgramExecutionServiceInterface,
+    ProgramInstanceStoreInterface,
+    ProgramRunProcessorInterface,
+    ProgramRunStoreInterface,
+    ProgramTemplateStoreInterface,
+)
 
 
-class ProgramExecutionService:
+class ProgramExecutionService(ProgramExecutionServiceInterface):
     """Service for executing programs using different processors"""
-    
+
     def __init__(
         self,
         processor: ProgramRunProcessorInterface,
         template_store: ProgramTemplateStoreInterface,
         instance_store: ProgramInstanceStoreInterface,
-        run_store: ProgramRunStoreInterface
+        run_store: ProgramRunStoreInterface,
     ):
         self.processor = processor
         self.template_store = template_store
         self.instance_store = instance_store
         self.run_store = run_store
-    
+
     async def execute_program(
         self,
         program_name: str,
         run_id: str,
-        parameters: Dict[str, Any],
-        environment_variables: Dict[str, str]
-    ) -> Dict[str, Any]:
+        parameters: dict[str, Any],
+        environment_variables: dict[str, str],
+    ) -> dict[str, Any]:
         """
         Execute a program using the configured processor
-        
+
         Args:
             program_name: Name of the program to execute
             run_id: Unique identifier for this run
             parameters: Runtime parameters
             environment_variables: Environment variables
-            
+
         Returns:
             Dict containing execution results
         """
         try:
             # Update status to running
             self.run_store.update_status(run_id, "running")
-            
+
             # Get program instance data
             instance_data = self.instance_store.get(program_name)
             if not instance_data:
                 raise ValueError(f"Program instance '{program_name}' not found")
-            
+
             # Get template data
-            template_name = instance_data.get('template_name')
+            template_name = instance_data.get("template_name")
             template_data = self.template_store.get(template_name) if template_name else {}
-            
+
             # Get the program template from registered templates
             program_template = None
             for template in REGISTERED_PROGRAM_TEMPLATES.values():
                 if template.name == template_name:
                     program_template = template
                     break
-            
+
             if not program_template:
-                raise ValueError(f"Program template '{template_name}' not found in registered templates")
-            
+                raise ValueError(
+                    f"Program template '{template_name}' not found in registered templates"
+                )
+
             # Create model instance with combined data
-            combined_data = {**instance_data.get('data', {}), **parameters}
+            combined_data = {**instance_data.get("data", {}), **parameters}
             model_instance = program_template.model_class(**combined_data)
-            
+
             # Execute using the processor
             result = await self.processor.execute_program(
                 program_name=program_name,
@@ -84,49 +88,50 @@ class ProgramExecutionService:
                 template_data=template_data,
                 instance_data=instance_data,
                 parameters=parameters,
-                environment_variables=environment_variables
+                environment_variables=environment_variables,
             )
-            
+
             # Update run status based on result
-            if result.get('status') == 'completed':
+            if result.get("status") == "completed":
                 self.run_store.update_status(
                     run_id,
-                    'completed',
+                    "completed",
                     finished_at=self._get_current_time(),
-                    output=result.get('output'),
-                    exit_code=result.get('exit_code', 0)
+                    output=result.get("output"),
+                    exit_code=result.get("exit_code", 0),
                 )
             else:
                 self.run_store.update_status(
                     run_id,
-                    'failed',
+                    "failed",
                     finished_at=self._get_current_time(),
-                    error_message=result.get('error_message'),
-                    exit_code=result.get('exit_code', 1)
+                    error_message=result.get("error_message"),
+                    exit_code=result.get("exit_code", 1),
                 )
-            
+
             return result
-            
+
         except Exception as e:
             # Update status to failed
             self.run_store.update_status(
                 run_id,
-                'failed',
+                "failed",
                 finished_at=self._get_current_time(),
                 error_message=str(e),
-                exit_code=1
+                exit_code=1,
             )
-            
+
             return {
                 "status": "failed",
                 "output": None,
                 "error_message": str(e),
                 "exit_code": 1,
                 "execution_time": 0,
-                "processor_type": "unknown"
+                "processor_type": "unknown",
             }
-    
+
     def _get_current_time(self) -> str:
         """Get current time in ISO format"""
         from datetime import datetime
+
         return datetime.utcnow().isoformat()


### PR DESCRIPTION
## Summary
- add ProgramExecutionServiceInterface
- use interfaces for all NovaContainer registrations
- update ProgramExecutionService to implement interface
- depend on ProgramExecutionServiceInterface in runs API

## Testing
- `uv run ruff format nova_app_template/api/runs.py nova_app_template/container.py nova_app_template/interfaces.py nova_app_template/services/program_execution_service.py`
- `uv run ruff check --select I --fix nova_app_template/interfaces.py nova_app_template/services/program_execution_service.py nova_app_template/container.py nova_app_template/api/runs.py`
- `uv run ruff check nova_app_template/interfaces.py nova_app_template/services/program_execution_service.py nova_app_template/container.py nova_app_template/api/runs.py`
- `uv run mypy`
- `PYTHONPATH=. uv run pytest -rs -v -m "not integration"` *(fails: ModuleNotFoundError: No module named 'trimesh')*

------
https://chatgpt.com/codex/tasks/task_b_68593912dc4c832eb089a66b800edc81