### PR TITLE
feat: introduce log function for multi mg trajectory

### DIFF
--- a/examples/start_here_two_robots_rrt.py
+++ b/examples/start_here_two_robots_rrt.py
@@ -1,0 +1,295 @@
+"""
+Two-Robot Multi-Motion-Group RRT Example
+
+Two virtual KUKA KR16 R2010 robots placed 1m apart along the Y axis.
+Collision-free joint trajectories are planned simultaneously using the
+Nova multi-motion-group RRT-Connect API, which checks inter-robot collisions
+at every explored state. The resulting time-synchronized trajectory is then
+executed on both virtual controllers concurrently.
+
+This demonstrates:
+- Setting up two virtual robot controllers in one cell
+- Using the multi-motion-group collision-free planning API (no external deps)
+- Coordinating both robots so they never collide with each other
+- Executing pre-planned trajectories on both robots concurrently
+"""
+
+import asyncio
+
+from pydantic import Field
+
+import nova
+from nova import api, run_program
+from nova.actions import joint_ptp
+from nova.cell import virtual_controller
+from nova.cell.motion_group import MotionGroup
+from nova.types import MotionSettings
+from nova_rerun_bridge.trajectory import log_multi_motion_group_trajectory
+ROBOT_SEPARATION_MM = 1000.0
+
+# Safe neutral start: both arms point in +X, away from each other.
+START_JOINTS = (0.0, -1.0, 1.0, 0.0, 0.5, 0.0)
+
+# Robot 1 (at Y=0) swings J1 to +π/2 → arm extends toward +Y, into robot 2's space.
+# Robot 2 (at Y=1000mm) swings J1 to -π/2 → arm extends toward -Y, into robot 1's space.
+# Without collision avoidance both TCPs would meet at the midpoint (~Y=500mm).
+TARGET_JOINTS_1 = (1.5708, -1.0, 1.0, 0.0, 0.5, 0.0)   # robot 1 → toward +Y
+TARGET_JOINTS_2 = (-1.5708, -1.0, 1.0, 0.0, 0.5, 0.0)  # robot 2 → toward -Y
+
+ROBOT_SEPARATION_MM = 1000.0
+
+
+async def set_robot_base(motion_group: MotionGroup, x: float, y: float, z: float) -> None:
+    """Move a virtual robot's base (mounting) to the given world-frame position (mm)."""
+    coord_sys_id = f"base_{motion_group._controller_id}"
+    await motion_group._api_client.virtual_controller_api.set_virtual_controller_mounting(
+        cell=motion_group._cell,
+        controller=motion_group._controller_id,
+        motion_group=motion_group.id,
+        coordinate_system=api.models.CoordinateSystem(
+            coordinate_system=coord_sys_id,
+            name=coord_sys_id,
+            reference_coordinate_system="",  # world frame
+            position=api.models.Vector3d([x, y, z]),
+            orientation=api.models.Orientation([0.0, 0.0, 0.0]),
+            orientation_type=api.models.OrientationType.ROTATION_VECTOR,
+        ),
+    )
+
+
+def _max_joint_accelerations(
+    description: api.models.MotionGroupDescription,
+) -> tuple[float, ...]:
+    """Return the per-joint maximum accelerations from the motion group description."""
+    auto_limits = description.operation_limits.auto_limits if description.operation_limits else None
+    joints = auto_limits.joints if auto_limits else None
+    if not joints:
+        raise ValueError("Motion group description has no auto joint limits")
+    return tuple(j.acceleration or 0.0 for j in joints)
+
+
+async def reset_robot(motion_group: MotionGroup, tcp: str, label: str) -> None:
+    description = await motion_group.get_description()
+    max_joint_accelerations = _max_joint_accelerations(description)
+    normal = MotionSettings(
+        tcp_velocity_limit=100,
+        joint_acceleration_limits=tuple(a * 0.5 for a in max_joint_accelerations),
+    )
+    print(f"[{label}] moving to start position...")
+    await motion_group.plan_and_execute(joint_ptp(START_JOINTS, settings=normal), tcp)
+    print(f"[{label}] done.")
+
+
+
+
+async def plan_multi_robot_rrt(ctx, 
+    motion_group_1: MotionGroup,
+    motion_group_2: MotionGroup,
+    tcp_1: str,
+    tcp_2: str,
+) -> api.models.MultiJointTrajectory | None:
+    """Plan collision-free, time-synchronized paths for both robots simultaneously.
+
+    The multi-motion-group RRT-Connect endpoint coordinates both arms in a shared
+    joint space, checking inter-robot collisions at every explored state. On success
+    it returns a single trajectory with shared timestamps so both robots move in a
+    temporally coordinated fashion.
+    """
+    # Fetch motion group setups and collision link chains for both robots in parallel
+    setup_1, setup_2, link_chain_1, link_chain_2 = await asyncio.gather(
+        motion_group_1.get_setup(tcp_name=tcp_1),
+        motion_group_2.get_setup(tcp_name=tcp_2),
+        motion_group_1.get_default_collision_link_chain(),
+        motion_group_2.get_default_collision_link_chain(),
+    )
+
+    request = api.models.MultiSearchCollisionFreeRequest(
+        motion_group_setups_by_motion_group_key=api.models.MotionGroupSetupDictionary({
+            motion_group_1.id: setup_1,
+            motion_group_2.id: setup_2,
+        }),
+        path_definitions_by_motion_group_key=api.models.JointPTPMotionDictionary({
+            motion_group_1.id: api.models.JointPTPMotion(
+                start_joint_position=api.models.DoubleArray(list(START_JOINTS)),
+                target_joint_position=api.models.DoubleArray(list(TARGET_JOINTS_1)),
+            ),
+            motion_group_2.id: api.models.JointPTPMotion(
+                start_joint_position=api.models.DoubleArray(list(START_JOINTS)),
+                target_joint_position=api.models.DoubleArray(list(TARGET_JOINTS_2)),
+            ),
+        }),
+        # Cross-group collision setup: each robot's link chain is checked against
+        # the other robot's links, providing robot-robot collision avoidance.
+        collision_setups=api.models.MultiCollisionSetupDictionary({
+            "world": api.models.MultiCollisionSetup(
+                collision_motion_groups_by_motion_group_key=api.models.CollisionMotionGroupDictionary({
+                    motion_group_1.id: api.models.CollisionMotionGroup(
+                        link_chain=link_chain_1,
+                        self_collision_detection=True,
+                    ),
+                    motion_group_2.id: api.models.CollisionMotionGroup(
+                        link_chain=link_chain_2,
+                        self_collision_detection=True,
+                    ),
+                }),
+            ),
+        }),
+        algorithm_settings=api.models.RRTConnectAlgorithm(
+            max_iterations=20000,
+            max_step_size=0.1,
+            apply_smoothing=True,
+            apply_blending=True,
+        ),
+    )
+
+    print("Planning collision-free paths for both robots simultaneously (RRT-Connect)...")
+    response = await motion_group_1._api_client.trajectory_planning_api.search_collision_free_multi_motion_group(
+        cell=motion_group_1._cell,
+        multi_search_collision_free_request=request,
+    )
+
+    if isinstance(response.response, api.models.PlanCollisionFreeFailedResponse | None):
+        print(f"ERROR: RRT planning failed — {response.response}")
+        return None
+
+    await log_multi_motion_group_trajectory(ctx.nova, response.response, request.motion_group_setups_by_motion_group_key, request.collision_setups)
+
+    return response.response
+
+
+async def execute_robot_from_multi_trajectory(
+    motion_group: MotionGroup,
+    multi_trajectory: api.models.MultiJointTrajectory,
+    tcp: str,
+    label: str,
+    count: int,
+    target_joints: tuple[float, ...],
+) -> None:
+    """Execute the pre-planned multi-robot trajectory."""
+    description = await motion_group.get_description()
+    max_joint_accelerations = _max_joint_accelerations(description)
+    fast = MotionSettings(
+        tcp_velocity_limit=250,
+        joint_acceleration_limits=max_joint_accelerations,
+    )
+
+    # Extract this robot's joint positions from the shared multi-trajectory
+    joint_positions = multi_trajectory.joint_positions_by_motion_group_key.root[motion_group.id].root
+    single_trajectory = api.models.JointTrajectory(
+        joint_positions=joint_positions,
+        times=multi_trajectory.times,
+        locations=multi_trajectory.locations,
+    )
+    # Actions represent the motion endpoints — used by Nova for viewer/movement controller
+    rrt_actions = [
+        joint_ptp(START_JOINTS, settings=fast),
+        joint_ptp(target_joints, settings=fast),
+    ]
+
+    print(f"[{label}] executing {count} RRT cycle(s) — trajectory: {multi_trajectory.times[-1]:.2f}s")
+    for i in range(count):
+        print(f"[{label}] movement {i + 1}/{count}")
+        await motion_group.execute(single_trajectory, tcp, actions=rrt_actions)
+        await asyncio.sleep(1)
+    print(f"[{label}] done.")
+
+
+@nova.program(
+    id="start_here_two_robots_rrt",
+    name="Start Here — Two Robots RRT",
+    viewer=nova.viewers.Rerun(),
+    preconditions=nova.ProgramPreconditions(
+        controllers=[
+            virtual_controller(
+                name="kuka-robot-1",
+                manufacturer=api.models.Manufacturer.KUKA,
+                type="kuka-kr16_r2010_2",
+            ),
+            virtual_controller(
+                name="kuka-robot-2",
+                manufacturer=api.models.Manufacturer.KUKA,
+                type="kuka-kr16_r2010_2",
+            ),
+        ],
+        cleanup_controllers=False,
+    ),
+)
+async def start(
+    ctx: nova.ProgramContext,
+    count: int = Field(
+        default=1, ge=1, le=10, description="The number of times to repeat the movement"
+    ),
+):
+    
+    """Move both robots to the safe neutral start position."""
+    cell = ctx.cell
+
+    controller_1 = await cell.controller("kuka-robot-1")
+    controller_2 = await cell.controller("kuka-robot-2")
+    motion_group_1 = controller_1[0]
+    motion_group_2 = controller_2[0]
+
+    print("Positioning robots 1m apart...")
+    await asyncio.gather(
+        set_robot_base(motion_group_1, x=0, y=0, z=0),
+        set_robot_base(motion_group_2, x=0, y=ROBOT_SEPARATION_MM, z=0),
+    )
+    await asyncio.sleep(5)
+
+    tcp_names_1, tcp_names_2 = await asyncio.gather(
+        motion_group_1.tcp_names(),
+        motion_group_2.tcp_names(),
+    )
+    tcp_1, tcp_2 = tcp_names_1[0], tcp_names_2[0]
+
+    await asyncio.gather(
+        reset_robot(motion_group_1, tcp_1, "robot-1 (Y=0mm)"),
+        reset_robot(motion_group_2, tcp_2, "robot-2 (Y=1000mm)"),
+    )
+
+    print("Both robots reset to start position.")
+
+    """Control two robots 1m apart with coordinated, inter-robot collision-free RRT paths."""
+    cell = ctx.cell
+    cycle = ctx.cycle(extra={"app": "visual-studio-code"})
+
+    # Place robot 1 at world origin and robot 2 exactly 1 m away along Y
+    print("Positioning robots 1m apart...")
+    await asyncio.gather(
+        set_robot_base(motion_group_1, x=0, y=0, z=0),
+        set_robot_base(motion_group_2, x=0, y=ROBOT_SEPARATION_MM, z=0),
+    )
+    # Give both virtual controllers time to restart with the new mounting
+    await asyncio.sleep(5)
+
+    tcp_names_1, tcp_names_2 = await asyncio.gather(
+        motion_group_1.tcp_names(),
+        motion_group_2.tcp_names(),
+    )
+    tcp_1, tcp_2 = tcp_names_1[0], tcp_names_2[0]
+
+    # Plan collision-free, time-synchronized paths for both robots at once
+    multi_trajectory = await plan_multi_robot_rrt(ctx,motion_group_1, motion_group_2, tcp_1, tcp_2)
+    if multi_trajectory is None:
+        print("Aborting: RRT planning failed.")
+        return
+
+    print(f"Planning successful! Trajectory duration: {multi_trajectory.times[-1]:.2f}s")
+
+    await cycle.start()
+
+    await asyncio.gather(
+        execute_robot_from_multi_trajectory(
+            motion_group_1, multi_trajectory, tcp_1, "robot-1 (Y=0mm)", count, TARGET_JOINTS_1
+        ),
+        execute_robot_from_multi_trajectory(
+            motion_group_2, multi_trajectory, tcp_2, "robot-2 (Y=1000mm)", count, TARGET_JOINTS_2
+        ),
+    )
+
+    await cycle.finish()
+    print("Both robots completed!")
+
+
+if __name__ == "__main__":
+    run_program(start)

--- a/examples/start_here_two_robots_rrt.py
+++ b/examples/start_here_two_robots_rrt.py
@@ -18,7 +18,6 @@ import asyncio
 
 from pydantic import Field
 
-import nova
 from nova import api, run_program
 from nova.actions import joint_ptp
 from nova.cell import virtual_controller
@@ -36,7 +35,7 @@ START_JOINTS = (0.0, -1.0, 1.0, 0.0, 0.5, 0.0)
 TARGET_JOINTS_1 = (1.5708, -1.0, 1.0, 0.0, 0.5, 0.0)   # robot 1 → toward +Y
 TARGET_JOINTS_2 = (-1.5708, -1.0, 1.0, 0.0, 0.5, 0.0)  # robot 2 → toward -Y
 
-ROBOT_SEPARATION_MM = 1000.0
+# ROBOT_SEPARATION_MM defined above
 
 
 async def set_robot_base(motion_group: MotionGroup, x: float, y: float, z: float) -> None:
@@ -148,7 +147,9 @@ async def plan_multi_robot_rrt(ctx,
         multi_search_collision_free_request=request,
     )
 
-    if isinstance(response.response, api.models.PlanCollisionFreeFailedResponse | None):
+    if response.response is None or isinstance(
+        response.response, api.models.PlanCollisionFreeFailedResponse
+    ):
         print(f"ERROR: RRT planning failed — {response.response}")
         return None
 
@@ -250,7 +251,6 @@ async def start(
     print("Both robots reset to start position.")
 
     """Control two robots 1m apart with coordinated, inter-robot collision-free RRT paths."""
-    cell = ctx.cell
     cycle = ctx.cycle(extra={"app": "visual-studio-code"})
 
     # Place robot 1 at world origin and robot 2 exactly 1 m away along Y

--- a/examples/start_here_two_robots_rrt.py
+++ b/examples/start_here_two_robots_rrt.py
@@ -33,9 +33,8 @@ START_JOINTS = (0.0, -1.0, 1.0, 0.0, 0.5, 0.0)
 # Robot 1 (at Y=0) swings J1 to +π/2 → arm extends toward +Y, into robot 2's space.
 # Robot 2 (at Y=1000mm) swings J1 to -π/2 → arm extends toward -Y, into robot 1's space.
 # Without collision avoidance both TCPs would meet at the midpoint (~Y=500mm).
-TARGET_JOINTS_1 = (1.5708, -1.0, 1.0, 0.0, 0.5, 0.0)   # robot 1 → toward +Y
+TARGET_JOINTS_1 = (1.5708, -1.0, 1.0, 0.0, 0.5, 0.0)  # robot 1 → toward +Y
 TARGET_JOINTS_2 = (-1.5708, -1.0, 1.0, 0.0, 0.5, 0.0)  # robot 2 → toward -Y
-
 
 
 async def set_robot_base(motion_group: MotionGroup, x: float, y: float, z: float) -> None:
@@ -56,9 +55,7 @@ async def set_robot_base(motion_group: MotionGroup, x: float, y: float, z: float
     )
 
 
-def _max_joint_accelerations(
-    description: api.models.MotionGroupDescription,
-) -> tuple[float, ...]:
+def _max_joint_accelerations(description: api.models.MotionGroupDescription) -> tuple[float, ...]:
     """Return the per-joint maximum accelerations from the motion group description."""
     auto_limits = description.operation_limits.auto_limits if description.operation_limits else None
     joints = auto_limits.joints if auto_limits else None
@@ -79,13 +76,8 @@ async def reset_robot(motion_group: MotionGroup, tcp: str, label: str) -> None:
     print(f"[{label}] done.")
 
 
-
-
-async def plan_multi_robot_rrt(ctx, 
-    motion_group_1: MotionGroup,
-    motion_group_2: MotionGroup,
-    tcp_1: str,
-    tcp_2: str,
+async def plan_multi_robot_rrt(
+    ctx, motion_group_1: MotionGroup, motion_group_2: MotionGroup, tcp_1: str, tcp_2: str
 ) -> api.models.MultiJointTrajectory | None:
     """Plan collision-free, time-synchronized paths for both robots simultaneously.
 
@@ -103,48 +95,47 @@ async def plan_multi_robot_rrt(ctx,
     )
 
     request = api.models.MultiSearchCollisionFreeRequest(
-        motion_group_setups_by_motion_group_key=api.models.MotionGroupSetupDictionary({
-            motion_group_1.id: setup_1,
-            motion_group_2.id: setup_2,
-        }),
-        path_definitions_by_motion_group_key=api.models.JointPTPMotionDictionary({
-            motion_group_1.id: api.models.JointPTPMotion(
-                start_joint_position=api.models.DoubleArray(list(START_JOINTS)),
-                target_joint_position=api.models.DoubleArray(list(TARGET_JOINTS_1)),
-            ),
-            motion_group_2.id: api.models.JointPTPMotion(
-                start_joint_position=api.models.DoubleArray(list(START_JOINTS)),
-                target_joint_position=api.models.DoubleArray(list(TARGET_JOINTS_2)),
-            ),
-        }),
+        motion_group_setups_by_motion_group_key=api.models.MotionGroupSetupDictionary(
+            {motion_group_1.id: setup_1, motion_group_2.id: setup_2}
+        ),
+        path_definitions_by_motion_group_key=api.models.JointPTPMotionDictionary(
+            {
+                motion_group_1.id: api.models.JointPTPMotion(
+                    start_joint_position=api.models.DoubleArray(list(START_JOINTS)),
+                    target_joint_position=api.models.DoubleArray(list(TARGET_JOINTS_1)),
+                ),
+                motion_group_2.id: api.models.JointPTPMotion(
+                    start_joint_position=api.models.DoubleArray(list(START_JOINTS)),
+                    target_joint_position=api.models.DoubleArray(list(TARGET_JOINTS_2)),
+                ),
+            }
+        ),
         # Cross-group collision setup: each robot's link chain is checked against
         # the other robot's links, providing robot-robot collision avoidance.
-        collision_setups=api.models.MultiCollisionSetupDictionary({
-            "world": api.models.MultiCollisionSetup(
-                collision_motion_groups_by_motion_group_key=api.models.CollisionMotionGroupDictionary({
-                    motion_group_1.id: api.models.CollisionMotionGroup(
-                        link_chain=link_chain_1,
-                        self_collision_detection=True,
-                    ),
-                    motion_group_2.id: api.models.CollisionMotionGroup(
-                        link_chain=link_chain_2,
-                        self_collision_detection=True,
-                    ),
-                }),
-            ),
-        }),
+        collision_setups=api.models.MultiCollisionSetupDictionary(
+            {
+                "world": api.models.MultiCollisionSetup(
+                    collision_motion_groups_by_motion_group_key=api.models.CollisionMotionGroupDictionary(
+                        {
+                            motion_group_1.id: api.models.CollisionMotionGroup(
+                                link_chain=link_chain_1, self_collision_detection=True
+                            ),
+                            motion_group_2.id: api.models.CollisionMotionGroup(
+                                link_chain=link_chain_2, self_collision_detection=True
+                            ),
+                        }
+                    )
+                )
+            }
+        ),
         algorithm_settings=api.models.RRTConnectAlgorithm(
-            max_iterations=20000,
-            max_step_size=0.1,
-            apply_smoothing=True,
-            apply_blending=True,
+            max_iterations=20000, max_step_size=0.1, apply_smoothing=True, apply_blending=True
         ),
     )
 
     print("Planning collision-free paths for both robots simultaneously (RRT-Connect)...")
     response = await motion_group_1._api_client.trajectory_planning_api.search_collision_free_multi_motion_group(
-        cell=motion_group_1._cell,
-        multi_search_collision_free_request=request,
+        cell=motion_group_1._cell, multi_search_collision_free_request=request
     )
 
     if response.response is None or isinstance(
@@ -153,7 +144,12 @@ async def plan_multi_robot_rrt(ctx,
         print(f"ERROR: RRT planning failed — {response.response}")
         return None
 
-    await log_multi_motion_group_trajectory(ctx.nova, response.response, request.motion_group_setups_by_motion_group_key, request.collision_setups)
+    await log_multi_motion_group_trajectory(
+        ctx.nova,
+        response.response,
+        request.motion_group_setups_by_motion_group_key,
+        request.collision_setups,
+    )
 
     return response.response
 
@@ -169,25 +165,23 @@ async def execute_robot_from_multi_trajectory(
     """Execute the pre-planned multi-robot trajectory."""
     description = await motion_group.get_description()
     max_joint_accelerations = _max_joint_accelerations(description)
-    fast = MotionSettings(
-        tcp_velocity_limit=250,
-        joint_acceleration_limits=max_joint_accelerations,
-    )
+    fast = MotionSettings(tcp_velocity_limit=250, joint_acceleration_limits=max_joint_accelerations)
 
     # Extract this robot's joint positions from the shared multi-trajectory
-    joint_positions = multi_trajectory.joint_positions_by_motion_group_key.root[motion_group.id].root
+    joint_positions = multi_trajectory.joint_positions_by_motion_group_key.root[
+        motion_group.id
+    ].root
     single_trajectory = api.models.JointTrajectory(
         joint_positions=joint_positions,
         times=multi_trajectory.times,
         locations=multi_trajectory.locations,
     )
     # Actions represent the motion endpoints — used by Nova for viewer/movement controller
-    rrt_actions = [
-        joint_ptp(START_JOINTS, settings=fast),
-        joint_ptp(target_joints, settings=fast),
-    ]
+    rrt_actions = [joint_ptp(START_JOINTS, settings=fast), joint_ptp(target_joints, settings=fast)]
 
-    print(f"[{label}] executing {count} RRT cycle(s) — trajectory: {multi_trajectory.times[-1]:.2f}s")
+    print(
+        f"[{label}] executing {count} RRT cycle(s) — trajectory: {multi_trajectory.times[-1]:.2f}s"
+    )
     for i in range(count):
         print(f"[{label}] movement {i + 1}/{count}")
         await motion_group.execute(single_trajectory, tcp, actions=rrt_actions)
@@ -221,7 +215,7 @@ async def start(
         default=1, ge=1, le=10, description="The number of times to repeat the movement"
     ),
 ):
-    
+
     print("Move both robots to the safe neutral start position.")
     cell = ctx.cell
 
@@ -238,8 +232,7 @@ async def start(
     await asyncio.sleep(5)
 
     tcp_names_1, tcp_names_2 = await asyncio.gather(
-        motion_group_1.tcp_names(),
-        motion_group_2.tcp_names(),
+        motion_group_1.tcp_names(), motion_group_2.tcp_names()
     )
     tcp_1, tcp_2 = tcp_names_1[0], tcp_names_2[0]
 
@@ -254,7 +247,7 @@ async def start(
     cycle = ctx.cycle(extra={"app": "visual-studio-code"})
 
     # Plan collision-free, time-synchronized paths for both robots at once
-    multi_trajectory = await plan_multi_robot_rrt(ctx,motion_group_1, motion_group_2, tcp_1, tcp_2)
+    multi_trajectory = await plan_multi_robot_rrt(ctx, motion_group_1, motion_group_2, tcp_1, tcp_2)
     if multi_trajectory is None:
         print("Aborting: RRT planning failed.")
         return

--- a/examples/start_here_two_robots_rrt.py
+++ b/examples/start_here_two_robots_rrt.py
@@ -18,14 +18,15 @@ import asyncio
 
 from pydantic import Field
 
+import nova
 from nova import api, run_program
 from nova.actions import joint_ptp
 from nova.cell import virtual_controller
 from nova.cell.motion_group import MotionGroup
 from nova.types import MotionSettings
 from nova_rerun_bridge.trajectory import log_multi_motion_group_trajectory
-ROBOT_SEPARATION_MM = 1000.0
 
+ROBOT_SEPARATION_MM = 1000.0
 # Safe neutral start: both arms point in +X, away from each other.
 START_JOINTS = (0.0, -1.0, 1.0, 0.0, 0.5, 0.0)
 
@@ -35,7 +36,6 @@ START_JOINTS = (0.0, -1.0, 1.0, 0.0, 0.5, 0.0)
 TARGET_JOINTS_1 = (1.5708, -1.0, 1.0, 0.0, 0.5, 0.0)   # robot 1 → toward +Y
 TARGET_JOINTS_2 = (-1.5708, -1.0, 1.0, 0.0, 0.5, 0.0)  # robot 2 → toward -Y
 
-# ROBOT_SEPARATION_MM defined above
 
 
 async def set_robot_base(motion_group: MotionGroup, x: float, y: float, z: float) -> None:
@@ -222,7 +222,7 @@ async def start(
     ),
 ):
     
-    """Move both robots to the safe neutral start position."""
+    print("Move both robots to the safe neutral start position.")
     cell = ctx.cell
 
     controller_1 = await cell.controller("kuka-robot-1")
@@ -250,23 +250,8 @@ async def start(
 
     print("Both robots reset to start position.")
 
-    """Control two robots 1m apart with coordinated, inter-robot collision-free RRT paths."""
+    print("Control two robots 1m apart with coordinated, inter-robot collision-free RRT paths.")
     cycle = ctx.cycle(extra={"app": "visual-studio-code"})
-
-    # Place robot 1 at world origin and robot 2 exactly 1 m away along Y
-    print("Positioning robots 1m apart...")
-    await asyncio.gather(
-        set_robot_base(motion_group_1, x=0, y=0, z=0),
-        set_robot_base(motion_group_2, x=0, y=ROBOT_SEPARATION_MM, z=0),
-    )
-    # Give both virtual controllers time to restart with the new mounting
-    await asyncio.sleep(5)
-
-    tcp_names_1, tcp_names_2 = await asyncio.gather(
-        motion_group_1.tcp_names(),
-        motion_group_2.tcp_names(),
-    )
-    tcp_1, tcp_2 = tcp_names_1[0], tcp_names_2[0]
 
     # Plan collision-free, time-synchronized paths for both robots at once
     multi_trajectory = await plan_multi_robot_rrt(ctx,motion_group_1, motion_group_2, tcp_1, tcp_2)

--- a/nova_rerun_bridge/robot_visualizer.py
+++ b/nova_rerun_bridge/robot_visualizer.py
@@ -193,6 +193,29 @@ class RobotVisualizer:
             transforms.append(accumulated.copy())
         return transforms
 
+    def compute_flange_pose(self, joint_positions: list[float]) -> Pose:
+        """Calculate the flange pose for a given joint position.
+
+        Uses forward kinematics to obtain the final (flange) frame transform and
+        converts it into a :class:`Pose` with rotation-vector orientation.
+
+        :param joint_positions: Joint values (in radians) for each joint.
+        :return: The flange pose relative to the robot base.
+        """
+        flange_transform = self.compute_forward_kinematics(joint_positions)[-1]
+        translation = flange_transform[:3, 3]
+        rotation_vector = Rotation.from_matrix(flange_transform[:3, :3]).as_rotvec()
+        return Pose(
+            (
+                float(translation[0]),
+                float(translation[1]),
+                float(translation[2]),
+                float(rotation_vector[0]),
+                float(rotation_vector[1]),
+                float(rotation_vector[2]),
+            )
+        )
+
     def rotation_matrix_to_axis_angle(self, Rm):
         """Derive an axis-angle representation while being resilient to scaling/noise."""
         try:

--- a/nova_rerun_bridge/trajectory.py
+++ b/nova_rerun_bridge/trajectory.py
@@ -81,7 +81,7 @@ async def log_motion(
     if dh_parameters is None:
         raise ValueError("DH parameters cannot be None")
 
-    tcp_offset = motion_group_setup.tcp_offset or api.models.Pose(
+    tcp_offset = getattr(motion_group_setup, "tcp_offset", None) or api.models.Pose(
         position=api.models.Vector3d([0, 0, 0]),
         orientation=api.models.RotationVector([0, 0, 0]),
     )
@@ -116,21 +116,21 @@ async def _log_motion(
     show_collision_tool: bool = True,
     show_safety_link_chain: bool = True,
 ):
-    """
-    Process a single motion for visualization from already-resolved motion group data.
+    """Process a single motion for visualization from already-resolved motion group data.
 
     Args:
-        trajectory: Joint trajectory to log
-        tcp: TCP to log
-        motion_group: Motion group to log
-        motion_group_setup: Resolved motion group setup
-        motion_group_model: Resolved motion group model
-        motion_group_description: Resolved motion group description
-        collision_setups: Collision setups to log [setup_name: collision_setup]
-        time_offset: Time offset for visualization
-        tool_asset: Optional tool asset file path
-        show_collision_link_chain: Whether to show collision geometry
-        show_safety_link_chain: Whether to show safety geometry
+        trajectory: Joint trajectory to log.
+        tcp: TCP offset pose (flange -> TCP).
+        motion_group_id: Motion group identifier used for entity paths/caching.
+        motion_group_setup: Resolved motion group setup (mounting, model name, etc.).
+        dh_parameters: DH parameters for the motion group's kinematic model.
+        collision_setups: Collision setups to visualize (layer name -> setup).
+        safety_collision_setup: Collision setup providing safety link-chain/tool geometry.
+        time_offset: Time offset for visualization.
+        tool_asset: Optional tool asset file path.
+        show_collision_link_chain: Whether to show collision geometry.
+        show_collision_tool: Whether to show collision tool geometry.
+        show_safety_link_chain: Whether to show safety geometry.
     """
     motion_id = str(uuid.uuid4())
 
@@ -336,16 +336,16 @@ async def log_multi_motion_group_trajectory(
     motion_group_setups: api.models.MotionGroupSetupDictionary,
     collision_setups: api.models.MultiCollisionSetupDictionary | None = None,
 ):
-    """Visualize the result of a multi motion group collision-free search.
+    """Visualize a multi motion group collision-free trajectory.
 
-    Iterates over every motion group contained in the request, resolves the
-    kinematic model (DH parameters) for each motion group and logs the
-    corresponding joint trajectory from the response.
+    Iterates over motion groups in ``motion_group_setups`` and logs each group's
+    joint trajectory (from ``trajectory``) using resolved kinematic data.
 
     Args:
-        nova: Nova client used to resolve the kinematic models.
-        request: The multi search collision-free request.
-        response: The multi search collision-free response.
+        nova: Nova client used to resolve kinematic models.
+        trajectory: Multi motion-group joint trajectory with shared timestamps.
+        motion_group_setups: Motion group setups keyed by motion group id.
+        collision_setups: Optional collision setups used during planning.
     """
 
     joint_positions_by_key = trajectory.joint_positions_by_motion_group_key.root

--- a/nova_rerun_bridge/trajectory.py
+++ b/nova_rerun_bridge/trajectory.py
@@ -6,7 +6,7 @@ import numpy as np
 import rerun as rr
 from scipy.spatial.transform import Rotation as R
 
-from nova import MotionGroup, api
+from nova import Nova, MotionGroup, api
 from nova.types import Pose
 from nova_rerun_bridge.collision_scene import extract_link_chain_and_tcp
 from nova_rerun_bridge.consts import TIME_INTERVAL_NAME
@@ -73,86 +73,123 @@ async def log_motion(
         )
 
     motion_group_setup = await motion_group.get_setup(tcp)
-    motion_group_model = await motion_group.get_model()
+    safety_collision_setup = await motion_group.get_safety_collision_setup(tcp)
+
     motion_group_description = await motion_group.get_description()
-    motion_group_id = motion_group.id
+    
+    dh_parameters = motion_group_description.dh_parameters
+    if dh_parameters is None:
+        raise ValueError("DH parameters cannot be None")
+
+    tcp_offset = motion_group_setup.tcp_offset or api.models.Pose(
+        position=api.models.Vector3d([0, 0, 0]),
+        orientation=api.models.RotationVector([0, 0, 0]),
+    )
+
+    await _log_motion(
+        trajectory=trajectory,
+        tcp=tcp_offset,
+        motion_group_id=motion_group.id,
+        motion_group_setup=motion_group_setup,
+        dh_parameters=dh_parameters,
+        collision_setups=collision_setups,
+        safety_collision_setup=safety_collision_setup,
+        time_offset=time_offset,
+        tool_asset=tool_asset,
+        show_collision_link_chain=show_collision_link_chain,
+        show_collision_tool=show_collision_tool,
+        show_safety_link_chain=show_safety_link_chain,
+    )
+
+
+async def _log_motion(
+    trajectory: api.models.JointTrajectory,
+    tcp: api.models.Pose,
+    motion_group_id: str,
+    motion_group_setup: api.models.MotionGroupSetup,
+    dh_parameters:  list[api.models.DHParameter],
+    collision_setups: dict[str, api.models.CollisionSetup],
+    safety_collision_setup: api.models.CollisionSetup,
+    time_offset: float = 0,
+    tool_asset: str | None = None,
+    show_collision_link_chain: bool = False,
+    show_collision_tool: bool = True,
+    show_safety_link_chain: bool = True,
+):
+    """
+    Process a single motion for visualization from already-resolved motion group data.
+
+    Args:
+        trajectory: Joint trajectory to log
+        tcp: TCP to log
+        motion_group: Motion group to log
+        motion_group_setup: Resolved motion group setup
+        motion_group_model: Resolved motion group model
+        motion_group_description: Resolved motion group description
+        collision_setups: Collision setups to log [setup_name: collision_setup]
+        time_offset: Time offset for visualization
+        tool_asset: Optional tool asset file path
+        show_collision_link_chain: Whether to show collision geometry
+        show_safety_link_chain: Whether to show safety geometry
+    """
     motion_id = str(uuid.uuid4())
 
-    if motion_group_description.dh_parameters is not None:
-        motion_group_description.dh_parameters[0].a = (
-            motion_group_description.dh_parameters[0].a or 0
+    if dh_parameters is not None:
+        dh_parameters[0].a = (
+            dh_parameters[0].a or 0
         )
-        motion_group_description.dh_parameters[0].d = (
-            motion_group_description.dh_parameters[0].d or 0
+        dh_parameters[0].d = (
+            dh_parameters[0].d or 0
         )
-        motion_group_description.dh_parameters[0].alpha = (
-            motion_group_description.dh_parameters[0].alpha or 0
+        dh_parameters[0].alpha = (
+            dh_parameters[0].alpha or 0
         )
-        motion_group_description.dh_parameters[0].theta = (
-            motion_group_description.dh_parameters[0].theta or 0
-        )
-
-        motion_group_description.dh_parameters[1].a = (
-            motion_group_description.dh_parameters[1].a or 0
-        )
-        motion_group_description.dh_parameters[1].d = (
-            motion_group_description.dh_parameters[1].d or 0
-        )
-        motion_group_description.dh_parameters[1].alpha = (
-            motion_group_description.dh_parameters[1].alpha or 0
-        )
-        motion_group_description.dh_parameters[1].theta = (
-            motion_group_description.dh_parameters[1].theta or 0
+        dh_parameters[0].theta = (
+            dh_parameters[0].theta or 0
         )
 
-    if motion_group_description.dh_parameters is None:
+        dh_parameters[1].a = (
+            dh_parameters[1].a or 0
+        )
+        dh_parameters[1].d = (
+            dh_parameters[1].d or 0
+        )
+        dh_parameters[1].alpha = (
+            dh_parameters[1].alpha or 0
+        )
+        dh_parameters[1].theta = (
+            dh_parameters[1].theta or 0
+        )
+
+    if dh_parameters is None:
         raise ValueError("DH parameters cannot be None")
 
     mounting = motion_group_setup.mounting or api.models.Pose(
         position=api.models.Vector3d([0, 0, 0]), orientation=api.models.RotationVector([0, 0, 0])
     )
-    robot = DHRobot(dh_parameters=motion_group_description.dh_parameters, mounting=mounting)
-
-    # TODO: merge collision_setups
-    collision_link_chain, collision_tcp = extract_link_chain_and_tcp(
-        collision_setups=collision_setups
-    )
+    robot = DHRobot(dh_parameters=dh_parameters, mounting=mounting)
 
     rr.reset_time()
     rr.set_time(TIME_INTERVAL_NAME, duration=time_offset)
 
     # Get or create visualizer from cache
-    if motion_group.id not in _visualizer_cache:
+    if motion_group_id not in _visualizer_cache:
+        # TODO: merge collision_setups
         collision_link_chain, collision_tcp = extract_link_chain_and_tcp(
             collision_setups=collision_setups
         )
 
-        # Build tcp geometries
-        tcp_geometries: dict[str, api.models.Collider] = {}
-        if motion_group_description.safety_tool_colliders is not None:
-            tool_colliders = motion_group_description.safety_tool_colliders.get(tcp)
-            if tool_colliders is not None:
-                tcp_geometries = dict(tool_colliders.root)
+        safety_link_chain, safety_tcp_geometry = extract_link_chain_and_tcp(
+            collision_setups={"safety":safety_collision_setup}
+        )
 
-        # Build safety link chain
-        safety_link_chain: list[api.models.LinkChain] = []
-        if motion_group_description.safety_link_colliders is not None:
-            safety_link_chain = [
-                api.models.LinkChain(
-                    [
-                        api.models.Link(link.root)
-                        for link in motion_group_description.safety_link_colliders
-                    ]
-                )
-            ]
-
-        _visualizer_cache[motion_group.id] = RobotVisualizer(
+        _visualizer_cache[motion_group_id] = RobotVisualizer(
             robot=robot,
-            robot_model_geometries=safety_link_chain,
-            tcp_geometries=tcp_geometries,
+            robot_model_geometries=[safety_link_chain] if safety_link_chain else [],
+            tcp_geometries=safety_tcp_geometry.root if safety_tcp_geometry else {},
             static_transform=False,
             base_entity_path=f"motion/{motion_group_id}",
-            motion_group_model=motion_group_model,
+            motion_group_model=motion_group_setup.motion_group_model.root,
             collision_link_chain=collision_link_chain,
             collision_tcp=collision_tcp,
             show_collision_link_chain=show_collision_link_chain,
@@ -160,14 +197,14 @@ async def log_motion(
             show_safety_link_chain=show_safety_link_chain,
         )
 
-    visualizer = _visualizer_cache[motion_group.id]
+    visualizer = _visualizer_cache[motion_group_id]
 
     # Process trajectory points
     await log_trajectory(
         motion_id=motion_id,
         trajectory=trajectory,
-        tcp=tcp,
-        motion_group=motion_group,
+        tcp=Pose(tcp),
+        motion_group_id=motion_group_id,
         robot=robot,
         visualizer=visualizer,
         timer_offset=time_offset,
@@ -190,8 +227,8 @@ def get_times_column(
 async def log_trajectory(
     motion_id: str,
     trajectory: api.models.JointTrajectory,
-    tcp: str,
-    motion_group: MotionGroup,
+    tcp: Pose,
+    motion_group_id: str,
     robot: DHRobot,
     visualizer: RobotVisualizer,
     timer_offset: float,
@@ -204,11 +241,9 @@ async def log_trajectory(
     rr.set_time(TIME_INTERVAL_NAME, duration=timer_offset)
 
     times_column = get_times_column(trajectory, timer_offset)
-    motion_group_id = motion_group.id
 
     # TODO: calculate tcp pose from joint positions
-    joint_positions = [tuple(p.root) for p in trajectory.joint_positions]
-    tcp_poses = await motion_group.forward_kinematics(joints=joint_positions, tcp=tcp)
+    tcp_poses = [visualizer.compute_flange_pose(joints.root) @ tcp for joints in trajectory.joint_positions]
     positions = [[p.position.x, p.position.y, p.position.z] for p in tcp_poses]
 
     rr.log(
@@ -293,3 +328,107 @@ def continue_after_sync():
     effective_offset = _last_end_time + _last_offset
     _last_offset = 0
     _last_end_time = effective_offset
+
+
+async def log_multi_motion_group_trajectory(
+    nova: Nova,
+    trajectory: api.models.MultiJointTrajectory,
+    motion_group_setups: api.models.MotionGroupSetupDictionary,
+    collision_setups: api.models.MultiCollisionSetupDictionary | None = None,
+):
+    """Visualize the result of a multi motion group collision-free search.
+
+    Iterates over every motion group contained in the request, resolves the
+    kinematic model (DH parameters) for each motion group and logs the
+    corresponding joint trajectory from the response.
+
+    Args:
+        nova: Nova client used to resolve the kinematic models.
+        request: The multi search collision-free request.
+        response: The multi search collision-free response.
+    """
+
+    joint_positions_by_key = trajectory.joint_positions_by_motion_group_key.root
+
+    # Cache resolved kinematic models per motion group model to avoid duplicate calls.
+    dh_parameters_cache: dict[str, list[api.models.DHParameter]] = {}
+
+    for motion_group_id, motion_group_setup in motion_group_setups.root.items():
+        joint_positions = joint_positions_by_key.get(motion_group_id)
+        if joint_positions is None:
+            continue
+
+        # Resolve DH parameters for this motion group's model.
+        motion_group_model = motion_group_setup.motion_group_model.root
+        dh_parameters = dh_parameters_cache.get(motion_group_model)
+        if dh_parameters is None:
+            kinematic_model = (
+                await nova.api.motion_group_models_api.get_motion_group_kinematic_model(
+                    motion_group_model=motion_group_model
+                )
+            )
+            dh_parameters = kinematic_model.dh_parameters
+            if dh_parameters is None:
+                raise ValueError("DH parameters cannot be None")
+            dh_parameters_cache[motion_group_model] = dh_parameters
+
+        # Build a single JointTrajectory from the shared timestamps and this
+        # motion group's joint positions.
+        joint_trajectory = api.models.JointTrajectory(
+            joint_positions=list(joint_positions.root),
+            times=trajectory.times,
+            locations=trajectory.locations,
+        )
+
+        tcp = motion_group_setup.tcp_offset or api.models.Pose(
+            position=api.models.Vector3d([0, 0, 0]),
+            orientation=api.models.RotationVector([0, 0, 0]),
+        )
+
+        # Use the collision setups configured on the motion group as the safety
+        # collision setup (link chain / tool geometry).
+        setup_collision_setups: dict[str, api.models.CollisionSetup] = (
+            dict(motion_group_setup.collision_setups.root)
+            if motion_group_setup.collision_setups is not None
+            else {}
+        )
+        safety_collision_setup = (
+            next(iter(setup_collision_setups.values()))
+            if setup_collision_setups
+            else api.models.CollisionSetup()
+        )
+
+        # Build the detailed collision setups for this motion group from the
+        # request's collision setups. Each layer contributes this motion group's
+        # link-chain/tool colliders plus the static environment colliders.
+        collision_setups_flattened: dict[str, api.models.CollisionSetup] = {}
+        if collision_setups is not None:
+            for setup_name, multi_setup in collision_setups.root.items():
+                collision_motion_groups = (
+                    multi_setup.collision_motion_groups_by_motion_group_key.root
+                    if multi_setup.collision_motion_groups_by_motion_group_key is not None
+                    else {}
+                )
+                collision_motion_group = collision_motion_groups.get(motion_group_id)
+                collision_setups_flattened[f"{setup_name}_{motion_group_id}"] = api.models.CollisionSetup(
+                    link_chain=collision_motion_group.link_chain
+                    if collision_motion_group is not None
+                    else None,
+                    tool=collision_motion_group.tool
+                    if collision_motion_group is not None
+                    else None,
+                    colliders=multi_setup.colliders,
+                )
+
+        await _log_motion(
+            trajectory=joint_trajectory,
+            tcp=tcp,
+            motion_group_id=motion_group_id,
+            motion_group_setup=motion_group_setup,
+            dh_parameters=dh_parameters,
+            collision_setups=collision_setups_flattened,
+            safety_collision_setup=safety_collision_setup,
+            time_offset=0,
+            show_safety_link_chain=True,
+            show_collision_link_chain=True,
+        )

--- a/nova_rerun_bridge/trajectory.py
+++ b/nova_rerun_bridge/trajectory.py
@@ -6,7 +6,7 @@ import numpy as np
 import rerun as rr
 from scipy.spatial.transform import Rotation as R
 
-from nova import Nova, MotionGroup, api
+from nova import MotionGroup, Nova, api
 from nova.types import Pose
 from nova_rerun_bridge.collision_scene import extract_link_chain_and_tcp
 from nova_rerun_bridge.consts import TIME_INTERVAL_NAME

--- a/nova_rerun_bridge/trajectory.py
+++ b/nova_rerun_bridge/trajectory.py
@@ -76,12 +76,12 @@ async def log_motion(
     safety_collision_setup = await motion_group.get_safety_collision_setup(tcp)
 
     motion_group_description = await motion_group.get_description()
-    
+
     dh_parameters = motion_group_description.dh_parameters
     if dh_parameters is None:
         raise ValueError("DH parameters cannot be None")
 
-    tcp_offset = getattr(motion_group_setup, "tcp_offset", None) or api.models.Pose(
+    tcp_offset = motion_group_setup.tcp_offset or api.models.Pose(
         position=api.models.Vector3d([0, 0, 0]),
         orientation=api.models.RotationVector([0, 0, 0]),
     )

--- a/nova_rerun_bridge/trajectory.py
+++ b/nova_rerun_bridge/trajectory.py
@@ -82,8 +82,7 @@ async def log_motion(
         raise ValueError("DH parameters cannot be None")
 
     tcp_offset = motion_group_setup.tcp_offset or api.models.Pose(
-        position=api.models.Vector3d([0, 0, 0]),
-        orientation=api.models.RotationVector([0, 0, 0]),
+        position=api.models.Vector3d([0, 0, 0]), orientation=api.models.RotationVector([0, 0, 0])
     )
 
     await _log_motion(
@@ -107,7 +106,7 @@ async def _log_motion(
     tcp: api.models.Pose,
     motion_group_id: str,
     motion_group_setup: api.models.MotionGroupSetup,
-    dh_parameters:  list[api.models.DHParameter],
+    dh_parameters: list[api.models.DHParameter],
     collision_setups: dict[str, api.models.CollisionSetup],
     safety_collision_setup: api.models.CollisionSetup,
     time_offset: float = 0,
@@ -135,31 +134,15 @@ async def _log_motion(
     motion_id = str(uuid.uuid4())
 
     if dh_parameters is not None:
-        dh_parameters[0].a = (
-            dh_parameters[0].a or 0
-        )
-        dh_parameters[0].d = (
-            dh_parameters[0].d or 0
-        )
-        dh_parameters[0].alpha = (
-            dh_parameters[0].alpha or 0
-        )
-        dh_parameters[0].theta = (
-            dh_parameters[0].theta or 0
-        )
+        dh_parameters[0].a = dh_parameters[0].a or 0
+        dh_parameters[0].d = dh_parameters[0].d or 0
+        dh_parameters[0].alpha = dh_parameters[0].alpha or 0
+        dh_parameters[0].theta = dh_parameters[0].theta or 0
 
-        dh_parameters[1].a = (
-            dh_parameters[1].a or 0
-        )
-        dh_parameters[1].d = (
-            dh_parameters[1].d or 0
-        )
-        dh_parameters[1].alpha = (
-            dh_parameters[1].alpha or 0
-        )
-        dh_parameters[1].theta = (
-            dh_parameters[1].theta or 0
-        )
+        dh_parameters[1].a = dh_parameters[1].a or 0
+        dh_parameters[1].d = dh_parameters[1].d or 0
+        dh_parameters[1].alpha = dh_parameters[1].alpha or 0
+        dh_parameters[1].theta = dh_parameters[1].theta or 0
 
     if dh_parameters is None:
         raise ValueError("DH parameters cannot be None")
@@ -180,7 +163,7 @@ async def _log_motion(
         )
 
         safety_link_chain, safety_tcp_geometry = extract_link_chain_and_tcp(
-            collision_setups={"safety":safety_collision_setup}
+            collision_setups={"safety": safety_collision_setup}
         )
 
         _visualizer_cache[motion_group_id] = RobotVisualizer(
@@ -243,7 +226,9 @@ async def log_trajectory(
     times_column = get_times_column(trajectory, timer_offset)
 
     # TODO: calculate tcp pose from joint positions
-    tcp_poses = [visualizer.compute_flange_pose(joints.root) @ tcp for joints in trajectory.joint_positions]
+    tcp_poses = [
+        visualizer.compute_flange_pose(joints.root) @ tcp for joints in trajectory.joint_positions
+    ]
     positions = [[p.position.x, p.position.y, p.position.z] for p in tcp_poses]
 
     rr.log(
@@ -410,14 +395,16 @@ async def log_multi_motion_group_trajectory(
                     else {}
                 )
                 collision_motion_group = collision_motion_groups.get(motion_group_id)
-                collision_setups_flattened[f"{setup_name}_{motion_group_id}"] = api.models.CollisionSetup(
-                    link_chain=collision_motion_group.link_chain
-                    if collision_motion_group is not None
-                    else None,
-                    tool=collision_motion_group.tool
-                    if collision_motion_group is not None
-                    else None,
-                    colliders=multi_setup.colliders,
+                collision_setups_flattened[f"{setup_name}_{motion_group_id}"] = (
+                    api.models.CollisionSetup(
+                        link_chain=collision_motion_group.link_chain
+                        if collision_motion_group is not None
+                        else None,
+                        tool=collision_motion_group.tool
+                        if collision_motion_group is not None
+                        else None,
+                        colliders=multi_setup.colliders,
+                    )
                 )
 
         await _log_motion(


### PR DESCRIPTION
In this MR I'd like to introduce rerun logging for multi motion group trajectories mainly for the purpose of visualizing the result of search-collisoin-free-multi-motion-group. As there is currently no python sdk wrapper for this endpoint, I wrote the logging function based on API models. It is meant to be imported and manually called by the user as shown in the added example script.