### PR TITLE
fix(NDX-777): ignore non-motion actions instead of failing

### DIFF
--- a/nova/cell/movement_controller/trajectory_cursor.py
+++ b/nova/cell/movement_controller/trajectory_cursor.py
@@ -502,7 +502,19 @@ class TrajectoryCursor:
         """
         self.motion_id = motion_id
         self.joint_trajectory = joint_trajectory
-        self.actions = CombinedActions(items=actions) if actions is not None else None  # ty: ignore[invalid-argument-type]
+
+        # The planner only assigns trajectory location units to motion actions
+        # (see nova.actions.container.CombinedActions.to_motion_command), so the
+        # cursor's location-to-action mapping must also be motion-only.
+        # Non-motion actions (e.g. WriteAction) are kept on ``_raw_actions`` in
+        # their original order so future work can emit events or use them as
+        # execution-step boundaries without losing positional information.
+        # TODO: surface non-motion actions through the cursor's event API.
+        self._raw_actions: tuple[Action, ...] | None = (
+            tuple(actions) if actions is not None else None
+        )
+        motion_actions = [a for a in actions if a.is_motion()] if actions is not None else None
+        self.actions = CombinedActions(items=motion_actions) if motion_actions is not None else None  # ty: ignore[invalid-argument-type]
 
         if self.actions is not None:
             expected_end_location = len(self.actions)
@@ -510,7 +522,7 @@ class TrajectoryCursor:
             if abs(actual_end_location - expected_end_location) > 0.01:
                 raise ValueError(
                     f"Trajectory end location ({actual_end_location}) does not match "
-                    f"number of actions ({expected_end_location}). "
+                    f"number of motion actions ({expected_end_location}). "
                     f"Expected location to be approximately {expected_end_location}.0"
                 )
         self._pending_intent: Intent | None = None

--- a/nova/cell/movement_controller/trajectory_cursor.py
+++ b/nova/cell/movement_controller/trajectory_cursor.py
@@ -496,7 +496,10 @@ class TrajectoryCursor:
             motion_id: Unique identifier for this motion execution.
             motion_group_state_stream: Async stream of motion group state updates.
             joint_trajectory: The planned joint-space trajectory to execute.
-            actions: List of motion actions that make up the trajectory. Optional for location-based navigation.
+            actions: Actions that make up the trajectory. May contain a mix of
+                motion and non-motion actions (e.g. ``WriteAction``); only the
+                motion actions drive the cursor's location-to-action mapping.
+                Optional for location-based navigation.
             initial_location: Starting position on the trajectory (usually 0.0).
             detach_on_standstill: If True, automatically detach when robot stops.
         """
@@ -513,8 +516,14 @@ class TrajectoryCursor:
         self._raw_actions: tuple[Action, ...] | None = (
             tuple(actions) if actions is not None else None
         )
-        motion_actions = [a for a in actions if a.is_motion()] if actions is not None else None
-        self.actions = CombinedActions(items=motion_actions) if motion_actions is not None else None  # ty: ignore[invalid-argument-type]
+        # Delegate motion detection to CombinedActions.motions instead of
+        # re-implementing it here.
+        raw_combined = (
+            CombinedActions(items=self._raw_actions) if self._raw_actions is not None else None  # ty: ignore[invalid-argument-type]
+        )
+        self.actions = (
+            CombinedActions(items=tuple(raw_combined.motions)) if raw_combined is not None else None
+        )
 
         if self.actions is not None:
             expected_end_location = len(self.actions)

--- a/tests/cell/test_trajectory_cursor.py
+++ b/tests/cell/test_trajectory_cursor.py
@@ -1,5 +1,7 @@
 """Tests for TrajectoryCursor action index and location logic."""
 
+import asyncio
+import contextlib
 import json
 from unittest.mock import MagicMock
 
@@ -390,5 +392,9 @@ async def test_cursor_accepts_mixed_motion_and_non_motion_actions():
         # preserved so the follow-up work can emit events for them.
         assert cursor._raw_actions == tuple(actions)
     finally:
-        # Tear down the background init task started by __init__.
+        # Tear down the background init task started by __init__. Cancel +
+        # await so the task is fully reaped before the test exits (avoids
+        # "Task was destroyed but it is pending!" warnings).
         cursor._initialize_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await cursor._initialize_task

--- a/tests/cell/test_trajectory_cursor.py
+++ b/tests/cell/test_trajectory_cursor.py
@@ -312,3 +312,83 @@ def test_motion_event_source_spans_serialize():
     assert payload["current_action_source"] is not None
     assert payload["current_action_source"]["start_line"] is not None
     assert payload["current_action_source"] == event.current_action_source.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Non-motion actions in the incoming action list (Option B)
+# ---------------------------------------------------------------------------
+#
+# The planner only assigns trajectory location units to motion actions
+# (see nova.actions.container.CombinedActions.to_motion_command). When the
+# caller passes a mixed list (motions + WriteAction / WaitAction / ...), the
+# trajectory's end location matches the number of motions, not len(actions).
+#
+# The cursor must:
+#   1. not raise during construction,
+#   2. keep its motion-aligned indexing (self.actions only contains motions),
+#   3. preserve the original list (with non-motion actions in order) so that
+#      future work can emit events on traversal of non-motion actions.
+
+
+async def _silent_state_stream():
+    """An async stream that yields nothing and never completes."""
+    import asyncio as _asyncio
+
+    await _asyncio.Future()
+    yield  # pragma: no cover
+
+
+def _trajectory_for_motion_count(num_motions: int):
+    """Minimal real JointTrajectory whose end location matches num_motions."""
+    from nova import api as _api
+
+    n = num_motions + 1
+    return _api.models.JointTrajectory(
+        joint_positions=[_api.models.Joints([0.0] * 6)] * n,
+        times=[float(i) for i in range(n)],
+        locations=[_api.models.Location(root=float(i)) for i in range(n)],
+    )
+
+
+async def test_cursor_accepts_mixed_motion_and_non_motion_actions():
+    """Cursor construction must tolerate non-motion actions in the action list.
+
+    Per the planner contract, joint_trajectory.locations[-1] equals the number
+    of motion actions, not the total number of actions. The cursor must filter
+    non-motion actions from its motion-aligned ``self.actions`` while keeping
+    the original list available for future event-emission work.
+    """
+    from nova.actions.io import io_write
+
+    motions = [lin(Pose((i * 100.0, 0, 0, 0, 0, 0))) for i in range(3)]
+    write = io_write(key="digital_out[0]", value=True)
+    # Interleave so order matters for the preserved raw list.
+    actions = [motions[0], write, motions[1], motions[2]]
+
+    trajectory = _trajectory_for_motion_count(num_motions=3)
+
+    # Construction must not raise the length-mismatch ValueError.
+    cursor = TrajectoryCursor(
+        motion_id="traj-mixed",
+        motion_group_state_stream=_silent_state_stream(),
+        joint_trajectory=trajectory,
+        actions=actions,
+        initial_location=0.0,
+    )
+    try:
+        # The motion-aligned action list drives indexing and must contain
+        # only the motion actions.
+        assert cursor.actions is not None
+        assert len(cursor.actions) == 3
+        assert list(cursor.actions) == motions
+
+        # Location-to-action indexing stays consistent with the trajectory.
+        assert cursor.end_location == 3.0
+        assert cursor.current_action is motions[0]
+
+        # The original action list (with non-motion entries, in order) is
+        # preserved so the follow-up work can emit events for them.
+        assert cursor._raw_actions == tuple(actions)
+    finally:
+        # Tear down the background init task started by __init__.
+        cursor._initialize_task.cancel()


### PR DESCRIPTION
## Problem

The trajectory planner assigns location units only to motion actions. When the caller passes a mixed action list (motions + `WriteAction` / `WaitAction` / etc.) the cursor's constructor compared `len(actions)` against `joint_trajectory.locations[-1]` and raised:

```
ValueError: Trajectory end location (3.0) does not match number of actions (4)
```

## Fix (Option B)

- **`self._raw_actions`** — the full caller-supplied list is stored verbatim (tuple, private). This preserves ordering and non-motion entries for future work (emitting events on traversal, using them as execution-step boundaries).
- **`self.actions`** — now built from a motion-only filter (`a.is_motion()`), keeping the 1:1 alignment between integer trajectory locations and action indices that the cursor's indexing logic requires.

No call sites changed — every consumer of `self.actions` already assumed motion-aligned indexing.

## Testing

Added `test_cursor_accepts_mixed_motion_and_non_motion_actions` (TDD: failing first, then green). Verifies:
1. Construction does not raise.
2. `self.actions` contains only the motion actions.
3. `self._raw_actions` preserves the original list in order.