### PR TITLE
Feature/added from euler util function

### DIFF
--- a/examples/Euler_angles_Pose.py
+++ b/examples/Euler_angles_Pose.py
@@ -1,0 +1,69 @@
+"""
+Example: Perform relative movements with a robot.
+
+Prerequisites:
+- Create an NOVA instance
+- Set env variables (you can specify them in an .env file):
+    - NOVA_API=<api>
+    - NOVA_ACCESS_TOKEN=<token>
+"""
+
+import asyncio
+import numpy as np
+
+import nova
+from nova import Nova, api, viewers
+from nova.actions import ptp, jnt
+from nova.cell import virtual_controller
+from nova.program import ProgramPreconditions
+from nova.types import MotionSettings, Pose
+
+
+@nova.program(
+    name="Plan and Execute",
+    viewer=viewers.Rerun(),
+    preconditions=ProgramPreconditions(
+        controllers=[
+            virtual_controller(
+                name="ur10",
+                manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
+                type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_MINUS_UR10E,
+            )
+        ],
+        cleanup_controllers=False,
+    ),
+)
+async def main():
+    async with Nova() as nova:
+        cell = nova.cell()
+        controller = await cell.controller("ur10")
+
+        # Connect to the controller and activate motion groups
+        async with controller[0] as motion_group:
+            home_joints = await motion_group.joints()
+            tcp_names = await motion_group.tcp_names()
+            tcp = tcp_names[0]
+
+            # move the robot to a home pose:
+            home_pose = [0, -np.pi/2, np.pi/2, -np.pi/2, -np.pi/2, 0]
+            await motion_group.plan_and_execute(jnt(home_pose), tcp=tcp)
+            current_pose = await motion_group.tcp_pose(tcp)
+
+            # move the tcp to rotation (90, 0, 90) "xyz"
+            
+            # rotate with rotation vector:
+            target_pose = Pose(current_pose[0], current_pose[1], current_pose[2], 1.2091996, -1.2091996, 1.2091996)
+            await motion_group.plan_and_execute(ptp(target_pose), tcp=tcp)
+            
+            # move back to home_pose
+            await motion_group.plan_and_execute(jnt(home_pose), tcp=tcp)
+            current_pose = await motion_group.tcp_pose(tcp)
+
+            # rotate with euler angles:
+            position = (current_pose[0], current_pose[1], current_pose[2])
+            euler_angles_rad = (np.pi / 2, 0, np.pi / 2)  # (90, 0, 90) in radians
+            target_pose = Pose.from_euler(position, euler_angles_rad, convention="xyz", degrees=False)
+            await motion_group.plan_and_execute(ptp(target_pose), settings=MotionSettings(tcp_velocity_limit=250), tcp=tcp)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/nova/types/pose.py
+++ b/nova/types/pose.py
@@ -261,6 +261,42 @@ class Pose(pydantic.BaseModel, Sized):
                 rotation_vec[2],
             )
         )
+    @classmethod
+    def from_euler(
+        cls,
+        position: Vector3d | tuple | list,
+        euler_angles: tuple | list,
+        convention: str = "xyz",
+        degrees: bool = False,
+    ) -> Pose:
+        """
+        Create a Pose from a position and Euler angles.
+
+        Args:
+            position: The position as a Vector3d, tuple, or list of 3 floats.
+            euler_angles: The Euler angles (e.g., roll, pitch, yaw) as a tuple or list of 3 floats.
+            convention: The Euler angle convention (e.g., 'xyz', 'zyx'). Defaults to 'xyz'.
+            degrees: Whether the provided Euler angles are in degrees. Defaults to False (radians).
+
+        Returns:
+            A new Pose object.
+
+        Example:
+        >>> # 90 degree rotation around the Z axis
+        >>> pose = Pose.from_euler(position=(1, 2, 3), euler_angles=(0, 0, 90), degrees=True)
+        >>> np.allclose(pose.orientation.to_tuple(), (0, 0, np.pi/2))
+        True
+        """
+        if not isinstance(position, Vector3d):
+            position = Vector3d.from_tuple(tuple(position))
+
+        # convert eulerangles to rotation vector
+        rotation = Rotation.from_euler(convention, euler_angles, degrees=degrees)
+        rotation_vector = rotation.as_rotvec()
+
+        orientation = Vector3d.from_tuple(tuple(rotation_vector))
+
+        return cls(position=position, orientation=orientation)
 
     def orientation_to_quaternion(self):
         values = np.asarray(self.orientation)

--- a/tests/type/test_from_euler.py
+++ b/tests/type/test_from_euler.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pytest
+
+from nova.types import Pose, Vector3d
+
+
+def test_pose_from_euler_degrees():
+    """
+    Tests creating a Pose from Euler angles specified in degrees.
+    A 90-degree rotation around the Z-axis.
+    """
+    # Input
+    position = (0.1, 0.2, 0.3)
+    euler_angles_deg = (0, 0, 90)
+
+    # Expected orientation is a rotation vector of magnitude pi/2 around the Z-axis
+    expected_orientation = (0, 0, np.pi / 2)
+
+    # Create pose using the new method
+    pose = Pose.from_euler(position, euler_angles_deg, convention="xyz", degrees=True)
+
+    # Assert
+    assert pose.position == Vector3d.from_tuple(position)
+    assert np.allclose(pose.orientation.to_tuple(), expected_orientation, atol=1e-7)
+
+
+def test_pose_from_euler_radians():
+    """
+    Tests creating a Pose from Euler angles specified in radians.
+    A 45-degree (pi/4) rotation around the Y-axis.
+    """
+    # Input
+    position = (0.5, 0, 0)
+    euler_angles_rad = (0, np.pi / 4, 0)
+
+    # Expected orientation is a rotation vector of magnitude pi/4 around the Y-axis
+    expected_orientation = (0, np.pi / 4, 0)
+
+    # Create pose using the new method
+    pose = Pose.from_euler(position, euler_angles_rad, convention="xyz", degrees=False)
+
+    # Assert
+    assert pose.position == Vector3d.from_tuple(position)
+    assert np.allclose(pose.orientation.to_tuple(), expected_orientation, atol=1e-7)
+
+
+def test_pose_from_euler_zero_rotation():
+    """
+    Tests creating a Pose with zero rotation.
+    """
+    position = (1, 2, 3)
+    euler_angles = (0, 0, 0)
+    expected_orientation = (0, 0, 0)
+
+    pose = Pose.from_euler(position, euler_angles, degrees=True)
+
+    assert pose.position == Vector3d.from_tuple(position)
+    assert np.allclose(pose.orientation.to_tuple(), expected_orientation, atol=1e-7)


### PR DESCRIPTION
This pull request enhances the `Pose` class with the `from_euler` utility function. It allows the user to create cartesian `Poses` from Euler angles easily, by providing the position, Euler angles, convention ("xyz" by default), and the option to specify the angles in degrees (false by default). This makes creating `Poses` in the SDK a lot more intuitive, as the regular `Pose` constructor only accepts rotation vectors. Without any tools, these are very hard to visualize and make setting an orientation rather difficult.

Creating a Pose from Euler angles would look something like this:

`position = (100, 0, 0)`
`euler_angles_rad = (0, np.pi / 4, np.pi / 2)`
`new_pose = Pose.from_euler(position, euler_angles_rad, convention="xyz", degrees=False)`