### PR TITLE
fix: prevent additional fields in program input schema

### DIFF
--- a/nova/program/function.py
+++ b/nova/program/function.py
@@ -18,7 +18,15 @@ from typing import (
 
 from docstring_parser import Docstring
 from docstring_parser import parse as parse_docstring
-from pydantic import BaseModel, Field, PrivateAttr, RootModel, create_model, validate_call
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    RootModel,
+    create_model,
+    validate_call,
+)
 from pydantic.fields import FieldInfo
 from pydantic.json_schema import JsonSchemaValue, models_json_schema
 
@@ -261,7 +269,12 @@ def input_and_output_types(
                 default.description = param_doc.description
 
         input_field_definitions[name] = (parameter.annotation, default)  # type: ignore
-    input = create_model("Input", **input_field_definitions, __module__=func.__module__)
+    input = create_model(
+        "Input",
+        **input_field_definitions,
+        __module__=func.__module__,
+        __config__=ConfigDict(extra="forbid"),
+    )
 
     if output_type and isinstance(output_type, type) and issubclass(output_type, BaseModel):
         output = output_type

--- a/tests/program/test_function.py
+++ b/tests/program/test_function.py
@@ -234,3 +234,18 @@ async def test_function_repr():
     assert "x: int" in func_repr
     assert "y: str" in func_repr
     assert "output=float" in func_repr
+
+
+def test_input_schema_should_include_additional_fields_false():
+    """
+    Input schema for functions decorated with @nova.program
+    should include "additionalProperties": false
+    to prevent extra fields in input.
+    """
+
+    @nova.program
+    async def sample_function(param1: int, param2: str):
+        pass
+
+    input_schema = sample_function.input_schema
+    assert input_schema.get("additionalProperties") is False


### PR DESCRIPTION
Input schema for functions decorated with @nova.program should include "additionalProperties": false to prevent extra fields in input.
