### PR TITLE
fix(NDX-443): fixes after testing

### DIFF
--- a/nova/cell/movement_controller/trajectory_cursor.py
+++ b/nova/cell/movement_controller/trajectory_cursor.py
@@ -984,12 +984,8 @@ class TrajectoryCursor:
                     self._in_queue.put_nowait(motion_group_state)
                     self._operation_handler.set_running()  # idempotent
 
-                    if isinstance(
-                        motion_group_state.execute.details, api.models.TrajectoryDetails
-                    ):
-                        self._current_location = (
-                            motion_group_state.execute.details.location.root
-                        )
+                    if isinstance(motion_group_state.execute.details, api.models.TrajectoryDetails):
+                        self._current_location = motion_group_state.execute.details.location.root
 
                 if result.complete_operation:
                     self._complete_operation()

--- a/nova/cell/movement_controller/trajectory_cursor.py
+++ b/nova/cell/movement_controller/trajectory_cursor.py
@@ -1002,7 +1002,9 @@ class TrajectoryCursor:
             logger.debug("TrajectoryCursor motion group state monitor was cancelled")
             raise
         finally:
+            # stop the request loop
             self.detach()
+            # stop the cursor iterator (TODO is this the right place?)
             self._in_queue.put_nowait(_QUEUE_SENTINEL)
 
     async def _response_consumer(self, ready_event: asyncio.Event):

--- a/nova/cell/movement_controller/trajectory_cursor.py
+++ b/nova/cell/movement_controller/trajectory_cursor.py
@@ -53,7 +53,6 @@ from typing import AsyncIterator, Optional, Union
 
 import pydantic
 from blinker import signal
-from icecream import ic
 
 from nova import api
 from nova.actions.base import Action
@@ -130,6 +129,28 @@ class OperationResult:
     start_location: Optional[float] = None
     final_location: Optional[float] = None
     error: Optional[Exception] = None
+
+
+@dataclass
+class StateProcessingResult:
+    """Result of processing a MotionGroupState in the context of an operation.
+
+    Most behavior is derived from MotionGroupState.execute presence:
+    - Queue state: Always when execute is present
+    - Set running: Always when execute is present (idempotent)
+    - Update location: Always when execute.details is TrajectoryDetails
+
+    This dataclass only encodes the remaining decisions.
+
+    Attributes:
+        skip: If True, ignore this state and continue to next.
+        complete_operation: If True, mark the operation as completed.
+        detach: If True, signal to detach from the cursor.
+    """
+
+    skip: bool = False
+    complete_operation: bool = False
+    detach: bool = False
 
 
 # Type alias for expected response types in _response_consumer
@@ -285,7 +306,6 @@ class OperationHandler:
         else:
             logger.debug(f"Operation completed with result: {result}")
             self._operation.future.set_result(result)
-        ic(result)
         self._reset()
 
     def in_progress(self) -> bool:
@@ -304,6 +324,51 @@ class OperationHandler:
     def _reset(self):
         """Clear the current operation."""
         self._operation = None
+
+
+def process_motion_group_state(
+    state: api.models.MotionGroupState,
+    current_operation: Optional[Operation],
+    detach_on_standstill: bool,
+) -> StateProcessingResult:
+    """Analyze MotionGroupState and determine what actions the monitor should take.
+
+    This pure function encapsulates the decision logic for processing motion group
+    state updates. Most behavior is derived from state.execute presence in the monitor;
+    this function only determines skip/complete/detach decisions.
+
+    Completion is defined as: execute present + (PausedByUser or Ended) + standstill.
+    Once an operation has execute, it will not receive a state with standstill=True
+    without execute - completion always comes through execute details.
+
+    Args:
+        state: The motion group state to process.
+        current_operation: The current operation in progress, or None.
+        detach_on_standstill: If True, signal detachment when operation completes.
+
+    Returns:
+        StateProcessingResult indicating what actions the monitor should take.
+    """
+    # No operation in progress - skip this state
+    if current_operation is None or current_operation.future.done():
+        return StateProcessingResult(skip=True)
+
+    # Waiting for execution to start
+    if not state.execute:
+        return StateProcessingResult(skip=True)
+
+    # Execute is present - check for completion conditions
+    if isinstance(state.execute.details, api.models.TrajectoryDetails):
+        match state.execute.details.state:
+            case api.models.TrajectoryPausedByUser() | api.models.TrajectoryEnded():
+                if state.standstill:
+                    return StateProcessingResult(
+                        complete_operation=True, detach=detach_on_standstill
+                    )
+            case _:
+                pass  # TrajectoryRunning or other - no completion
+
+    return StateProcessingResult()  # No special action needed
 
 
 class MovementOption(StrEnum):
@@ -904,69 +969,40 @@ class TrajectoryCursor:
         try:
             async for motion_group_state in self._motion_group_state_stream:
                 ready_event.set()
-                from icecream import ic
 
-                ic(motion_group_state, self._is_operation_in_progress())
+                result = process_motion_group_state(
+                    state=motion_group_state,
+                    current_operation=self._operation_handler.current_operation,
+                    detach_on_standstill=self._detach_on_standstill,
+                )
 
-                if not self._is_operation_in_progress():
-                    # We only care about motion group states if there is an operation in progress
-                    # assert that we are the sole reason for movement
-                    assert not motion_group_state.execute
+                if result.skip:
                     continue
-                else:
-                    current_op = self._operation_handler.current_operation
-                    assert current_op is not None
-                    if not motion_group_state.execute and current_op.operation_state in (
-                        OperationState.INITIAL,
-                        OperationState.COMMANDED,
-                    ):  #
-                        continue  # wait for the execution to actually start
 
-                    if not motion_group_state.execute and motion_group_state.standstill:
-                        assert current_op.operation_state not in (
-                            OperationState.INITIAL,
-                            OperationState.COMMANDED,
-                        ), (
-                            f"Unexpected operation state {current_op.operation_state} when standstill is True"
-                        )
-                        self._complete_operation()
-                        if self._detach_on_standstill:
-                            logger.debug("Detaching on standstill")
-                            break
-
-                    assert motion_group_state.execute
-                    # TODO it is questionable if we want to maintain the semantics of yield motion group states during
-                    # execution this is the only reason we do this here
+                # Derived from execute presence
+                if motion_group_state.execute:
                     self._in_queue.put_nowait(motion_group_state)
+                    self._operation_handler.set_running()  # idempotent
 
-                    if motion_group_state.execute and isinstance(
+                    if isinstance(
                         motion_group_state.execute.details, api.models.TrajectoryDetails
                     ):
-                        self._current_location = motion_group_state.execute.details.location.root
-                        match motion_group_state.execute.details.state:
-                            case api.models.TrajectoryRunning():
-                                self._operation_handler.set_running()  # idempotent
-                            case api.models.TrajectoryPausedByUser():
-                                if motion_group_state.standstill:
-                                    self._complete_operation()
-                                    if self._detach_on_standstill:
-                                        break
-                            case api.models.TrajectoryEnded():
-                                if motion_group_state.standstill:
-                                    self._complete_operation()
-                                    if self._detach_on_standstill:
-                                        break
-                            case _:
-                                assert False, (
-                                    f"Unexpected or unsupported motion group execute state: {motion_group_state.execute.details.state}"
-                                )
+                        self._current_location = (
+                            motion_group_state.execute.details.location.root
+                        )
+
+                if result.complete_operation:
+                    self._complete_operation()
+
+                if result.detach:
+                    logger.debug("Detaching on standstill")
+                    break
+
         except asyncio.CancelledError:
             logger.debug("TrajectoryCursor motion group state monitor was cancelled")
             raise
         finally:
-            # stop the request loop
             self.detach()
-            # stop the cursor iterator (TODO is this the right place?)
             self._in_queue.put_nowait(_QUEUE_SENTINEL)
 
     async def _response_consumer(self, ready_event: asyncio.Event):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "exceptiongroup>=1.2.2",
     "nats-py>=2.11.0",
     "blinker>=1.9.0",
-    "faststream[nats]>=0.5.48",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11, <3.13"
 
 [options]
@@ -1709,7 +1709,7 @@ wheels = [
 
 [[package]]
 name = "wandelbots-nova"
-version = "4.5.1"
+version = "4.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiostream" },

--- a/uv.lock
+++ b/uv.lock
@@ -510,24 +510,6 @@ wheels = [
 ]
 
 [[package]]
-name = "fast-depends"
-version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/a3/e7c234b84c407e4450e3fb930059aca7e786177a8af9954118104cf8ba24/fast_depends-3.0.3.tar.gz", hash = "sha256:fa63413beafc41b9cdd1e3efa7b9231c71d0c9d1c5c19cdc007a3b3c39f83f6e", size = 18172, upload-time = "2025-10-19T07:38:20.301Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/64/935128fefc9a4ffd5e160eec6e6ae6d85956f98e4f452fc57bfe337def92/fast_depends-3.0.3-py3-none-any.whl", hash = "sha256:15f7bb88cbfd541ef185667f73895c5aa32e5803d61b905b3405a43f7da914e8", size = 25292, upload-time = "2025-10-19T07:38:17.748Z" },
-]
-
-[package.optional-dependencies]
-pydantic = [
-    { name = "pydantic" },
-]
-
-[[package]]
 name = "fastapi"
 version = "0.121.0"
 source = { registry = "https://pypi.org/simple" }
@@ -540,25 +522,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8c/e3/77a2df0946703973b9905fd0cde6172c15e0781984320123b4f5079e7113/fastapi-0.121.0.tar.gz", hash = "sha256:06663356a0b1ee93e875bbf05a31fb22314f5bed455afaaad2b2dad7f26e98fa", size = 342412, upload-time = "2025-11-03T10:25:54.818Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/2c/42277afc1ba1a18f8358561eee40785d27becab8f80a1f945c0a3051c6eb/fastapi-0.121.0-py3-none-any.whl", hash = "sha256:8bdf1b15a55f4e4b0d6201033da9109ea15632cb76cf156e7b8b4019f2172106", size = 109183, upload-time = "2025-11-03T10:25:53.27Z" },
-]
-
-[[package]]
-name = "faststream"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "fast-depends", extra = ["pydantic"] },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/d1/ce3d0354be79d8e18fafd2c6cfd32b75521bd4d45ac79be386f1967c7155/faststream-0.6.3.tar.gz", hash = "sha256:f94d9790d61fe02fe9a274ce6dc030a59b4aa662ca8eda1c8505676fa3f79125", size = 299146, upload-time = "2025-11-03T19:59:31.864Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/b9/1e18ac5ae26ccf6a9fc726a98e7cf9b917565671f1e721bdcbf8c8550422/faststream-0.6.3-py3-none-any.whl", hash = "sha256:77abe68377210b3f728285ae035682a49178feff3c7b5733731eebe9e2efa710", size = 503396, upload-time = "2025-11-03T19:59:29.907Z" },
-]
-
-[package.optional-dependencies]
-nats = [
-    { name = "nats-py" },
 ]
 
 [[package]]
@@ -1756,7 +1719,6 @@ dependencies = [
     { name = "blinker" },
     { name = "docstring-parser" },
     { name = "exceptiongroup" },
-    { name = "faststream", extra = ["nats"] },
     { name = "httpx" },
     { name = "loguru" },
     { name = "nats-py" },
@@ -1826,7 +1788,6 @@ requires-dist = [
     { name = "dotenv", marker = "extra == 'wandelscript'" },
     { name = "exceptiongroup", specifier = ">=1.2.2" },
     { name = "fastapi", marker = "extra == 'novax'", specifier = ">=0.115.6" },
-    { name = "faststream", extras = ["nats"], specifier = ">=0.5.48" },
     { name = "geometricalgebra", marker = "extra == 'wandelscript'", specifier = ">=0.1.3,<0.2" },
     { name = "httpx", specifier = ">=0.28.0,<0.29" },
     { name = "loguru", specifier = ">=0.7.2,<0.8" },


### PR DESCRIPTION
## Summary
- Simplify `StateProcessingResult` from 6 fields to 3 (skip, complete_operation, detach)
- Derive queue/running/location behavior from `MotionGroupState.execute` presence
- Remove dead code for handling `execute=False` with `standstill=True` after operation started
- Remove icecream debug dependency

## Test plan
- [x] Run trajectory tests: `PYTHONPATH=. uv run pytest -rs -v -m "not integration" -k trajectory`
- [x] Run linter: `uv run ruff check nova/cell/movement_controller/trajectory_cursor.py`
- [x] Run type checker: `uv run mypy nova/cell/movement_controller/trajectory_cursor.py`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)