### PR TITLE
fix: update log level from warning to debug

### DIFF
--- a/nova/actions/base.py
+++ b/nova/actions/base.py
@@ -25,11 +25,11 @@ class Action(pydantic.BaseModel, ABC):
         action_type = getattr(cls, "type", None)
         # when no type is found -> skip
         if not isinstance(action_type, str):
-            logger.warning(f"Action class '{cls.__name__}' does not have a valid type")
+            logger.debug(f"Action class '{cls.__name__}' does not have a valid type")
             return
 
         if action_type in Action._registry:
-            logger.warning(f"Duplicate action type '{action_type}'")
+            logger.debug(f"Duplicate action type '{action_type}'")
             return
         Action._registry[action_type] = cls
 


### PR DESCRIPTION
following warning messages show up in every import of the python package but they don't provide any meaningful information to the user. It only confuses them
This MR updates the log level from warning to debug.