### PR TITLE
feat(NDX-696): add jerk limit fields to MotionSettings and fix zero value blending bug

### DIFF
--- a/.github/workflows/pip-audit.yaml
+++ b/.github/workflows/pip-audit.yaml
@@ -21,10 +21,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-          pip-version: ">=26.1.1"
 
       - name: Set up Python environment
         run: |
+          pip install --upgrade pip
           pip install uv
           uv sync --extra "nova-rerun-bridge" --extra "wandelscript" --extra "novax"
 

--- a/.github/workflows/pip-audit.yaml
+++ b/.github/workflows/pip-audit.yaml
@@ -3,9 +3,9 @@ name: "SAST: pip-audit"
 
 on:
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
   push:
-    branches: ["main"]
+    branches: [ "main" ]
   schedule:
     - cron: "33 4 * * 1" # weekly
 
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+          pip-version: ">=26.1.1"
 
       - name: Set up Python environment
         run: |

--- a/.github/workflows/pip-audit.yaml
+++ b/.github/workflows/pip-audit.yaml
@@ -21,10 +21,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+          pip-version: "26.1.1"
 
       - name: Set up Python environment
         run: |
-          pip install --upgrade pip
           pip install uv
           uv sync --extra "nova-rerun-bridge" --extra "wandelscript" --extra "novax"
 

--- a/nova/actions/motions.py
+++ b/nova/actions/motions.py
@@ -49,7 +49,7 @@ class Linear(Motion):
 
     Examples:
     >>> Linear(target=Pose((1, 2, 3, 4, 5, 6)), settings=MotionSettings(tcp_velocity_limit=10))
-    Linear(metas={}, type='linear', target=Pose(position=Vector3d(x=1, y=2, z=3), orientation=Vector3d(x=4, y=5, z=6)), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, tcp_velocity_limit=10.0, tcp_acceleration_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None)
+    Linear(metas={}, type='linear', target=Pose(position=Vector3d(x=1, y=2, z=3), orientation=Vector3d(x=4, y=5, z=6)), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, joint_jerk_limits=None, tcp_velocity_limit=10.0, tcp_acceleration_limit=None, tcp_jerk_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, tcp_orientation_jerk_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None)
 
     """
 
@@ -88,7 +88,7 @@ def linear(
     >>> assert linear((1, 2, 3)) == linear((1, 2, 3, 0, 0, 0))
     >>> assert linear(Pose((1, 2, 3, 4, 5, 6)), settings=ms) == linear((1, 2, 3, 4, 5, 6), settings=ms)
     >>> Action.from_dict(linear((1, 2, 3, 4, 5, 6), MotionSettings()).model_dump())
-    Linear(metas={'line_number': 1}, type='linear', target=Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0)), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, tcp_velocity_limit=50.0, tcp_acceleration_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None)
+    Linear(metas={'line_number': 1}, type='linear', target=Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0)), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, joint_jerk_limits=None, tcp_velocity_limit=50.0, tcp_acceleration_limit=None, tcp_jerk_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, tcp_orientation_jerk_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None)
 
     """
     if not isinstance(target, Pose):
@@ -108,7 +108,7 @@ class CartesianPTP(Motion):
 
     Examples:
     >>> CartesianPTP(target=Pose((1, 2, 3, 4, 5, 6)), settings=MotionSettings(tcp_velocity_limit=30))
-    CartesianPTP(metas={}, type='cartesian_ptp', target=Pose(position=Vector3d(x=1, y=2, z=3), orientation=Vector3d(x=4, y=5, z=6)), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, tcp_velocity_limit=30.0, tcp_acceleration_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None)
+    CartesianPTP(metas={}, type='cartesian_ptp', target=Pose(position=Vector3d(x=1, y=2, z=3), orientation=Vector3d(x=4, y=5, z=6)), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, joint_jerk_limits=None, tcp_velocity_limit=30.0, tcp_acceleration_limit=None, tcp_jerk_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, tcp_orientation_jerk_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None)
 
     """
 
@@ -148,7 +148,7 @@ def cartesian_ptp(
     >>> assert cartesian_ptp((1, 2, 3)) == cartesian_ptp((1, 2, 3, 0, 0, 0))
     >>> assert cartesian_ptp(Pose((1, 2, 3, 4, 5, 6)), settings=ms) == cartesian_ptp((1, 2, 3, 4, 5, 6), settings=ms)
     >>> Action.from_dict(cartesian_ptp((1, 2, 3, 4, 5, 6), MotionSettings()).model_dump())
-    CartesianPTP(metas={'line_number': 1}, type='cartesian_ptp', target=Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0)), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, tcp_velocity_limit=50.0, tcp_acceleration_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None)
+    CartesianPTP(metas={'line_number': 1}, type='cartesian_ptp', target=Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0)), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, joint_jerk_limits=None, tcp_velocity_limit=50.0, tcp_acceleration_limit=None, tcp_jerk_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, tcp_orientation_jerk_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None)
 
     """
     target = _convert_to_pose(target)
@@ -212,7 +212,7 @@ def circular(
     >>> assert circular((1, 2, 3, 4, 5, 6), (7, 8, 9, 10, 11, 12), settings=ms) == Circular(target=Pose((1, 2, 3, 4, 5, 6)), intermediate=Pose((7, 8, 9, 10, 11, 12)), settings=ms, metas={'line_number': 1})
     >>> assert circular((1, 2, 3), (4, 5, 6)) == circular((1, 2, 3, 0, 0, 0), (4, 5, 6, 0, 0, 0))
     >>> Action.from_dict(circular((1, 2, 3, 4, 5, 6), (7, 8, 9, 10, 11, 12), MotionSettings()).model_dump())
-    Circular(metas={'line_number': 1}, type='circular', target=Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0)), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, tcp_velocity_limit=50.0, tcp_acceleration_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None, intermediate=Pose(position=Vector3d(x=7.0, y=8.0, z=9.0), orientation=Vector3d(x=10.0, y=11.0, z=12.0)))
+    Circular(metas={'line_number': 1}, type='circular', target=Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0)), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, joint_jerk_limits=None, tcp_velocity_limit=50.0, tcp_acceleration_limit=None, tcp_jerk_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, tcp_orientation_jerk_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None, intermediate=Pose(position=Vector3d(x=7.0, y=8.0, z=9.0), orientation=Vector3d(x=10.0, y=11.0, z=12.0)))
 
     """
     target = _convert_to_pose(target)
@@ -235,7 +235,7 @@ class JointPTP(Motion):
 
     Examples:
     >>> JointPTP(target=(1, 2, 3, 4, 5, 6), settings=MotionSettings(tcp_velocity_limit=30))
-    JointPTP(metas={}, type='joint_ptp', target=(1.0, 2.0, 3.0, 4.0, 5.0, 6.0), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, tcp_velocity_limit=30.0, tcp_acceleration_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None)
+    JointPTP(metas={}, type='joint_ptp', target=(1.0, 2.0, 3.0, 4.0, 5.0, 6.0), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, joint_jerk_limits=None, tcp_velocity_limit=30.0, tcp_acceleration_limit=None, tcp_jerk_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, tcp_orientation_jerk_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None)
 
     """
 
@@ -276,7 +276,7 @@ def joint_ptp(
     >>> ms = MotionSettings(tcp_acceleration_limit=10)
     >>> assert joint_ptp((1, 2, 3, 4, 5, 6), settings=ms) == JointPTP(target=(1, 2, 3, 4, 5, 6), settings=ms, metas={'line_number': 1})
     >>> Action.from_dict(joint_ptp((1, 2, 3, 4, 5, 6), MotionSettings()).model_dump())
-    JointPTP(metas={'line_number': 1}, type='joint_ptp', target=(1.0, 2.0, 3.0, 4.0, 5.0, 6.0), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, tcp_velocity_limit=50.0, tcp_acceleration_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None)
+    JointPTP(metas={'line_number': 1}, type='joint_ptp', target=(1.0, 2.0, 3.0, 4.0, 5.0, 6.0), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, joint_jerk_limits=None, tcp_velocity_limit=50.0, tcp_acceleration_limit=None, tcp_jerk_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, tcp_orientation_jerk_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None)
 
     """
 
@@ -327,7 +327,7 @@ def spline(
     >>> assert spline((1, 2, 3, 4, 5, 6), settings=ms) == Spline(target=Pose((1, 2, 3, 4, 5, 6)), settings=ms, metas={'line_number': 1})
     >>> assert spline((1, 2, 3)) == spline((1, 2, 3, 0, 0, 0))
     >>> Action.from_dict(spline((1, 2, 3, 4, 5, 6), MotionSettings()).model_dump())
-    Spline(metas={'line_number': 1}, type='spline', target=Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0)), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, tcp_velocity_limit=50.0, tcp_acceleration_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None, path_parameter=1.0, time=None)
+    Spline(metas={'line_number': 1}, type='spline', target=Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0)), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, joint_jerk_limits=None, tcp_velocity_limit=50.0, tcp_acceleration_limit=None, tcp_jerk_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, tcp_orientation_jerk_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None, path_parameter=1.0, time=None)
 
     """
     target = _convert_to_pose(target)
@@ -350,7 +350,7 @@ class CollisionFreeMotion(Motion):
 
     Examples:
     >>> CollisionFreeMotion(target=Pose((1, 2, 3, 4, 5, 6)), settings=MotionSettings(tcp_velocity_limit=30))
-    CollisionFreeMotion(metas={}, type='collision_free', target=Pose(position=Vector3d(x=1, y=2, z=3), orientation=Vector3d(x=4, y=5, z=6)), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, tcp_velocity_limit=30.0, tcp_acceleration_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None, algorithm=CollisionFreeAlgorithm(root=RRTConnectAlgorithm(algorithm_name='RRTConnectAlgorithm', max_iterations=10000, max_step_size=1, adaptive_step_size=True, apply_smoothing=True, apply_blending=True)))
+    CollisionFreeMotion(metas={}, type='collision_free', target=Pose(position=Vector3d(x=1, y=2, z=3), orientation=Vector3d(x=4, y=5, z=6)), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, joint_jerk_limits=None, tcp_velocity_limit=30.0, tcp_acceleration_limit=None, tcp_jerk_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, tcp_orientation_jerk_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None, algorithm=CollisionFreeAlgorithm(root=RRTConnectAlgorithm(algorithm_name='RRTConnectAlgorithm', max_iterations=10000, max_step_size=1, adaptive_step_size=True, apply_smoothing=True, apply_blending=True)))
     """
 
     type: Literal["collision_free"] = "collision_free"
@@ -392,7 +392,7 @@ def collision_free(
     >>> ms = MotionSettings(tcp_acceleration_limit=10)
     >>> assert collision_free((1, 2, 3, 4, 5, 6), settings=ms) == CollisionFreeMotion(target=(1, 2, 3, 4, 5, 6), settings=ms, metas={'line_number': 1})
     >>> Action.from_dict(collision_free((1, 2, 3, 4, 5, 6), MotionSettings()).model_dump())
-    CollisionFreeMotion(metas={'line_number': 1}, type='collision_free', target=(1.0, 2.0, 3.0, 4.0, 5.0, 6.0), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, tcp_velocity_limit=50.0, tcp_acceleration_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None, algorithm=CollisionFreeAlgorithm(root=RRTConnectAlgorithm(algorithm_name='RRTConnectAlgorithm', max_iterations=10000, max_step_size=1.0, adaptive_step_size=True, apply_smoothing=True, apply_blending=True)))
+    CollisionFreeMotion(metas={'line_number': 1}, type='collision_free', target=(1.0, 2.0, 3.0, 4.0, 5.0, 6.0), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, joint_jerk_limits=None, tcp_velocity_limit=50.0, tcp_acceleration_limit=None, tcp_jerk_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, tcp_orientation_jerk_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None, algorithm=CollisionFreeAlgorithm(root=RRTConnectAlgorithm(algorithm_name='RRTConnectAlgorithm', max_iterations=10000, max_step_size=1.0, adaptive_step_size=True, apply_smoothing=True, apply_blending=True)))
     """
     kwargs.update(line_number=utils.get_caller_linenumber())
     return CollisionFreeMotion(

--- a/nova/types/motion_settings.py
+++ b/nova/types/motion_settings.py
@@ -35,27 +35,40 @@ class MotionSettings(pydantic.BaseModel):
             Maximum joint acceleration in [rad/s^2] for each joint.
             Either leave this field empty or set a value for each joint.
 
+        joint_jerk_limits:
+            Maximum joint jerk in [rad/s^3] for each joint.
+            Either leave this field empty or set a value for each joint. (experimental)
+
         tcp_velocity_limit:
             Maximum allowed TCP velocity in [mm/s].
 
         tcp_acceleration_limit:
             Maximum allowed TCP acceleration in [mm/s^2].
 
+        tcp_jerk_limit:
+            Maximum allowed TCP jerk in [mm/s^3]. (experimental)
+
         tcp_orientation_velocity_limit:
             Maximum allowed TCP rotation velocity in [rad/s].
 
         tcp_orientation_acceleration_limit:
             Maximum allowed TCP rotation acceleration in [rad/s^2].
+
+        tcp_orientation_jerk_limit:
+            Maximum allowed TCP rotation jerk in [rad/s^3]. (experimental)
     """
 
     blending_auto: int | None = pydantic.Field(default=None)
     blending_radius: float | None = pydantic.Field(default=None)
     joint_velocity_limits: tuple[float, ...] | None = pydantic.Field(default=None)
     joint_acceleration_limits: tuple[float, ...] | None = pydantic.Field(default=None)
+    joint_jerk_limits: tuple[float, ...] | None = pydantic.Field(default=None)
     tcp_velocity_limit: float | None = pydantic.Field(default=DEFAULT_TCP_VELOCITY_LIMIT)
     tcp_acceleration_limit: float | None = pydantic.Field(default=None)
+    tcp_jerk_limit: float | None = pydantic.Field(default=None)
     tcp_orientation_velocity_limit: float | None = pydantic.Field(default=None)
     tcp_orientation_acceleration_limit: float | None = pydantic.Field(default=None)
+    tcp_orientation_jerk_limit: float | None = pydantic.Field(default=None)
 
     position_zone_radius: float | None = pydantic.Field(default=None, deprecated=True)
     min_blending_velocity: int | None = pydantic.Field(default=None, deprecated=True)
@@ -81,11 +94,19 @@ class MotionSettings(pydantic.BaseModel):
         if blending_radius is not None and blending_auto is not None:
             raise ValueError("Can't set both blending_radius and blending_auto")
 
-        if self.joint_acceleration_limits is not None and self.joint_velocity_limits is not None:
-            if len(self.joint_acceleration_limits) != len(self.joint_velocity_limits):
-                raise ValueError(
-                    "joint_acceleration_limits and joint_velocity_limits must have the same length."
-                )
+        joint_limits_lengths = [
+            len(lim)
+            for lim in (
+                self.joint_velocity_limits,
+                self.joint_acceleration_limits,
+                self.joint_jerk_limits,
+            )
+            if lim is not None
+        ]
+        if len(set(joint_limits_lengths)) > 1:
+            raise ValueError(
+                "joint_velocity_limits, joint_acceleration_limits, and joint_jerk_limits must have the same length."
+            )
         return self
 
     def has_blending_settings(self) -> bool:
@@ -96,10 +117,13 @@ class MotionSettings(pydantic.BaseModel):
             [
                 self.tcp_velocity_limit,
                 self.tcp_acceleration_limit,
+                self.tcp_jerk_limit,
                 self.tcp_orientation_velocity_limit,
                 self.tcp_orientation_acceleration_limit,
+                self.tcp_orientation_jerk_limit,
                 self.joint_velocity_limits,
                 self.joint_acceleration_limits,
+                self.joint_jerk_limits,
             ]
         )
 
@@ -111,10 +135,13 @@ class MotionSettings(pydantic.BaseModel):
             joint_acceleration_limits=list(self.joint_acceleration_limits)
             if self.joint_acceleration_limits
             else None,
+            joint_jerk_limits=list(self.joint_jerk_limits) if self.joint_jerk_limits else None,
             tcp_velocity_limit=self.tcp_velocity_limit,
             tcp_acceleration_limit=self.tcp_acceleration_limit,
+            tcp_jerk_limit=self.tcp_jerk_limit,
             tcp_orientation_velocity_limit=self.tcp_orientation_velocity_limit,
             tcp_orientation_acceleration_limit=self.tcp_orientation_acceleration_limit,
+            tcp_orientation_jerk_limit=self.tcp_orientation_jerk_limit,
         )
 
     def as_blending_setting(self) -> api.models.BlendingPosition | api.models.BlendingAuto:
@@ -134,12 +161,16 @@ class MotionSettings(pydantic.BaseModel):
         return api.models.CartesianLimits(
             velocity=self.tcp_velocity_limit,
             acceleration=self.tcp_acceleration_limit,
+            jerk=self.tcp_jerk_limit,
             orientation_velocity=self.tcp_orientation_velocity_limit,
             orientation_acceleration=self.tcp_orientation_acceleration_limit,
+            orientation_jerk=self.tcp_orientation_jerk_limit,
         )
 
     def as_joint_limits(self) -> list[api.models.JointLimits] | None:
-        if self.joint_velocity_limits is None and self.joint_acceleration_limits is None:
+        if not any(
+            [self.joint_velocity_limits, self.joint_acceleration_limits, self.joint_jerk_limits]
+        ):
             return None
 
         if self.joint_velocity_limits is not None:
@@ -147,6 +178,9 @@ class MotionSettings(pydantic.BaseModel):
 
         if self.joint_acceleration_limits is not None:
             length = len(self.joint_acceleration_limits)
+
+        if self.joint_jerk_limits is not None:
+            length = len(self.joint_jerk_limits)
 
         limits = []
         for i in range(length):
@@ -160,7 +194,8 @@ class MotionSettings(pydantic.BaseModel):
                 if self.joint_acceleration_limits is not None
                 else None
             )
-            limit = api.models.JointLimits(velocity=velocity, acceleration=acceleration)
+            jerk = self.joint_jerk_limits[i] if self.joint_jerk_limits is not None else None
+            limit = api.models.JointLimits(velocity=velocity, acceleration=acceleration, jerk=jerk)
             limits.append(limit)
 
         return limits

--- a/nova/types/motion_settings.py
+++ b/nova/types/motion_settings.py
@@ -81,10 +81,14 @@ class MotionSettings(pydantic.BaseModel):
         return f"__ms_{field}"
 
     def _get_blending_radius(self) -> float | None:
-        return self.blending_radius or self.position_zone_radius
+        if self.blending_radius is not None:
+            return self.blending_radius
+        return self.position_zone_radius
 
     def _get_blending_auto(self) -> int | None:
-        return self.blending_auto or self.min_blending_velocity
+        if self.blending_auto is not None:
+            return self.blending_auto
+        return self.min_blending_velocity
 
     @pydantic.model_validator(mode="after")
     def validate_blending_settings(self) -> "MotionSettings":
@@ -110,17 +114,22 @@ class MotionSettings(pydantic.BaseModel):
         return self
 
     def has_blending_settings(self) -> bool:
-        return any([self._get_blending_auto(), self._get_blending_radius()])
+        return self._get_blending_auto() is not None or self._get_blending_radius() is not None
 
     def has_limits_override(self) -> bool:
         return any(
-            [
+            value is not None
+            for value in [
                 self.tcp_velocity_limit,
                 self.tcp_acceleration_limit,
                 self.tcp_jerk_limit,
                 self.tcp_orientation_velocity_limit,
                 self.tcp_orientation_acceleration_limit,
                 self.tcp_orientation_jerk_limit,
+            ]
+        ) or any(
+            joint_limits is not None and len(joint_limits) > 0
+            for joint_limits in [
                 self.joint_velocity_limits,
                 self.joint_acceleration_limits,
                 self.joint_jerk_limits,
@@ -149,7 +158,7 @@ class MotionSettings(pydantic.BaseModel):
             raise ValueError("No blending settings set")
 
         blending_radius = self._get_blending_radius()
-        if blending_radius:
+        if blending_radius is not None:
             return api.models.BlendingPosition(
                 position_zone_radius=blending_radius, blending_name="BlendingPosition"
             )

--- a/tests/nova/types/test_motion_settings.py
+++ b/tests/nova/types/test_motion_settings.py
@@ -1,5 +1,8 @@
 import pytest
 
+from nova.actions import cartesian_ptp
+from nova.actions.container import CombinedActions
+from nova.types import Pose
 from nova.types.motion_settings import DEFAULT_TCP_VELOCITY_LIMIT, MotionSettings
 
 
@@ -69,3 +72,74 @@ def test_blending_settings():
 
     with pytest.raises(ValueError, match="Can't set both blending_radius and blending_auto"):
         MotionSettings(position_zone_radius=10.0, min_blending_velocity=50)
+
+
+def test_zero_blending_values_are_treated_as_explicit_settings():
+    """Zero blending values are valid explicit settings and must not be treated as missing."""
+    zero_radius_settings = MotionSettings(blending_radius=0.0)
+    zero_radius_blending = zero_radius_settings.as_blending_setting()
+    assert zero_radius_settings.has_blending_settings() is True
+    assert zero_radius_blending.position_zone_radius == 0.0
+
+    zero_auto_settings = MotionSettings(blending_auto=0)
+    zero_auto_blending = zero_auto_settings.as_blending_setting()
+    assert zero_auto_settings.has_blending_settings() is True
+    assert zero_auto_blending.min_velocity_in_percent == 0
+
+
+def test_zero_blending_radius_still_conflicts_with_blending_auto():
+    """Zero blending radius still conflicts with blending_auto during validation."""
+    with pytest.raises(ValueError, match="Can't set both blending_radius and blending_auto"):
+        MotionSettings(blending_radius=0.0, blending_auto=50)
+
+
+def test_zero_scalar_limits_are_treated_as_overrides():
+    """All scalar TCP limits should count as overrides even when explicitly set to zero."""
+    assert MotionSettings(tcp_velocity_limit=0.0).has_limits_override() is True
+    assert MotionSettings(tcp_acceleration_limit=0.0).has_limits_override() is True
+    assert MotionSettings(tcp_orientation_velocity_limit=0.0).has_limits_override() is True
+    assert MotionSettings(tcp_orientation_acceleration_limit=0.0).has_limits_override() is True
+
+
+def test_to_motion_command_keeps_zero_limit_overrides():
+    """Explicit zero-valued scalar limits should still be serialized as overrides."""
+    target_pose = Pose((1.0, 2.0, 3.0, 0.0, 0.0, 0.0))
+    test_cases = [
+        {
+            "description": "TCP velocity set to 0.0 should still create a limits override.",
+            "settings": MotionSettings(tcp_velocity_limit=0.0),
+            "field_name": "tcp_velocity_limit",
+        },
+        {
+            "description": "TCP acceleration set to 0.0 should still create a limits override.",
+            "settings": MotionSettings(tcp_acceleration_limit=0.0),
+            "field_name": "tcp_acceleration_limit",
+        },
+        {
+            "description": (
+                "TCP orientation velocity set to 0.0 should still create a limits override."
+            ),
+            "settings": MotionSettings(tcp_orientation_velocity_limit=0.0),
+            "field_name": "tcp_orientation_velocity_limit",
+        },
+        {
+            "description": (
+                "TCP orientation acceleration set to 0.0 should still create a limits override."
+            ),
+            "settings": MotionSettings(tcp_orientation_acceleration_limit=0.0),
+            "field_name": "tcp_orientation_acceleration_limit",
+        },
+    ]
+
+    for test_case in test_cases:
+        combined_actions = CombinedActions(
+            items=(cartesian_ptp(target_pose, settings=test_case["settings"]),)
+        )
+
+        motion_commands = combined_actions.to_motion_command()
+
+        assert len(motion_commands) == 1
+        assert motion_commands[0].limits_override is not None, test_case["description"]
+        assert getattr(motion_commands[0].limits_override, test_case["field_name"]) == 0.0, (
+            test_case["description"]
+        )

--- a/tests/nova/types/test_motion_settings.py
+++ b/tests/nova/types/test_motion_settings.py
@@ -13,6 +13,21 @@ def test_different_joint_limits_length_raises():
         )
 
 
+def test_mismatched_joint_jerk_limits_length_raises():
+    """joint_jerk_limits length must match joint_velocity_limits and joint_acceleration_limits."""
+    with pytest.raises(ValueError):
+        MotionSettings(
+            joint_velocity_limits=[0.5, 0.5, 0.5],
+            joint_jerk_limits=[1.0, 1.0, 1.0, 1.0],
+        )
+
+    with pytest.raises(ValueError):
+        MotionSettings(
+            joint_acceleration_limits=[1.0, 1.0, 1.0],
+            joint_jerk_limits=[2.0, 2.0],
+        )
+
+
 def test_motion_settings_with_no_explicit_tcp_limits():
     motion_settings = MotionSettings()
     tcp_cartesian_limits = motion_settings.as_tcp_cartesian_limits()
@@ -37,6 +52,18 @@ def test_motion_settings_tcp_cartesian_limits():
     )
 
 
+def test_motion_settings_tcp_cartesian_limits_jerk_fields():
+    """as_tcp_cartesian_limits() must populate jerk and orientation_jerk from the new fields."""
+    motion_settings = MotionSettings(
+        tcp_jerk_limit=3.0,
+        tcp_orientation_jerk_limit=0.8,
+    )
+
+    cartesian_limits = motion_settings.as_tcp_cartesian_limits()
+    assert cartesian_limits.jerk == motion_settings.tcp_jerk_limit
+    assert cartesian_limits.orientation_jerk == motion_settings.tcp_orientation_jerk_limit
+
+
 def test_motion_settings_as_joint_limits():
     motion_settings = MotionSettings()
     limits = motion_settings.as_joint_limits()
@@ -55,6 +82,35 @@ def test_joint_velocity_limits():
     for i in range(6):
         assert limits[i].velocity == motion_settings.joint_velocity_limits[i]
         assert limits[i].acceleration == motion_settings.joint_acceleration_limits[i]
+
+
+def test_joint_jerk_limits():
+    """as_joint_limits() must set the jerk field on each JointLimits entry."""
+    motion_settings = MotionSettings(
+        joint_velocity_limits=[0.5, 0.5, 0.5],
+        joint_jerk_limits=[2.0, 2.0, 2.0],
+    )
+
+    limits = motion_settings.as_joint_limits()
+    assert limits is not None
+    assert len(limits) == 3
+    for i in range(3):
+        assert limits[i].velocity == motion_settings.joint_velocity_limits[i]
+        assert limits[i].jerk == motion_settings.joint_jerk_limits[i]
+        assert limits[i].acceleration is None
+
+
+def test_joint_jerk_limits_only():
+    """as_joint_limits() works when only joint_jerk_limits is set (no velocity/acceleration)."""
+    motion_settings = MotionSettings(joint_jerk_limits=[3.0, 3.0, 3.0, 3.0, 3.0, 3.0])
+
+    limits = motion_settings.as_joint_limits()
+    assert limits is not None
+    assert len(limits) == 6
+    for i in range(6):
+        assert limits[i].jerk == motion_settings.joint_jerk_limits[i]
+        assert limits[i].velocity is None
+        assert limits[i].acceleration is None
 
 
 def test_blending_settings():
@@ -97,8 +153,10 @@ def test_zero_scalar_limits_are_treated_as_overrides():
     """All scalar TCP limits should count as overrides even when explicitly set to zero."""
     assert MotionSettings(tcp_velocity_limit=0.0).has_limits_override() is True
     assert MotionSettings(tcp_acceleration_limit=0.0).has_limits_override() is True
+    assert MotionSettings(tcp_jerk_limit=0.0).has_limits_override() is True
     assert MotionSettings(tcp_orientation_velocity_limit=0.0).has_limits_override() is True
     assert MotionSettings(tcp_orientation_acceleration_limit=0.0).has_limits_override() is True
+    assert MotionSettings(tcp_orientation_jerk_limit=0.0).has_limits_override() is True
 
 
 def test_to_motion_command_keeps_zero_limit_overrides():

--- a/tests/nova/types/test_motion_settings.py
+++ b/tests/nova/types/test_motion_settings.py
@@ -17,15 +17,11 @@ def test_mismatched_joint_jerk_limits_length_raises():
     """joint_jerk_limits length must match joint_velocity_limits and joint_acceleration_limits."""
     with pytest.raises(ValueError):
         MotionSettings(
-            joint_velocity_limits=[0.5, 0.5, 0.5],
-            joint_jerk_limits=[1.0, 1.0, 1.0, 1.0],
+            joint_velocity_limits=[0.5, 0.5, 0.5], joint_jerk_limits=[1.0, 1.0, 1.0, 1.0]
         )
 
     with pytest.raises(ValueError):
-        MotionSettings(
-            joint_acceleration_limits=[1.0, 1.0, 1.0],
-            joint_jerk_limits=[2.0, 2.0],
-        )
+        MotionSettings(joint_acceleration_limits=[1.0, 1.0, 1.0], joint_jerk_limits=[2.0, 2.0])
 
 
 def test_motion_settings_with_no_explicit_tcp_limits():
@@ -54,10 +50,7 @@ def test_motion_settings_tcp_cartesian_limits():
 
 def test_motion_settings_tcp_cartesian_limits_jerk_fields():
     """as_tcp_cartesian_limits() must populate jerk and orientation_jerk from the new fields."""
-    motion_settings = MotionSettings(
-        tcp_jerk_limit=3.0,
-        tcp_orientation_jerk_limit=0.8,
-    )
+    motion_settings = MotionSettings(tcp_jerk_limit=3.0, tcp_orientation_jerk_limit=0.8)
 
     cartesian_limits = motion_settings.as_tcp_cartesian_limits()
     assert cartesian_limits.jerk == motion_settings.tcp_jerk_limit
@@ -87,8 +80,7 @@ def test_joint_velocity_limits():
 def test_joint_jerk_limits():
     """as_joint_limits() must set the jerk field on each JointLimits entry."""
     motion_settings = MotionSettings(
-        joint_velocity_limits=[0.5, 0.5, 0.5],
-        joint_jerk_limits=[2.0, 2.0, 2.0],
+        joint_velocity_limits=[0.5, 0.5, 0.5], joint_jerk_limits=[2.0, 2.0, 2.0]
     )
 
     limits = motion_settings.as_joint_limits()


### PR DESCRIPTION
### Summary
- Add `joint_jerk_limits`, `tcp_jerk_limit`, and `tcp_orientation_jerk_limit` fields to `MotionSettings`, matching the new jerk fields in the API's `LimitsOverride`, `CartesianLimits`, and `JointLimits` models (experimental)
- Wire jerk limits through `as_limits_settings()`, `as_tcp_cartesian_limits()`, `as_joint_limits()`, and `has_limits_override()`
- Extend joint limits length validation to include `joint_jerk_limits`
- Fix `MotionSettings` checks so explicit `0` values are treated as set values instead of falsy/missing (subsumes #410)
- Add tests for zero-valued limits and blending edge cases

### Testing
```bash
PYTHONPATH=. uv run pytest -rs -v tests/nova/types/test_motion_settings.py
```

Closes #410