### PR TITLE
fix(ci): create nova_rerun_bridge_app dir before mv in Docker build

### DIFF
--- a/.github/workflows/push_nova_rerun_bridge_image.yaml
+++ b/.github/workflows/push_nova_rerun_bridge_image.yaml
@@ -62,6 +62,7 @@ jobs:
           done
 
           # Move to final destination
+          mkdir -p nova_rerun_bridge/nova_rerun_bridge_app
           mv temp_build/* nova_rerun_bridge/nova_rerun_bridge_app/
           rm -rf temp_build
 


### PR DESCRIPTION
Add `mkdir -p nova_rerun_bridge/nova_rerun_bridge_app` before the `mv`.