### PR TITLE
fix: Normalize schemeless Nova hosts

### DIFF
--- a/nova/config.py
+++ b/nova/config.py
@@ -48,8 +48,15 @@ class NovaConfig(BaseModel):
         self.host = self.host.strip()
         self.host = self.host.rstrip("/")
 
-        # app store has a special case for the host
-        if self.host == "api-gateway:8080":
+        if not self.host:
+            return self
+
+        parsed_host = urlparse(self.host)
+        if parsed_host.scheme and parsed_host.netloc:
+            return self
+
+        parsed_host_without_scheme = urlparse(f"//{self.host}")
+        if parsed_host_without_scheme.netloc:
             self.host = f"http://{self.host}"
         return self
 

--- a/nova/config.py
+++ b/nova/config.py
@@ -82,14 +82,26 @@ class NovaConfig(BaseModel):
 
         parsed_host = urlparse(self.host)
         if parsed_host.scheme == "http":
+            try:
+                port = parsed_host.port
+            except ValueError as exc:
+                raise ValueError(
+                    "Invalid port in NovaConfig.host; expected a numeric port value."
+                ) from exc
             self.nats_client_config["servers"] = (
-                f"ws://{parsed_host.hostname}:{parsed_host.port or 80}/api/nats"
+                f"ws://{parsed_host.hostname}:{port or 80}/api/nats"
             )
             return self
 
         if parsed_host.scheme == "https" and self.access_token:
+            try:
+                port = parsed_host.port
+            except ValueError as exc:
+                raise ValueError(
+                    "Invalid port in NovaConfig.host; expected a numeric port value."
+                ) from exc
             self.nats_client_config["servers"] = (
-                f"wss://{self.access_token}@{parsed_host.hostname}:{parsed_host.port or 443}/api/nats"
+                f"wss://{self.access_token}@{parsed_host.hostname}:{port or 443}/api/nats"
             )
             return self
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,7 +32,6 @@ def test_when_no_user_input_no_env_var_but_only_host_http():
 
 
 def test_when_host_missing_scheme_from_app_store(monkeypatch):
-    monkeypatch.setattr(config_module, "NATS_BROKER", None)
     config = NovaConfig(host="api-gateway:8080")
 
     assert config.host == "http://api-gateway:8080"
@@ -40,7 +39,6 @@ def test_when_host_missing_scheme_from_app_store(monkeypatch):
 
 
 def test_when_host_missing_scheme_for_generic_host(monkeypatch):
-    monkeypatch.setattr(config_module, "NATS_BROKER", None)
     config = NovaConfig(host="api.example.com")
 
     assert config.host == "http://api.example.com"
@@ -48,7 +46,6 @@ def test_when_host_missing_scheme_for_generic_host(monkeypatch):
 
 
 def test_when_host_missing_scheme_for_localhost(monkeypatch):
-    monkeypatch.setattr(config_module, "NATS_BROKER", None)
     config = NovaConfig(host="localhost:8080")
 
     assert config.host == "http://localhost:8080"
@@ -79,3 +76,6 @@ def test_when_host_has_trailing_slash_it_is_normalized():
 def test_host_is_trimmed():
     config = NovaConfig(host=" api.example.com/   ")
     assert config.host == "http://api.example.com"
+
+    config_with_scheme = NovaConfig(host=" https://api.example.com/   ")
+    assert config_with_scheme.host == "https://api.example.com"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,12 @@
+import pytest
+
 import nova.config as config_module
 from nova.config import NovaConfig
+
+
+@pytest.fixture(autouse=True)
+def clear_nats_broker(monkeypatch):
+    monkeypatch.setattr(config_module, "NATS_BROKER", None)
 
 
 def test_when_user_provides_nats_config_explicitly():
@@ -32,6 +39,22 @@ def test_when_host_missing_scheme_from_app_store(monkeypatch):
     assert config.nats_client_config["servers"] == "ws://api-gateway:8080/api/nats"
 
 
+def test_when_host_missing_scheme_for_generic_host(monkeypatch):
+    monkeypatch.setattr(config_module, "NATS_BROKER", None)
+    config = NovaConfig(host="api.example.com")
+
+    assert config.host == "http://api.example.com"
+    assert config.nats_client_config["servers"] == "ws://api.example.com:80/api/nats"
+
+
+def test_when_host_missing_scheme_for_localhost(monkeypatch):
+    monkeypatch.setattr(config_module, "NATS_BROKER", None)
+    config = NovaConfig(host="localhost:8080")
+
+    assert config.host == "http://localhost:8080"
+    assert config.nats_client_config["servers"] == "ws://localhost:8080/api/nats"
+
+
 def test_when_host_and_token_prioritize_env_var(monkeypatch):
     monkeypatch.setattr(config_module, "NATS_BROKER", "nats://env-broker:4222")
     config = NovaConfig(host="https://api.example.com", access_token="test-token")
@@ -54,5 +77,5 @@ def test_when_host_has_trailing_slash_it_is_normalized():
 
 
 def test_host_is_trimmed():
-    config = NovaConfig(host=" https://api.example.com/   ")
-    assert config.host == "https://api.example.com"
+    config = NovaConfig(host=" api.example.com/   ")
+    assert config.host == "http://api.example.com"


### PR DESCRIPTION
## Summary
- normalize any schemeless Nova host with a parser-based stdlib check
- keep fully-qualified URLs unchanged
- extend config tests for generic schemeless hosts and isolate NATS_BROKER in tests

## Testing
- uv run pytest tests/test_config.py