### PR TITLE
chore(api): update wandelbots-api-client to 26.4.0

### DIFF
--- a/examples/welding.py
+++ b/examples/welding.py
@@ -198,7 +198,7 @@ async def test(ctx: nova.ProgramContext):
     )
 
     # Log to rerun
-    await log_mesh_to_rerun(scene)  # type: ignore
+    await log_mesh_to_rerun(scene)  # type: ignore[arg-type]
 
     cell = ctx.nova.cell()
     controller = await cell.controller("ur10e-welding")
@@ -240,7 +240,7 @@ async def test(ctx: nova.ProgramContext):
     mesh_collider = await add_mesh_to_collision_world(
         collision_api=ctx.nova.api.store_collision_components_api,
         cell_name=cell.id,
-        scene=scene,  # type: ignore
+        scene=scene,  # type: ignore[arg-type]
     )
 
     # Build collision world with welding part included

--- a/nova/actions/motions.py
+++ b/nova/actions/motions.py
@@ -119,7 +119,7 @@ class CartesianPTP(Motion):
 
         Examples:
         >>> CartesianPTP(target=Pose((1, 2, 3, 4, 5, 6)), settings=MotionSettings(tcp_velocity_limit=30)).to_api_model()
-        PathCartesianPTP(target_pose=Pose(position=Vector3d(root=[1.0, 2.0, 3.0]), orientation=RotationVector(root=[4.0, 5.0, 6.0])), path_definition_name='PathCartesianPTP')
+        PathCartesianPTP(target_pose=Pose(position=Vector3d(root=[1.0, 2.0, 3.0]), orientation=RotationVector(root=[4.0, 5.0, 6.0])), kinematic_configuration=None, path_definition_name='PathCartesianPTP')
         """
         if not isinstance(self.target, Pose):
             raise ValueError("Target must be a Pose object")
@@ -350,7 +350,7 @@ class CollisionFreeMotion(Motion):
 
     Examples:
     >>> CollisionFreeMotion(target=Pose((1, 2, 3, 4, 5, 6)), settings=MotionSettings(tcp_velocity_limit=30))
-    CollisionFreeMotion(metas={}, type='collision_free', target=Pose(position=Vector3d(x=1, y=2, z=3), orientation=Vector3d(x=4, y=5, z=6)), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, joint_jerk_limits=None, tcp_velocity_limit=30.0, tcp_acceleration_limit=None, tcp_jerk_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, tcp_orientation_jerk_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None, algorithm=CollisionFreeAlgorithm(root=RRTConnectAlgorithm(algorithm_name='RRTConnectAlgorithm', max_iterations=10000, max_step_size=1, adaptive_step_size=True, apply_smoothing=True, apply_blending=True)))
+    CollisionFreeMotion(metas={}, type='collision_free', target=Pose(position=Vector3d(x=1, y=2, z=3), orientation=Vector3d(x=4, y=5, z=6)), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, joint_jerk_limits=None, tcp_velocity_limit=30.0, tcp_acceleration_limit=None, tcp_jerk_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, tcp_orientation_jerk_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None, algorithm=CollisionFreeAlgorithm(root=RRTConnectAlgorithm(algorithm_name='RRTConnectAlgorithm', max_iterations=10000, max_step_size=0.1, adaptive_step_size=True, step_size=None, apply_smoothing=True, apply_blending=True)))
     """
 
     type: Literal["collision_free"] = "collision_free"
@@ -392,7 +392,7 @@ def collision_free(
     >>> ms = MotionSettings(tcp_acceleration_limit=10)
     >>> assert collision_free((1, 2, 3, 4, 5, 6), settings=ms) == CollisionFreeMotion(target=(1, 2, 3, 4, 5, 6), settings=ms, metas={'line_number': 1})
     >>> Action.from_dict(collision_free((1, 2, 3, 4, 5, 6), MotionSettings()).model_dump())
-    CollisionFreeMotion(metas={'line_number': 1}, type='collision_free', target=(1.0, 2.0, 3.0, 4.0, 5.0, 6.0), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, joint_jerk_limits=None, tcp_velocity_limit=50.0, tcp_acceleration_limit=None, tcp_jerk_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, tcp_orientation_jerk_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None, algorithm=CollisionFreeAlgorithm(root=RRTConnectAlgorithm(algorithm_name='RRTConnectAlgorithm', max_iterations=10000, max_step_size=1.0, adaptive_step_size=True, apply_smoothing=True, apply_blending=True)))
+    CollisionFreeMotion(metas={'line_number': 1}, type='collision_free', target=(1.0, 2.0, 3.0, 4.0, 5.0, 6.0), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, joint_jerk_limits=None, tcp_velocity_limit=50.0, tcp_acceleration_limit=None, tcp_jerk_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, tcp_orientation_jerk_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None, algorithm=CollisionFreeAlgorithm(root=RRTConnectAlgorithm(algorithm_name='RRTConnectAlgorithm', max_iterations=10000, max_step_size=0.1, adaptive_step_size=True, step_size=None, apply_smoothing=True, apply_blending=True)))
     """
     kwargs.update(line_number=utils.get_caller_linenumber())
     return CollisionFreeMotion(

--- a/nova/cell/motion_group.py
+++ b/nova/cell/motion_group.py
@@ -662,7 +662,7 @@ class MotionGroup(AbstractRobot):
         if first_collision_setup is not None:
             motion_group_setup.collision_setups.root["collision-check"] = first_collision_setup
 
-        motion_commands = CombinedActions(items=tuple(actions)).to_motion_command()  # type: ignore
+        motion_commands = CombinedActions(items=tuple(actions)).to_motion_command()
 
         # Plan the trajectory
         plan_trajectory_response = await self._api_client.trajectory_planning_api.plan_trajectory(
@@ -912,7 +912,7 @@ class MotionGroup(AbstractRobot):
 
         controller = movement_controller(
             MovementControllerContext(
-                combined_actions=CombinedActions(items=tuple(actions)),  # type: ignore
+                combined_actions=CombinedActions(items=tuple(actions)),
                 motion_id=trajectory_id,
                 start_on_io=start_on_io,
                 pause_on_io=pause_on_io,

--- a/nova/cell/movement_controller/trajectory_cursor.py
+++ b/nova/cell/movement_controller/trajectory_cursor.py
@@ -470,7 +470,7 @@ class TrajectoryCursor:
         """
         self.motion_id = motion_id
         self.joint_trajectory = joint_trajectory
-        self.actions = CombinedActions(items=actions) if actions is not None else None  # type: ignore
+        self.actions = CombinedActions(items=actions) if actions is not None else None
 
         if self.actions is not None:
             expected_end_location = len(self.actions)

--- a/nova_rerun_bridge/collision_scene.py
+++ b/nova_rerun_bridge/collision_scene.py
@@ -37,7 +37,7 @@ def log_colliders_once(entity_path: str, colliders: dict[str, api.models.Collide
                 rr.Ellipsoids3D(
                     radii=[collider.shape.radius, collider.shape.radius, collider.shape.radius],
                     centers=[pose.position.to_tuple()],
-                    rotation_axis_angles=[rr.RotationAxisAngle(axis=axis, angle=angle)],  # type: ignore
+                    rotation_axis_angles=[rr.RotationAxisAngle(axis=axis, angle=angle)],  # type: ignore[arg-type]
                     colors=[(221, 193, 193, 255)],
                 ),
                 static=True,
@@ -257,7 +257,7 @@ def log_colliders_once(entity_path: str, colliders: dict[str, api.models.Collide
                         vertex_positions=vertices,
                         triangle_indices=triangles,
                         vertex_normals=normals,
-                        albedo_factor=[colors.colors[0]],  # type: ignore
+                        albedo_factor=[colors.colors[0]],  # type: ignore[list-item]
                     ),
                     static=True,
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.11, <3.13"
 readme = "README.md"
 dependencies = [
     "httpx>=0.28.0,<0.29",
-    "wandelbots_api_client~=26.3.0",
+    "wandelbots_api_client~=26.4.0",
     "websockets>=14.1.0,<15",
     "loguru>=0.7.2,<0.8",
     "pydantic>=2.11.4,<3",
@@ -132,6 +132,7 @@ exclude = [
 ]
 namespace_packages = true
 explicit_package_bases = true
+plugins = ['pydantic.mypy']
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]

--- a/tests/nova/cell/motion_group/test_inverse_kinematics.py
+++ b/tests/nova/cell/motion_group/test_inverse_kinematics.py
@@ -167,7 +167,7 @@ async def test_inverse_kinematics_unreachable_pose_due_to_collision_setup(ur_mg)
     # if you change the orientation, IK will find no solution
     orientation = ((120 / 360) * 2 * pi, (-135 / 360) * 2 * pi, 0)
     solutions = await ur_mg._inverse_kinematics(
-        poses=[Pose(700, 0, 1, *orientation)], tcp="Flange", motion_group_setup=setup
+        poses=[Pose(700, 0, 7, *orientation)], tcp="Flange", motion_group_setup=setup
     )
 
     assert len(solutions) == 1, "Inverse kinematics did not return solutions for all poses"

--- a/uv.lock
+++ b/uv.lock
@@ -1777,7 +1777,7 @@ wheels = [
 
 [[package]]
 name = "wandelbots-api-client"
-version = "26.3.1rc2"
+version = "26.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1792,14 +1792,14 @@ dependencies = [
     { name = "urllib3" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/f6/c5ad105f35bae6d118760660ab6b6a9c2b22add014636dc4c8b910c99b6e/wandelbots_api_client-26.3.1rc2.tar.gz", hash = "sha256:68978ed1a486b2b1bb8afb2ffefe723ac94d3b3d74c4f8816f816d6d5ec58d5e", size = 607994, upload-time = "2026-05-04T07:08:11.409Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/a6/3bb765f571a988b65c219af787603c2a041bb97e76f20369685e6a3dd223/wandelbots_api_client-26.4.0.tar.gz", hash = "sha256:ecb5cd9eb4ca0251892f268f5d7da37afdc21419b11a8d6cebddef94e0f93678", size = 635384, upload-time = "2026-06-01T14:36:15.728Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/46/04fb3c22aba8cdac94dfd5accba8458506e40bd9dfa5a73135b03bd45b75/wandelbots_api_client-26.3.1rc2-py3-none-any.whl", hash = "sha256:4253e762f061e39a80cd08e491d2bff42c8215f8865890dbcca3e548defd82bd", size = 1442122, upload-time = "2026-05-04T07:08:14.369Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/36/3568ea69faa337ab907bcdd264fc881b99bdfea5a21f95a6b594713dd523/wandelbots_api_client-26.4.0-py3-none-any.whl", hash = "sha256:b884fbc55aca6b20117f3596d00eda9d46a3fa7edaeec4402843eddae04b29c4", size = 1510637, upload-time = "2026-06-01T14:36:12.506Z" },
 ]
 
 [[package]]
 name = "wandelbots-nova"
-version = "5.1.1"
+version = "5.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiostream" },
@@ -1899,7 +1899,7 @@ requires-dist = [
     { name = "trimesh", marker = "extra == 'nova-rerun-bridge'", specifier = ">=4.5.3" },
     { name = "typer", extras = ["all"], marker = "extra == 'wandelscript'", specifier = ">=0.12,<0.20" },
     { name = "uvicorn", marker = "extra == 'novax'", specifier = ">=0.34.0" },
-    { name = "wandelbots-api-client", specifier = "~=26.3.0" },
+    { name = "wandelbots-api-client", specifier = "~=26.4.0" },
     { name = "websockets", specifier = ">=14.1.0,<15" },
 ]
 provides-extras = ["nova-rerun-bridge", "wandelscript", "novax", "benchmark"]

--- a/wandelscript/ffi.py
+++ b/wandelscript/ffi.py
@@ -63,7 +63,7 @@ def foreign_function(
             @wraps(fn)
             def wrapper(*args: Any, **kwargs: Any) -> Any:
                 bound = sig.bind_partial(*args, **kwargs)
-                converted = {}
+                converted: dict[str, Any] = {}
                 for name, value in bound.arguments.items():
                     param = sig.parameters[name]
                     anno = param.annotation


### PR DESCRIPTION
- Enable pydantic.mypy plugin — the new client relies on  pydantic.Field(default, ...) for validation constraints and
  deprecation markers, which mypy cannot resolve without the plugin
- Update doctests for new client output:
  - CollisionFreeMotion for new RRTConnect defaults (max_step_size=0.1, step_size=None)
  - CartesianPTP.to_api_model for the new kinematic_configuration field on PathCartesianPTP
- Remove now-unused # type: ignore comments — the plugin resolves the underlying issues
- Replace the # type: ignore[assignment] in wandelscript/ffi.py with an  explicit converted: dict[str, Any] annotation
- Adjust inverse kinematic test, collision checks of backend have  changed and currently report false positive for tcp pose (TCP  shouldn't be in collision), therefore TCP position has to be adapted slightly, but this is not critical for the test-case
