### PR TITLE
feat(api): update wandelbots-api-client to 26.3

### DIFF
--- a/examples/collision_free_p2p.py
+++ b/examples/collision_free_p2p.py
@@ -119,7 +119,7 @@ async def build_collision_world(
             virtual_controller(
                 name="kuka-kr16-r2010",
                 manufacturer=api.models.Manufacturer.KUKA,
-                type=api.models.VirtualControllerTypes.KUKA_KR16_R2010_2,
+                type="kuka-kr16_r2010_2",
             )
         ],
         cleanup_controllers=False,

--- a/examples/collision_setup.py
+++ b/examples/collision_setup.py
@@ -173,7 +173,7 @@ async def build_collision_world(
             virtual_controller(
                 name="ur5",
                 manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-                type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR5E,
+                type="universalrobots-ur5e",
             )
         ],
         cleanup_controllers=False,

--- a/examples/move_multiple_robots.py
+++ b/examples/move_multiple_robots.py
@@ -39,12 +39,12 @@ async def move_robot(controller: Controller):
             virtual_controller(
                 name="ur10",
                 manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-                type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+                type="universalrobots-ur10e",
             ),
             virtual_controller(
                 name="ur5",
                 manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-                type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR5E,
+                type="universalrobots-ur5e",
             ),
         ],
         cleanup_controllers=False,

--- a/examples/multi_motion_group.py
+++ b/examples/multi_motion_group.py
@@ -34,7 +34,7 @@ def load_joint_trajectories() -> dict[str, api.models.JointTrajectory]:
             virtual_controller(
                 name="kuka",
                 manufacturer=nova.api.models.Manufacturer.KUKA,
-                type=nova.api.models.VirtualControllerTypes.KUKA_KR210_R2700_2,
+                type="kuka-kr210_r2700_2",
                 controller_config_json=load_controller_config(),
             )
         ]

--- a/examples/multi_step_movement_with_collision_free.py
+++ b/examples/multi_step_movement_with_collision_free.py
@@ -23,7 +23,7 @@ from nova.types import Pose
             virtual_controller(
                 name="ur",
                 manufacturer=models.Manufacturer.UNIVERSALROBOTS,
-                type=models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+                type="universalrobots-ur10e",
             )
         ],
         cleanup_controllers=False,

--- a/examples/plan_and_execute.py
+++ b/examples/plan_and_execute.py
@@ -23,7 +23,7 @@ from nova.types import MotionSettings, Pose
             virtual_controller(
                 name="ur10e",
                 manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-                type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+                type="universalrobots-ur10e",
             )
         ],
         cleanup_controllers=False,

--- a/examples/robocore.py
+++ b/examples/robocore.py
@@ -175,22 +175,16 @@ def calculate_handover_orientation(
             virtual_controller(
                 name="fanuc",
                 manufacturer=api.models.Manufacturer.FANUC,
-                type=api.models.VirtualControllerTypes.FANUC_LR_MATE_200I_D7_L,
+                type="fanuc-lrmate200id_7l",
             ),
             virtual_controller(
-                name="kuka",
-                manufacturer=api.models.Manufacturer.KUKA,
-                type=api.models.VirtualControllerTypes.KUKA_KR6_R700_2,
+                name="kuka", manufacturer=api.models.Manufacturer.KUKA, type="kuka-kr6_r700_2"
             ),
             virtual_controller(
-                name="abb",
-                manufacturer=api.models.Manufacturer.ABB,
-                type=api.models.VirtualControllerTypes.ABB_IRB1200_7,
+                name="abb", manufacturer=api.models.Manufacturer.ABB, type="abb-irb1200_7"
             ),
             virtual_controller(
-                name="yaskawa",
-                manufacturer=api.models.Manufacturer.YASKAWA,
-                type=api.models.VirtualControllerTypes.YASKAWA_GP7,
+                name="yaskawa", manufacturer=api.models.Manufacturer.YASKAWA, type="yaskawa-gp7"
             ),
         ],
         cleanup_controllers=False,

--- a/examples/run_wandelscript_file.py
+++ b/examples/run_wandelscript_file.py
@@ -20,7 +20,7 @@ async def main():
             virtual_controller(
                 name="ur10e",
                 manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-                type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+                type="universalrobots-ur10e",
             )
         )
 

--- a/examples/serialize_program.py
+++ b/examples/serialize_program.py
@@ -26,7 +26,7 @@ from nova.types import Pose
             virtual_controller(
                 name="ur10e",
                 manufacturer=models.Manufacturer.UNIVERSALROBOTS,
-                type=models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+                type="universalrobots-ur10e",
             )
         ],
         cleanup_controllers=False,

--- a/examples/signals.py
+++ b/examples/signals.py
@@ -32,7 +32,7 @@ from nova.utils.io import IOChange, get_bus_io_value, set_bus_io_value, wait_for
             virtual_controller(
                 name="ur5",
                 manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-                type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR5E,
+                type="universalrobots-ur5e",
             )
         ],
         cleanup_controllers=False,

--- a/examples/start_here.py
+++ b/examples/start_here.py
@@ -36,7 +36,7 @@ from nova.types import MotionSettings, Pose
             virtual_controller(
                 name="kuka-kr16-r2010",
                 manufacturer=api.models.Manufacturer.KUKA,
-                type=api.models.VirtualControllerTypes.KUKA_KR16_R2010_2,
+                type="kuka-kr16_r2010_2",
             )
         ],
         cleanup_controllers=False,

--- a/examples/visualize_tool.py
+++ b/examples/visualize_tool.py
@@ -23,7 +23,7 @@ robot_tcp_data = api.models.RobotTcpData(
             virtual_controller(
                 name="ur10",
                 manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-                type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+                type="universalrobots-ur10e",
             )
         ],
         cleanup_controllers=True,

--- a/examples/welding.py
+++ b/examples/welding.py
@@ -179,7 +179,7 @@ async def calculate_seam_poses(mesh_pose: api.models.Pose) -> tuple[Pose, Pose, 
             virtual_controller(
                 name="ur10e-welding",
                 manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-                type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+                type="universalrobots-ur10e",
             )
         ],
         cleanup_controllers=False,

--- a/examples/your-nova-app/your_nova_app/start_here.py
+++ b/examples/your-nova-app/your_nova_app/start_here.py
@@ -35,7 +35,7 @@ from nova.types import MotionSettings, Pose
             virtual_controller(
                 name="kuka-kr16-r2010",
                 manufacturer=api.models.Manufacturer.KUKA,
-                type=api.models.VirtualControllerTypes.KUKA_KR16_R2010_2,
+                type="kuka-kr16_r2010_2",
             )
         ],
         cleanup_controllers=False,

--- a/nova/cell/controllers.py
+++ b/nova/cell/controllers.py
@@ -105,7 +105,7 @@ def yaskawa_controller(name: str, controller_ip: str) -> api.models.RobotControl
 def virtual_controller(
     name: str,
     manufacturer: api.models.Manufacturer,
-    type: api.models.VirtualControllerTypes | None = None,
+    type: str | None = None,
     controller_config_json: str | None = None,
     position: list[float] | str | None = None,
 ) -> api.models.RobotController:
@@ -114,7 +114,7 @@ def virtual_controller(
     Args:
         name (str): The name of the controller.
         manufacturer (api.models.Manufacturer): The manufacturer of the robot.
-        type (api.models.VirtualControllerTypes | None): One of the available virtual controller types for this manufacturer.
+        type (str | None): Robot type string (e.g., "universalrobots-ur10e", "kuka-kr16_r2010_2").
         position: (list[float] | None): Initial joint position of the first motion group from the virtual robot controller.
         controller_config_json (str | None): Complete JSON configuration of the virtual robot controller.
     """

--- a/nova_rerun_bridge/examples/import_ply.py
+++ b/nova_rerun_bridge/examples/import_ply.py
@@ -21,7 +21,7 @@ from nova_rerun_bridge.consts import TIME_INTERVAL_NAME
             virtual_controller(
                 name="ur10",
                 manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-                type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+                type="universalrobots-ur10e",
             )
         ],
         cleanup_controllers=False,

--- a/nova_rerun_bridge/examples/reachability_check.py
+++ b/nova_rerun_bridge/examples/reachability_check.py
@@ -39,7 +39,7 @@ def log_mesh_to_rerun(scene: trimesh.Trimesh) -> None:
             virtual_controller(
                 name="ur10",
                 manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-                type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+                type="universalrobots-ur10e",
             )
         ],
         cleanup_controllers=False,

--- a/nova_rerun_bridge/examples/stream_robot.py
+++ b/nova_rerun_bridge/examples/stream_robot.py
@@ -37,7 +37,7 @@ async def handle_shutdown():
             virtual_controller(
                 name="ur10",
                 manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-                type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+                type="universalrobots-ur10e",
             )
         ],
         cleanup_controllers=False,

--- a/nova_rerun_bridge/examples/use_nova_rerun_bridge.py
+++ b/nova_rerun_bridge/examples/use_nova_rerun_bridge.py
@@ -18,7 +18,7 @@ from nova_rerun_bridge import NovaRerunBridge
             virtual_controller(
                 name="ur10",
                 manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-                type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+                type="universalrobots-ur10e",
             )
         ],
         cleanup_controllers=False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.11, <3.13"
 readme = "README.md"
 dependencies = [
     "httpx>=0.28.0,<0.29",
-    "wandelbots_api_client~=25.10.0",
+    "wandelbots_api_client~=26.3.0",
     "websockets>=14.1.0,<15",
     "loguru>=0.7.2,<0.8",
     "pydantic>=2.11.4,<3",

--- a/tests/cell/test_io.py
+++ b/tests/cell/test_io.py
@@ -29,7 +29,7 @@ async def setup_controllers() -> AsyncGenerator[tuple[Controller, Controller], N
             virtual_controller(
                 name="ur-test",
                 manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-                type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+                type="universalrobots-ur10e",
             )
         )
 
@@ -38,7 +38,7 @@ async def setup_controllers() -> AsyncGenerator[tuple[Controller, Controller], N
             virtual_controller(
                 name="kuka-test",
                 manufacturer=api.models.Manufacturer.KUKA,
-                type=api.models.VirtualControllerTypes.KUKA_KR16_R2010_2,
+                type="kuka-kr16_r2010_2",
             )
         )
 

--- a/tests/cell/test_process_motion_group_state.py
+++ b/tests/cell/test_process_motion_group_state.py
@@ -26,6 +26,7 @@ def _make_motion_group_state(
     return api.models.MotionGroupState(
         timestamp=datetime.now(timezone.utc),
         sequence_number=1,
+        description_revision=0,
         motion_group="mg-0",
         controller="ctrl-0",
         joint_position=api.models.Joints(root=[0.0] * 6),

--- a/tests/cell/test_trajectory_state_machine.py
+++ b/tests/cell/test_trajectory_state_machine.py
@@ -24,6 +24,7 @@ def _make_motion_group_state(
     return api.models.MotionGroupState(
         timestamp=datetime.now(timezone.utc),
         sequence_number=1,
+        description_revision=0,
         motion_group="mg-0",
         controller="ctrl-0",
         joint_position=api.models.Joints(root=[0.0] * 6),

--- a/tests/nova/cell/motion_group/test_collision_check_planning.py
+++ b/tests/nova/cell/motion_group/test_collision_check_planning.py
@@ -27,7 +27,7 @@ async def ur_mg():
             virtual_controller(
                 name=controller_name,
                 manufacturer=models.Manufacturer.UNIVERSALROBOTS,
-                type=models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+                type="universalrobots-ur10e",
                 # create controller API doesn't accept 6 values
                 position=[*initial_joint_positions, 0],
             )

--- a/tests/nova/cell/motion_group/test_collision_free_planning.py
+++ b/tests/nova/cell/motion_group/test_collision_free_planning.py
@@ -26,7 +26,7 @@ async def ur_mg():
             virtual_controller(
                 name=controller_name,
                 manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-                type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+                type="universalrobots-ur10e",
                 # create controller API doesn't accept 6 values
                 position=[*initial_joint_positions, 0],
             )

--- a/tests/nova/cell/motion_group/test_inverse_kinematics.py
+++ b/tests/nova/cell/motion_group/test_inverse_kinematics.py
@@ -26,7 +26,7 @@ async def ur_mg():
             virtual_controller(
                 name=controller_name,
                 manufacturer=models.Manufacturer.UNIVERSALROBOTS,
-                type=models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+                type="universalrobots-ur10e",
                 position=initial_joint_positions,
             )
         )

--- a/tests/nova/cell/motion_group/test_motion_group_movement.py
+++ b/tests/nova/cell/motion_group/test_motion_group_movement.py
@@ -24,7 +24,7 @@ async def ur_mg():
             virtual_controller(
                 name=controller_name,
                 manufacturer=models.Manufacturer.UNIVERSALROBOTS,
-                type=models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+                type="universalrobots-ur10e",
                 position=[0.0, -pi / 2, -pi / 2, 0.0, 0.0, 0.0, 0.0],
             )
         )

--- a/tests/nova/cell/motion_group/test_motion_group_task_cancelation.py
+++ b/tests/nova/cell/motion_group/test_motion_group_task_cancelation.py
@@ -38,7 +38,7 @@ async def ur_mg():
             virtual_controller(
                 name=controller_name,
                 manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-                type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+                type="universalrobots-ur10e",
             )
         )
 

--- a/tests/nova/cell/motion_group/test_pause_on_io.py
+++ b/tests/nova/cell/motion_group/test_pause_on_io.py
@@ -27,6 +27,7 @@ async def test_pause_on_io_in_context_initialization():
         yield api.models.MotionGroupState(
             timestamp=datetime.now(timezone.utc),
             sequence_number=0,
+            description_revision=0,
             motion_group="mg0",
             controller="test-controller",
             joint_position=[0.0] * 6,
@@ -60,6 +61,7 @@ async def test_move_forward_controller_includes_pause_on_io_in_start_request():
         yield api.models.MotionGroupState(
             timestamp=datetime.now(timezone.utc),
             sequence_number=0,
+            description_revision=0,
             motion_group="mg0",
             controller="test-controller",
             joint_position=[0.0] * 6,
@@ -112,7 +114,7 @@ async def test_pause_on_io_parameter_accepted_by_execution_api():
             virtual_controller(
                 name=controller_name,
                 manufacturer=api.models.Manufacturer.KUKA,
-                type=api.models.VirtualControllerTypes.KUKA_KR6_R700_SIXX,
+                type="kuka-kr6_r700_sixx",
                 position=initial_joint_positions,
             )
         )
@@ -165,7 +167,7 @@ async def _test_pause_on_io_stops_motion_early_when_triggered():
             virtual_controller(
                 name=controller_name,
                 manufacturer=api.models.Manufacturer.KUKA,
-                type=api.models.VirtualControllerTypes.KUKA_KR6_R700_SIXX,
+                type="kuka-kr6_r700_sixx",
                 position=initial_joint_positions,
             )
         )

--- a/tests/novax/api/test_program_registry.py
+++ b/tests/novax/api/test_program_registry.py
@@ -170,12 +170,12 @@ async def test_program_definition_for_program_with_preconditions():
                 virtual_controller(
                     name="controller1",
                     manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-                    type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+                    type="universalrobots-ur10e",
                 ),
                 virtual_controller(
                     name="controller2",
                     manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-                    type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR5E,
+                    type="universalrobots-ur5e",
                 ),
             ],
             cleanup_controllers=False,
@@ -259,12 +259,12 @@ async def test_program_definition_for_program_with_input_schema_and_precondition
                 virtual_controller(
                     name="controller1",
                     manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-                    type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+                    type="universalrobots-ur10e",
                 ),
                 virtual_controller(
                     name="controller2",
                     manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-                    type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR5E,
+                    type="universalrobots-ur5e",
                 ),
             ],
             cleanup_controllers=False,

--- a/tests/program/test_runner_ndx305.py
+++ b/tests/program/test_runner_ndx305.py
@@ -15,7 +15,7 @@ async def test_program_runner_with_unrelated_controller_in_estop():
             virtual_controller(
                 name="kuka-no-estop",
                 manufacturer=api.models.Manufacturer.KUKA,
-                type=api.models.VirtualControllerTypes.KUKA_KR16_R1610_2,
+                type="kuka-kr16_r1610_2",
             )
         ],
         cleanup_controllers=False,
@@ -48,7 +48,7 @@ async def test_program_runner_with_unrelated_controller_in_estop():
         virtual_controller(
             name="ur10e-estop",
             manufacturer=api.models.Manufacturer.UNIVERSALROBOTS,
-            type=api.models.VirtualControllerTypes.UNIVERSALROBOTS_UR10E,
+            type="universalrobots-ur10e",
         )
     )
     # Set the controller in estop

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11, <3.13"
 
 [options]
@@ -1696,7 +1696,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/91/26/430de0d8aaf5aad9f
 
 [[package]]
 name = "wandelbots-api-client"
-version = "25.10.0"
+version = "26.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1711,14 +1711,14 @@ dependencies = [
     { name = "urllib3" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/9e/1f1f9775dcaccb7123f44302794a04dec56237baa7bf00d566dd3e40370d/wandelbots_api_client-25.10.0.tar.gz", hash = "sha256:dbad17b3d2873a80524048b76742397f5c41c4382bee363d87b28450766cf4bb", size = 487865, upload-time = "2025-12-03T14:02:49.604Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/fa/6ad4b3ed324680f89ca08770d5e30109ebc53544d441cfcd710f5d0631f2/wandelbots_api_client-26.3.0.tar.gz", hash = "sha256:c151a850eb3fcb61698c35b42213e97cc784091e58146ebd41141ec46094a8b1", size = 607242, upload-time = "2026-04-14T13:13:38.946Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/cb/55bf5d47ce022f4013aec5bd218ba03b2db22db689b79262144bd90177ca/wandelbots_api_client-25.10.0-py3-none-any.whl", hash = "sha256:e25fccedce38a4f09bb8334bcbd88df4885635ab6ad31e04107e6fce4d40408b", size = 1240899, upload-time = "2025-12-03T14:02:47.267Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c8/067a8a04c808b1b2a63bc2b33f9da000fc0f55a6a7e331b8aa8bb71c5319/wandelbots_api_client-26.3.0-py3-none-any.whl", hash = "sha256:60ba1184e7cb075e0c438e5621f1a989feef11810a6b5d6d08b7e7abb521b72a", size = 1442061, upload-time = "2026-04-14T13:13:36.595Z" },
 ]
 
 [[package]]
 name = "wandelbots-nova"
-version = "4.10.1"
+version = "4.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiostream" },
@@ -1818,7 +1818,7 @@ requires-dist = [
     { name = "trimesh", marker = "extra == 'nova-rerun-bridge'", specifier = ">=4.5.3" },
     { name = "typer", extras = ["all"], marker = "extra == 'wandelscript'", specifier = ">=0.12,<0.20" },
     { name = "uvicorn", marker = "extra == 'novax'", specifier = ">=0.34.0" },
-    { name = "wandelbots-api-client", specifier = "~=25.10.0" },
+    { name = "wandelbots-api-client", specifier = "~=26.3.0" },
     { name = "websockets", specifier = ">=14.1.0,<15" },
 ]
 provides-extras = ["nova-rerun-bridge", "wandelscript", "novax", "benchmark"]


### PR DESCRIPTION
Updates `wandelbots-api-client` from 25.10.0 to 26.3.0.                                             
                                                                                                         
 ## Addressed  Breaking Changes:
                                           
 1. **`VirtualControllerTypes` enum removed** - Replaced with raw strings (e.g., `"universalrobots-ur10e"`)                                                                                            
 2. **`MotionGroupState.description_revision`** - New required field added to test mocks