### PR TITLE
fix(NDX-665): check initial state in wait_for_bus_io before listening for changes

### DIFF
--- a/nova/utils/io.py
+++ b/nova/utils/io.py
@@ -96,7 +96,7 @@ async def wait_for_bus_io(
     Underlying NATS subscription guarantees at-most-once delivery when the consumer is healthy.
 
     Provided nats_subscription_kwargs should be used to tune the subscription behavior.
-    Additional tuning behaviour can be achieved by adjusting the NATS client configuration
+    Additional tuning behavior can be achieved by adjusting the NATS client configuration
     in the Nova instance.
 
     :param bus_ios: A list of bus IO names to monitor for changes.

--- a/nova/utils/io.py
+++ b/nova/utils/io.py
@@ -41,6 +41,23 @@ def _convert_value(value: bool | str | float | None) -> bool | int | float | Non
     return value
 
 
+def _build_io_changes(
+    bus_ios: list[str],
+    old_values: dict[str, api.models.IOValue] | None,
+    new_values: dict[str, api.models.IOValue],
+) -> dict[str, IOChange]:
+    """Build a dict of IOChange entries for the requested bus IOs."""
+    return {
+        io: IOChange(
+            old_value=_convert_value(
+                old_values[io].root.value if old_values and io in old_values else None
+            ),
+            new_value=_convert_value(new_values[io].root.value if io in new_values else None),
+        )
+        for io in bus_ios
+    }
+
+
 async def get_bus_io_value(
     ios: list[str], *, nova: Nova | None = None, cell: str = "cell"
 ) -> dict[str, bool | int | float]:
@@ -128,18 +145,7 @@ async def wait_for_bus_io(
         old_values_dict = {value.root.io: value for value in old_values}
 
         # Check initial state before listening for changes
-        should_terminate = on_change(
-            {
-                io: IOChange(
-                    old_value=None,
-                    new_value=_convert_value(
-                        old_values_dict[io].root.value if io in old_values_dict else None
-                    ),
-                )
-                for io in bus_ios
-            }
-        )
-        if should_terminate:
+        if on_change(_build_io_changes(bus_ios, None, old_values_dict)):
             return
 
         async for message in sub.messages:
@@ -148,21 +154,7 @@ async def wait_for_bus_io(
             new_values = TypeAdapter(list[api.models.IOValue]).validate_json(message.data)
             new_values_dict = {value.root.io: value for value in new_values}
 
-            should_terminate = on_change(
-                {
-                    io: IOChange(
-                        old_value=_convert_value(
-                            old_values_dict[io].root.value if io in old_values_dict else None
-                        ),
-                        new_value=_convert_value(
-                            new_values_dict[io].root.value if io in new_values_dict else None
-                        ),
-                    )
-                    for io in bus_ios
-                }
-            )
-
-            if should_terminate:
+            if on_change(_build_io_changes(bus_ios, old_values_dict, new_values_dict)):
                 break
 
             old_values_dict = new_values_dict

--- a/nova/utils/io.py
+++ b/nova/utils/io.py
@@ -87,17 +87,23 @@ async def wait_for_bus_io(
     Wait for changes on specified bus IOs and call the on_change callback when changes occur.
     The function will continue to listen for changes until the on_change callback returns True.
 
+    The callback is first invoked with the current IO state before listening for changes.
+    In this initial call, ``old_value`` is ``None`` and ``new_value`` holds the current value.
+    If the callback returns True for the initial state, the function returns immediately
+    without waiting for any NATS messages.
+
     Note that this function does not guarantee that all IO changes are captured.
     Underlying NATS subscription guarantees at-most-once delivery when the consumer is healthy.
 
     Provided nats_subscription_kwargs should be used to tune the subscription behavior.
-    Additional tuning behaviour can be achieved by adjusting the NATS client configuration in the Nova instance.
+    Additional tuning behaviour can be achieved by adjusting the NATS client configuration
+    in the Nova instance.
 
-
-    :param nova: The Nova instance to use. It should have a connected NATS client.
     :param bus_ios: A list of bus IO names to monitor for changes.
     :param on_change: A callback function that takes a dictionary of IO changes and returns a boolean.
                       If the callback returns True, the function will stop listening for changes.
+                      On the initial call, ``old_value`` is ``None`` for all IOs.
+    :param nova: The Nova instance to use. It should have a connected NATS client.
     :param cell: The cell name to monitor (default is "cell").
     :param nats_subscription_kwargs: Additional keyword arguments to pass to the NATS subscription.
                                      Refer to nats.subscribe() for available options.
@@ -120,6 +126,21 @@ async def wait_for_bus_io(
     try:
         old_values = await nova.api.bus_ios_api.get_bus_io_values(cell=cell, ios=bus_ios)
         old_values_dict = {value.root.io: value for value in old_values}
+
+        # Check initial state before listening for changes
+        should_terminate = on_change(
+            {
+                io: IOChange(
+                    old_value=None,
+                    new_value=_convert_value(
+                        old_values_dict[io].root.value if io in old_values_dict else None
+                    ),
+                )
+                for io in bus_ios
+            }
+        )
+        if should_terminate:
+            return
 
         async for message in sub.messages:
             logger.debug("Received bus IO update message: %s", message.data.decode())

--- a/nova/utils/io.py
+++ b/nova/utils/io.py
@@ -14,7 +14,7 @@ class IOChange:
     """
     Represents a change in an IO value.
 
-    :param old_value: The previous value of the IO. None if it did not exist.
+    :param old_value: The previous value of the IO. None if the value has been observed for the first time.
     :param new_value: The new value of the IO. None if the IO is no longer present
     """
 

--- a/tests/cell/test_io.py
+++ b/tests/cell/test_io.py
@@ -421,3 +421,28 @@ async def test_wait_io_with_noisy_integer(setup_virtual_profinet: tuple[str, ...
         # VERIFY
         async with asyncio.timeout(5):
             await wait_task
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_wait_io_initial_state_already_met(setup_virtual_profinet: tuple[str, ...]):
+    """wait_for_bus_io should return immediately when the initial state already satisfies the callback."""
+    test_bool, _, _, _ = setup_virtual_profinet
+
+    async with Nova() as nova:
+        # SETUP – set the IO to the target value *before* calling wait_for_bus_io
+        await set_bus_io_value({test_bool: True}, nova=nova)
+
+        call_log: list[dict[str, IOChange]] = []
+
+        def on_change(changes: dict[str, IOChange]) -> bool:
+            call_log.append(changes)
+            return changes[test_bool].new_value is True
+
+        # EXECUTE & VERIFY – should return immediately from initial state check
+        async with asyncio.timeout(2):
+            await wait_for_bus_io([test_bool], on_change=on_change, nova=nova)
+
+        assert len(call_log) == 1
+        assert call_log[0][test_bool].old_value is None
+        assert call_log[0][test_bool].new_value is True


### PR DESCRIPTION
## Problem

`wait_for_bus_io` never evaluates the initial IO state against the `on_change` callback. If the target condition is already met when the function is called, callers block indefinitely waiting for a change that already happened.

## Solution

After subscribing to NATS and fetching the current IO values, `on_change` is now called once with the initial state (`old_value=None`, `new_value=<current value>`). If the callback returns `True`, the function returns immediately without entering the message loop.

This is consistent with the existing `IOChange` docstring which defines `old_value=None` as "the IO did not exist previously."

## Changes

- **`nova/utils/io.py`**: Added initial `on_change` call after fetching `old_values`, updated docstring
- **`tests/cell/test_io.py`**: Added `test_wait_io_initial_state_already_met` integration test

## Backward compatibility

Existing callbacks that check `old_value is False` (like in the existing tests and examples) are unaffected — the initial call has `old_value=None`, which doesn't match `False`.