### PR TITLE
fix(NDX-403): wait_for_bool_io()

### DIFF
--- a/nova/core/gateway.py
+++ b/nova/core/gateway.py
@@ -14,8 +14,8 @@ import wandelbots_api_client.v2 as v2
 from nova.auth.auth_config import Auth0Config
 from nova.auth.authorization import Auth0DeviceAuthorization
 from nova.cell.robot_cell import ConfigurablePeriphery, Device
-from nova.config import INTERNAL_CLUSTER_NOVA_API  # noqa: F401
 from nova.config import (  # add to the module for backward compatibility
+    INTERNAL_CLUSTER_NOVA_API,  # noqa: F401
     NOVA_ACCESS_TOKEN,
     NOVA_API,
     NOVA_PASSWORD,


### PR DESCRIPTION
This pull request makes minor improvements to the `nova/core/gateway.py` file, focusing on import cleanup and a small fix to the use of an enum value.

- Imports and Backward Compatibility:
  * Cleaned up the import of `INTERNAL_CLUSTER_NOVA_API` to avoid duplicate imports and maintain backward compatibility.

- Enum Usage Fix:
  * Updated the `comparison_type` argument in the `wait_for_bool_io` method to use the `.value` of the `ComparisonType` enum, ensuring the correct value is passed.