### PR TITLE
chore(examples): simplify count parameter in start_here.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![Build status](https://github.com/wandelbotsgmbh/wandelbots-nova/actions/workflows/nova-release.yaml/badge.svg)](https://github.com/wandelbotsgmbh/wandelbots-nova/actions/workflows/nova-release.yaml)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/wandelbotsgmbh/wandelbots-nova)
 
+> **📚 New to the SDK?** Explore the [DeepWiki documentation](https://deepwiki.com/wandelbotsgmbh/wandelbots-nova) for architecture guides and tutorials. You can also **chat with it** to get code examples, detailed explanations, and answers to your questions.
+
 This library provides an SDK for the Wandelbots NOVA API.
 
 The SDK will help you to build your own apps and services using Python on top of Wandelbots NOVA and makes programming a robot as easy as possible.

--- a/examples/start_here.py
+++ b/examples/start_here.py
@@ -44,9 +44,7 @@ from nova.types import MotionSettings, Pose
 )
 async def start(
     ctx: nova.ProgramContext,
-    count: int = Field(
-        default=1, ge=1, le=10, description="The number of times to repeat the movement"
-    ),
+    count: int = 1 # optional input parameter that in this case is used for repeating the execution
 ):
     """Main robot control function."""
     cell = ctx.cell


### PR DESCRIPTION
The "Field" input variable causes warnings in the VSCode app that confuse users. A simple int variable with a comment should be sufficient.