### PR TITLE
Draft: feat: publish new messages

### DIFF
--- a/nova/program/runner.py
+++ b/nova/program/runner.py
@@ -361,6 +361,10 @@ class ProgramRunner(ABC):
             message = Message(subject=subject, data=data)
             await nova.nats.publish_message(message)
 
+            subject = f"nova.v2.cells.{self._cell_id}.apps.{self._app_name}.programs.{self.program_id}.status"
+            message = Message(subject=subject, data=data)
+            await nova.nats.publish_message(message)
+
     async def _run_program(
         self, stop_event: anyio.Event, on_state_change: Callable[[], Awaitable[None]]
     ) -> None:


### PR DESCRIPTION
core nats only provides at most once delivery guarantee to the consumers, and this is only when the consumer is online. Nats jetstream extends the core nats and adds at least once delivery. There are a lot more features about NATS jetstream that can be seen in their documentation.

By adding jetstream, we enable the following use cases:
- a consumer can go offline and come back online and still not miss messages ( jetstream configuration is important here, we only save last 3 messages, this means the last program run, this can be increased if we want to increase the resilience of the system)
- if a consumer is only interested in the last message they don't need to store a state and instead they can read the stream
- if the system shutsdown unexpectedly ( e.g. power goes down on the shop floor) because we know the last state we can try recover from that when the system comes back online.

Note that, jetstream is a feature that enables these use cases and the system will not automatically recover from them. It allows us to implement a safer distributed system.

