### PR TITLE
feat: make TCP optional for plan/execute to support motion groups without TCP

### DIFF
--- a/nova/cell/motion_group.py
+++ b/nova/cell/motion_group.py
@@ -9,7 +9,7 @@ import numpy as np
 from nova import api
 from nova.actions import Action, CombinedActions, MovementController, MovementControllerContext
 from nova.actions.mock import WaitAction
-from nova.actions.motions import CollisionFreeMotion
+from nova.actions.motions import CartesianPTP, Circular, CollisionFreeMotion, Linear
 from nova.config import ENABLE_TRAJECTORY_TUNING
 from nova.core.gateway import ApiGateway
 from nova.exceptions import LoadPlanFailed, NoInverseKinematicsSolutionFound, PlanTrajectoryFailed
@@ -486,7 +486,7 @@ class MotionGroup(AbstractRobot):
         )
 
     async def _load_planned_motion(
-        self, joint_trajectory: api.models.JointTrajectory, tcp: str
+        self, joint_trajectory: api.models.JointTrajectory, tcp: str | None
     ) -> str:
         load_plan_response = await self._api_client.trajectory_caching_api.add_trajectory(
             cell=self._cell,
@@ -507,7 +507,7 @@ class MotionGroup(AbstractRobot):
     async def _plan_with_collision_check(
         self,
         actions: list[Action],
-        tcp: str,
+        tcp: str | None,
         motion_group_setup: api.models.MotionGroupSetup,
         start_joint_position: tuple[float, ...],
     ) -> api.models.JointTrajectory:
@@ -578,7 +578,7 @@ class MotionGroup(AbstractRobot):
     async def _plan_collision_free(
         self,
         action: CollisionFreeMotion,
-        tcp: str,
+        tcp: str | None,
         motion_group_setup: api.models.MotionGroupSetup,
         start_joint_position: tuple[float, ...] | None = None,
     ) -> api.models.JointTrajectory:
@@ -613,6 +613,7 @@ class MotionGroup(AbstractRobot):
 
         best_joint_solutions: list[tuple[float, ...]] = []
         if isinstance(action.target, Pose):
+            assert tcp is not None, "TCP is required for collision_free with Pose target"
             solutions = await self._inverse_kinematics(
                 poses=[action.target], tcp=tcp, motion_group_setup=motion_group_setup
             )
@@ -667,12 +668,26 @@ class MotionGroup(AbstractRobot):
     async def _plan(
         self,
         actions: list[Action],
-        tcp: str,
+        tcp: str | None = None,
         start_joint_position: tuple[float, ...] | None = None,
         motion_group_setup: api.models.MotionGroupSetup | None = None,
     ) -> api.models.JointTrajectory:
         if not actions:
             raise ValueError("No actions provided")
+
+        if tcp is None:
+            _requires_tcp = (Linear, CartesianPTP, Circular)
+            for action in actions:
+                if isinstance(action, _requires_tcp):
+                    raise ValueError(
+                        "TCP is required for cartesian motion actions (lin, ptp, cir). "
+                        "Provide a TCP or use joint-space actions (jnt) instead."
+                    )
+                if isinstance(action, CollisionFreeMotion) and isinstance(action.target, Pose):
+                    raise ValueError(
+                        "TCP is required for collision_free motions with a Pose target. "
+                        "Provide a TCP or use a joint-space target instead."
+                    )
 
         current_joints = start_joint_position or await self.joints()
         motion_group_setup = motion_group_setup or await self.get_setup(tcp)
@@ -737,7 +752,7 @@ class MotionGroup(AbstractRobot):
     async def _execute(
         self,
         joint_trajectory: api.models.JointTrajectory,
-        tcp: str,
+        tcp: str | None,
         actions: list[Action],
         movement_controller: MovementController | None,
         start_on_io: api.models.StartOnIO | None = None,
@@ -808,7 +823,7 @@ class MotionGroup(AbstractRobot):
             monitor_task.cancel()
 
     async def _tune_trajectory(
-        self, joint_trajectory: api.models.JointTrajectory, tcp: str, actions: list[Action]
+        self, joint_trajectory: api.models.JointTrajectory, tcp: str | None, actions: list[Action]
     ) -> AsyncGenerator[api.models.MotionGroupState, None]:
         start_joints = await self.joints()
 

--- a/nova/cell/motion_group.py
+++ b/nova/cell/motion_group.py
@@ -613,7 +613,8 @@ class MotionGroup(AbstractRobot):
 
         best_joint_solutions: list[tuple[float, ...]] = []
         if isinstance(action.target, Pose):
-            assert tcp is not None, "TCP is required for collision_free with Pose target"
+            if tcp is None:
+                raise ValueError("TCP is required for collision_free with Pose target")
             solutions = await self._inverse_kinematics(
                 poses=[action.target], tcp=tcp, motion_group_setup=motion_group_setup
             )

--- a/nova/cell/robot_cell.py
+++ b/nova/cell/robot_cell.py
@@ -222,7 +222,7 @@ class AbstractRobot(Device):
     async def _plan(
         self,
         actions: list[Action],
-        tcp: str,
+        tcp: str | None = None,
         start_joint_position: tuple[float, ...] | None = None,
         motion_group_setup: api.models.MotionGroupSetup | None = None,
     ) -> api.models.JointTrajectory:
@@ -231,7 +231,7 @@ class AbstractRobot(Device):
         Args:
             actions (list[Action] | Action): The actions to be planned. Can be a single action or a list of actions.
                 Only motion actions are considered for planning.
-            tcp (str): The id of the tool center point (TCP)
+            tcp (str | None): The id of the tool center point (TCP). Can be None for joint-space-only motions.
             start_joint_position (tuple[float, ...] | None): The starting joint position. If None, the current joint
 
         Returns:
@@ -241,7 +241,7 @@ class AbstractRobot(Device):
     async def plan(
         self,
         actions: ActionsLike,
-        tcp: str,
+        tcp: str | None = None,
         start_joint_position: tuple[float, ...] | None = None,
         motion_group_setup: api.models.MotionGroupSetup | None = None,
     ) -> api.models.JointTrajectory:
@@ -250,7 +250,7 @@ class AbstractRobot(Device):
         Args:
             actions (list[Action] | Action): The actions to be planned. Can be a single action or a list of actions.
                 Only motion actions are considered for planning.
-            tcp (str): The id of the tool center point (TCP)
+            tcp (str | None): The id of the tool center point (TCP). Can be None for joint-space-only motions.
             start_joint_position: the initial position of the robot
             start_joint_position (tuple[float, ...] | None): The starting joint position. If None, the current joint
             motion_group_setup (api.models.MotionGroupSetup | None): The motion group setup to be used for planning.
@@ -287,7 +287,7 @@ class AbstractRobot(Device):
             raise planning_error
 
     async def _log_planning_results(
-        self, actions: list[Action], trajectory: api.models.JointTrajectory, tcp: str
+        self, actions: list[Action], trajectory: api.models.JointTrajectory, tcp: str | None
     ) -> None:
         """Log planning results to active viewers if any are configured."""
         from nova.cell.motion_group import MotionGroup
@@ -304,7 +304,9 @@ class AbstractRobot(Device):
                 actions=actions, trajectory=trajectory, tcp=tcp, motion_group=self
             )
 
-    async def _log_planning_error(self, actions: list[Action], error: Exception, tcp: str) -> None:
+    async def _log_planning_error(
+        self, actions: list[Action], error: Exception, tcp: str | None
+    ) -> None:
         """Log planning error to active viewers if any are configured."""
         from nova.cell.motion_group import MotionGroup
         from nova.viewers import get_viewer_manager
@@ -321,7 +323,7 @@ class AbstractRobot(Device):
     def _execute(
         self,
         joint_trajectory: api.models.JointTrajectory,
-        tcp: str,
+        tcp: str | None,
         actions: list[Action],
         movement_controller: MovementController | None,
         start_on_io: api.models.StartOnIO | None = None,
@@ -331,7 +333,7 @@ class AbstractRobot(Device):
 
         Args:
             joint_trajectory (api.models.JointTrajectory): The planned joint trajectory
-            tcp (str): The id of the tool center point (TCP)
+            tcp (str | None): The id of the tool center point (TCP). Can be None for joint-space-only motions.
             actions (list[Action] | Action | None): The actions to be executed. Defaults to None.
             movement_controller (MovementController): The movement controller to be used. Defaults to move_forward
             start_on_io (StartOnIO | None): The start on IO. If none, does not wait for IO. Defaults to None.
@@ -341,7 +343,7 @@ class AbstractRobot(Device):
     async def stream_execute(
         self,
         joint_trajectory: api.models.JointTrajectory,
-        tcp: str,
+        tcp: str | None,
         actions: ActionsLike,
         movement_controller: MovementController | None = None,
         start_on_io: api.models.StartOnIO | None = None,
@@ -354,7 +356,7 @@ class AbstractRobot(Device):
 
         Args:
             joint_trajectory (api.models.JointTrajectory): The planned joint trajectory
-            tcp (str): The id of the tool center point (TCP)
+            tcp (str | None): The id of the tool center point (TCP). Can be None for joint-space-only motions.
             actions (list[Action] | Action | None): The actions to be executed. Defaults to None.
             movement_controller (MovementController): The movement controller to be used. Defaults to move_forward
             start_on_io (StartOnIO | None): The start on IO. If none, does not wait for IO. Defaults to None.
@@ -378,7 +380,7 @@ class AbstractRobot(Device):
     async def execute(
         self,
         joint_trajectory: api.models.JointTrajectory,
-        tcp: str,
+        tcp: str | None,
         actions: ActionsLike,
         movement_controller: MovementController | None = None,
         start_on_io: api.models.StartOnIO | None = None,
@@ -388,7 +390,7 @@ class AbstractRobot(Device):
 
         Args:
             joint_trajectory (api.models.JointTrajectory): The planned joint trajectory
-            tcp (str): The id of the tool center point (TCP)
+            tcp (str | None): The id of the tool center point (TCP). Can be None for joint-space-only motions.
             actions (list[Action] | Action): The actions to be executed.
             movement_controller (MovementController): The movement controller to be used. Defaults to move_forward
             start_on_io (StartOnIO | None): The start on IO. If none, does not wait for IO. Defaults to None.
@@ -410,7 +412,7 @@ class AbstractRobot(Device):
     async def stream_plan_and_execute(
         self,
         actions: ActionsLike,
-        tcp: str,
+        tcp: str | None = None,
         start_joint_position: tuple[float, ...] | None = None,
         movement_controller: MovementController | None = None,
         start_on_io: api.models.StartOnIO | None = None,
@@ -420,7 +422,7 @@ class AbstractRobot(Device):
 
         Args:
             actions (list[Action] | Action): The actions to be planned and executed.
-            tcp (str): The id of the tool center point (TCP)
+            tcp (str | None): The id of the tool center point (TCP). Can be None for joint-space-only motions.
             start_joint_position (tuple[float, ...] | None): The starting joint position.
             movement_controller (MovementController | None): The movement controller to be used. Defaults to move_forward.
             start_on_io (StartOnIO | None): The start on IO. If none, does not wait for IO. Defaults to None.
@@ -442,7 +444,7 @@ class AbstractRobot(Device):
     async def plan_and_execute(
         self,
         actions: ActionsLike,
-        tcp: str,
+        tcp: str | None = None,
         start_joint_position: tuple[float, ...] | None = None,
         movement_controller: MovementController | None = None,
         start_on_io: api.models.StartOnIO | None = None,
@@ -452,7 +454,7 @@ class AbstractRobot(Device):
 
         Args:
             actions (list[Action] | Action): The actions to be planned and executed.
-            tcp (str): The id of the tool center point (TCP)
+            tcp (str | None): The id of the tool center point (TCP). Can be None for joint-space-only motions.
             start_joint_position (tuple[float, ...] | None): The starting joint position.
             movement_controller (MovementController | None): The movement controller to be used. Defaults to move_forward.
             start_on_io (StartOnIO | None): The start on IO. If none, does not wait for IO. Defaults to None.

--- a/nova/cell/simulation.py
+++ b/nova/cell/simulation.py
@@ -148,7 +148,7 @@ class SimulatedRobot(ConfigurablePeriphery, AbstractRobot):
     async def _plan(
         self,
         actions: list[Action],
-        tcp: str,
+        tcp: str | None = None,
         start_joint_position: tuple[float, ...] | None = None,
         motion_group_setup: api.models.MotionGroupSetup | None = None,
     ) -> api.models.JointTrajectory:
@@ -251,7 +251,7 @@ class SimulatedRobot(ConfigurablePeriphery, AbstractRobot):
     async def _execute(
         self,
         joint_trajectory: api.models.JointTrajectory,
-        tcp: str,
+        tcp: str | None,
         actions: list[Action],
         movement_controller: MovementController | None,
         start_on_io: api.models.StartOnIO | None = None,

--- a/nova/viewers/base.py
+++ b/nova/viewers/base.py
@@ -37,7 +37,7 @@ class Viewer(ABC):
         self,
         actions: Sequence[Action],
         trajectory: models.JointTrajectory,
-        tcp: str,
+        tcp: str | None,
         motion_group: MotionGroup,
     ) -> None:
         """Log successful planning results.
@@ -45,20 +45,24 @@ class Viewer(ABC):
         Args:
             actions: List of actions that were planned
             trajectory: The resulting trajectory
-            tcp: TCP used for planning
+            tcp: TCP used for planning, or None if no TCP was used
             motion_group: The motion group used for planning
         """
         pass
 
     async def log_planning_failure(
-        self, actions: Sequence[Action], error: Exception, tcp: str, motion_group: MotionGroup
+        self,
+        actions: Sequence[Action],
+        error: Exception,
+        tcp: str | None,
+        motion_group: MotionGroup,
     ) -> None:
         """Log planning failure results.
 
         Args:
             actions: List of actions that failed to plan
             error: The planning error that occurred
-            tcp: TCP used for planning
+            tcp: TCP used for planning, or None if no TCP was used
             motion_group: The motion group used for planning
         """
         pass

--- a/nova/viewers/manager.py
+++ b/nova/viewers/manager.py
@@ -47,7 +47,7 @@ class ViewerManager:
         self,
         actions: Sequence[Action],
         trajectory: models.JointTrajectory,
-        tcp: str,
+        tcp: str | None,
         motion_group: MotionGroup,
     ) -> None:
         """Log successful planning results to all active viewers."""
@@ -61,7 +61,11 @@ class ViewerManager:
                 logger.warning("Failed to log planning results to viewer: %s", e)
 
     async def log_planning_failure(
-        self, actions: Sequence[Action], error: Exception, tcp: str, motion_group: MotionGroup
+        self,
+        actions: Sequence[Action],
+        error: Exception,
+        tcp: str | None,
+        motion_group: MotionGroup,
     ) -> None:
         """Log planning failure to all active viewers."""
         for viewer in self._viewers:
@@ -112,7 +116,7 @@ def cleanup_active_viewers() -> None:
 async def log_planning_results_to_viewers(
     actions: Sequence[Action],
     trajectory: models.JointTrajectory,
-    tcp: str,
+    tcp: str | None,
     motion_group: MotionGroup,
 ) -> None:
     """Log successful planning results to all active viewers. (Legacy function for backward compatibility)"""
@@ -120,7 +124,7 @@ async def log_planning_results_to_viewers(
 
 
 async def log_planning_error_to_viewers(
-    actions: Sequence[Action], error: Exception, tcp: str, motion_group: MotionGroup
+    actions: Sequence[Action], error: Exception, tcp: str | None, motion_group: MotionGroup
 ) -> None:
     """Log planning failure to all active viewers. (Legacy function for backward compatibility)"""
     await _viewer_manager.log_planning_failure(actions, error, tcp, motion_group)

--- a/nova/viewers/rerun.py
+++ b/nova/viewers/rerun.py
@@ -203,7 +203,7 @@ class Rerun(Viewer):
         self,
         actions: Sequence[Action],
         trajectory: api.models.JointTrajectory,
-        tcp: str,
+        tcp: str | None,
         motion_group: MotionGroup,
     ) -> None:
         """Log planning results including actions, trajectory, and collision scenes.
@@ -231,14 +231,15 @@ class Rerun(Viewer):
             )
 
             # Log trajectory with tool asset if configured for this TCP
-            tool_asset = self._resolve_tool_asset(tcp)
-            await self._bridge.log_trajectory(
-                trajectory=downsampled_trajectory,
-                tcp=tcp,
-                motion_group=motion_group,
-                collision_setups=extract_collision_setups_from_actions(actions),
-                tool_asset=tool_asset,
-            )
+            if tcp is not None:
+                tool_asset = self._resolve_tool_asset(tcp)
+                await self._bridge.log_trajectory(
+                    trajectory=downsampled_trajectory,
+                    tcp=tcp,
+                    motion_group=motion_group,
+                    collision_setups=extract_collision_setups_from_actions(actions),
+                    tool_asset=tool_asset,
+                )
 
             # Log collision scenes from actions if configured
             if self.show_collision_scenes:
@@ -254,7 +255,7 @@ class Rerun(Viewer):
         self,
         actions: Sequence[Action],
         trajectory: api.models.JointTrajectory,
-        tcp: str,
+        tcp: str | None,
         motion_group: MotionGroup,
     ) -> None:
         """Log successful planning results to Rerun viewer.
@@ -277,7 +278,11 @@ class Rerun(Viewer):
         )
 
     async def log_planning_failure(
-        self, actions: Sequence[Action], error: Exception, tcp: str, motion_group: MotionGroup
+        self,
+        actions: Sequence[Action],
+        error: Exception,
+        tcp: str | None,
+        motion_group: MotionGroup,
     ) -> None:
         """Log planning failure to Rerun viewer.
 
@@ -312,12 +317,13 @@ class Rerun(Viewer):
                         error.error.joint_trajectory,
                         sample_interval_ms=self.trajectory_sample_interval_ms,
                     )
-                    await self._bridge.log_trajectory(
-                        trajectory=downsampled_trajectory,
-                        tcp=tcp,
-                        motion_group=motion_group,
-                        collision_setups=extract_collision_setups_from_actions(actions),
-                    )
+                    if tcp is not None:
+                        await self._bridge.log_trajectory(
+                            trajectory=downsampled_trajectory,
+                            tcp=tcp,
+                            motion_group=motion_group,
+                            collision_setups=extract_collision_setups_from_actions(actions),
+                        )
 
                 # Log error feedback if available
                 if hasattr(error.error, "error_feedback") and error.error.error_feedback:
@@ -358,13 +364,15 @@ class Rerun(Viewer):
         self._bridge = None
         self._logged_safety_zones.clear()  # Reset safety zone tracking
 
-    def _resolve_tool_asset(self, tcp: str) -> str | None:
+    def _resolve_tool_asset(self, tcp: str | None) -> str | None:
         """Resolve the tool asset file path for a given TCP.
 
         Args:
-            tcp: The TCP ID to resolve tool asset for
+            tcp: The TCP ID to resolve tool asset for, or None
 
         Returns:
             Path to tool asset file if configured, None otherwise
         """
+        if tcp is None:
+            return None
         return self.tcp_tools.get(tcp)

--- a/tests/cell/test_optional_tcp.py
+++ b/tests/cell/test_optional_tcp.py
@@ -1,0 +1,227 @@
+"""Tests for optional TCP support in plan/execute.
+
+Motion groups without a TCP should be able to plan and execute joint-space-only
+workflows (jnt, wait, io_write) without providing a TCP. Cartesian actions
+(lin, ptp, cir, collision_free with Pose target) must raise a clear error
+when TCP is None.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nova import api
+from nova.actions import cir, collision_free, jnt, lin, ptp, wait
+from nova.cell.motion_group import MotionGroup
+from nova.core.gateway import ApiGateway
+from nova.types import Pose
+
+
+@pytest.fixture
+def mock_motion_group():
+    """Create a MotionGroup instance with mocked internals for TCP-optional tests."""
+    mock_api_client = MagicMock(spec=ApiGateway)
+
+    # Mock get_current_motion_group_state (used by joints())
+    mock_state = MagicMock()
+    mock_state.joint_position = [0.0, -1.57, -1.57, 0.0, 0.0, 0.0]
+    mock_state.tcp_pose = api.models.Pose(
+        position=api.models.Vector3d([0.0, 0.0, 0.0]),
+        orientation=api.models.RotationVector([0.0, 0.0, 0.0]),
+    )
+    mock_state.tcp = None
+    mock_api_client.motion_group_api = MagicMock()
+    mock_api_client.motion_group_api.get_current_motion_group_state = AsyncMock(
+        return_value=mock_state
+    )
+
+    # Mock get_motion_group_description (used by get_setup)
+    mock_description = MagicMock()
+    mock_description.motion_group_model = api.models.MotionGroupModel("test-model")
+    mock_description.cycle_time = 8
+    mock_description.mounting = None
+    mock_description.tcps = None  # No TCPs configured
+    mock_description.operation_limits = MagicMock()
+    mock_description.operation_limits.auto_limits = api.models.LimitSet(joints=[])
+    mock_description.safety_tool_colliders = None
+    mock_description.safety_link_colliders = None
+    mock_description.safety_zones = None
+    mock_api_client.motion_group_api.get_motion_group_description = AsyncMock(
+        return_value=mock_description
+    )
+
+    # Mock trajectory planning API
+    mock_plan_response = MagicMock()
+    mock_plan_response.response = api.models.JointTrajectory(
+        joint_positions=[
+            api.models.Joints([0.0, -1.57, -1.57, 0.0, 0.0, 0.0]),
+            api.models.Joints([0.1, -1.47, -1.47, 0.1, 0.1, 0.1]),
+        ],
+        times=[0.0, 1.0],
+        locations=[api.models.Location(0.0), api.models.Location(1.0)],
+    )
+    mock_api_client.trajectory_planning_api = MagicMock()
+    mock_api_client.trajectory_planning_api.plan_trajectory = AsyncMock(
+        return_value=mock_plan_response
+    )
+
+    # Mock trajectory caching API (used by _load_planned_motion in execute)
+    mock_add_trajectory_response = MagicMock()
+    mock_add_trajectory_response.error = None
+    mock_add_trajectory_response.trajectory = "test-trajectory-id"
+    mock_api_client.trajectory_caching_api = MagicMock()
+    mock_api_client.trajectory_caching_api.add_trajectory = AsyncMock(
+        return_value=mock_add_trajectory_response
+    )
+
+    return MotionGroup(
+        api_client=mock_api_client,
+        cell="test_cell",
+        controller_id="test-controller",
+        motion_group_id="0@test-controller",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation: tcp=None rejects cartesian actions
+# ---------------------------------------------------------------------------
+
+
+class TestPlanWithoutTcpRejectsCartesianActions:
+    """tcp=None must raise ValueError for any action that requires a TCP."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_lin(self, mock_motion_group):
+        with pytest.raises(ValueError, match="TCP is required for cartesian motion actions"):
+            await mock_motion_group.plan([lin((0, 0, 0, 0, 0, 0))])
+
+    @pytest.mark.asyncio
+    async def test_rejects_ptp(self, mock_motion_group):
+        with pytest.raises(ValueError, match="TCP is required for cartesian motion actions"):
+            await mock_motion_group.plan([ptp((0, 0, 0, 0, 0, 0))])
+
+    @pytest.mark.asyncio
+    async def test_rejects_cir(self, mock_motion_group):
+        with pytest.raises(ValueError, match="TCP is required for cartesian motion actions"):
+            await mock_motion_group.plan([cir((0, 0, 0, 0, 0, 0), intermediate=(1, 1, 1, 0, 0, 0))])
+
+    @pytest.mark.asyncio
+    async def test_rejects_collision_free_with_pose_target(self, mock_motion_group):
+        with pytest.raises(ValueError, match="TCP is required for collision_free"):
+            await mock_motion_group.plan([collision_free(Pose((0, 0, 0, 0, 0, 0)))])
+
+    @pytest.mark.asyncio
+    async def test_rejects_mixed_jnt_and_lin(self, mock_motion_group):
+        """Even if some actions are joint-space, a single cartesian action should fail."""
+        with pytest.raises(ValueError, match="TCP is required for cartesian motion actions"):
+            await mock_motion_group.plan(
+                [jnt((0.0, -1.57, -1.57, 0.0, 0.0, 0.0)), lin((0, 0, 0, 0, 0, 0))]
+            )
+
+
+# ---------------------------------------------------------------------------
+# Happy path: tcp=None works for joint-space actions
+# ---------------------------------------------------------------------------
+
+
+class TestPlanWithoutTcpAcceptsJointActions:
+    """tcp=None must succeed for joint-space-only workflows."""
+
+    @pytest.mark.asyncio
+    async def test_plan_jnt_without_tcp(self, mock_motion_group):
+        trajectory = await mock_motion_group.plan([jnt((0.1, -1.47, -1.47, 0.1, 0.1, 0.1))])
+        assert trajectory is not None
+        assert len(trajectory.joint_positions) > 0
+
+    @pytest.mark.asyncio
+    async def test_plan_wait_without_tcp(self, mock_motion_group):
+        trajectory = await mock_motion_group.plan([wait(1.0)])
+        assert trajectory is not None
+        # Wait generates a trajectory with same joint positions at each timestep
+        assert len(trajectory.joint_positions) >= 2
+
+    @pytest.mark.asyncio
+    async def test_plan_jnt_and_wait_without_tcp(self, mock_motion_group):
+        trajectory = await mock_motion_group.plan(
+            [jnt((0.1, -1.47, -1.47, 0.1, 0.1, 0.1)), wait(0.5)]
+        )
+        assert trajectory is not None
+        assert len(trajectory.joint_positions) > 0
+
+    @pytest.mark.asyncio
+    async def test_plan_collision_free_with_joint_target_without_tcp(self, mock_motion_group):
+        """collision_free with a tuple (joint) target should not require TCP."""
+        joint_target = (0.1, -1.47, -1.47, 0.1, 0.1, 0.1)
+
+        mock_plan_cf_response = MagicMock()
+        mock_plan_cf_response.response = api.models.JointTrajectory(
+            joint_positions=[
+                api.models.Joints([0.0, -1.57, -1.57, 0.0, 0.0, 0.0]),
+                api.models.Joints(list(joint_target)),
+            ],
+            times=[0.0, 1.0],
+            locations=[api.models.Location(0.0), api.models.Location(1.0)],
+        )
+        mock_motion_group._api_client.trajectory_planning_api.plan_collision_free = AsyncMock(
+            return_value=mock_plan_cf_response
+        )
+
+        trajectory = await mock_motion_group.plan([collision_free(joint_target)])
+        assert trajectory is not None
+
+
+# ---------------------------------------------------------------------------
+# Execution: tcp=None flows through correctly
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPlannedMotionWithNoneTcp:
+    """_load_planned_motion should pass tcp=None to AddTrajectoryRequest."""
+
+    @pytest.mark.asyncio
+    async def test_load_planned_motion_passes_none_tcp(self, mock_motion_group):
+        joint_trajectory = api.models.JointTrajectory(
+            joint_positions=[api.models.Joints([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])],
+            times=[0.0],
+            locations=[api.models.Location(0.0)],
+        )
+
+        await mock_motion_group._load_planned_motion(joint_trajectory, tcp=None)
+
+        call_kwargs = mock_motion_group._api_client.trajectory_caching_api.add_trajectory.call_args
+        request = call_kwargs.kwargs["add_trajectory_request"]
+        assert request.tcp is None
+
+
+# ---------------------------------------------------------------------------
+# Edge case: empty actions
+# ---------------------------------------------------------------------------
+
+
+class TestPlanWithoutTcpEdgeCases:
+    @pytest.mark.asyncio
+    async def test_empty_actions_raises_before_tcp_check(self, mock_motion_group):
+        with pytest.raises(ValueError, match="No actions provided"):
+            await mock_motion_group.plan([])
+
+    @pytest.mark.asyncio
+    async def test_plan_jnt_with_explicit_tcp_still_works(self, mock_motion_group):
+        """Backward compatibility: passing tcp explicitly should still work."""
+        # Need to mock tcps for get_setup when tcp is provided
+        mock_desc = (
+            mock_motion_group._api_client.motion_group_api.get_motion_group_description.return_value
+        )
+        mock_desc.tcps = {
+            "Flange": MagicMock(
+                pose=api.models.Pose(
+                    position=api.models.Vector3d([0, 0, 0]),
+                    orientation=api.models.RotationVector([0, 0, 0]),
+                ),
+                name="Flange",
+            )
+        }
+
+        trajectory = await mock_motion_group.plan(
+            [jnt((0.1, -1.47, -1.47, 0.1, 0.1, 0.1))], tcp="Flange"
+        )
+        assert trajectory is not None


### PR DESCRIPTION
## Summary

Some motion groups don't have a TCP configured. Previously, the SDK required `tcp: str` as a mandatory parameter for `plan()`, `execute()`, and all related methods. This change makes TCP optional (`str | None`) so that joint-space-only workflows (e.g. `jnt()` actions) can work without specifying a TCP.

## Changes

- **`nova/cell/robot_cell.py`** — Changed `tcp: str` → `tcp: str | None = None` in `plan()`, `plan_and_execute()`, `stream_plan_and_execute()`, and `tcp: str | None` in `execute()`, `stream_execute()`, `_execute()`. Updated `_log_planning_results()` and `_log_planning_error()`.
- **`nova/cell/motion_group.py`** — Updated `_plan()`, `_execute()`, `_plan_with_collision_check()`, `_plan_collision_free()`, `_load_planned_motion()`, `_tune_trajectory()` to accept `str | None`. Added validation in `_plan()`: raises `ValueError` if cartesian actions (`lin`, `ptp`, `cir`, `collision_free` with Pose target) are used without a TCP. Kept `_inverse_kinematics()` as `tcp: str` since IK fundamentally requires a TCP.
- **`nova/viewers/base.py`**, **`nova/viewers/manager.py`**, **`nova/viewers/rerun.py`** — Updated `log_planning_success()` and `log_planning_failure()` to accept `tcp: str | None`. Rerun viewer skips trajectory visualization when `tcp is None`.

## Usage

```python
# Joint-space motions — no TCP needed:
await motion_group.plan_and_execute([jnt(joints)])

# Cartesian motions — TCP still required (clear error if missing):
await motion_group.plan_and_execute([lin(pose)], tcp="Flange")
```

## Verification

- All existing tests pass (non-breaking — existing code passes explicit TCP strings)
- mypy clean, ruff clean
