### PR TITLE
feat: made novax usage easier e.g. autoscanning

### DIFF
--- a/examples/your-nova-app/README.md
+++ b/examples/your-nova-app/README.md
@@ -13,6 +13,16 @@ Use the following steps for development:
     * access the docs on `http://localhost:8000/docs`
 * build, push and install the app with `nova app install`
 
+## quick run (no app needed)
+
+To iterate on a program from dev without scaffolding an app, just point the
+`novax` CLI at any file with `@nova.program` functions — they auto-register:
+
+```bash
+uv run novax run your_nova_app/start_here.py --cell cell
+```
+
+
 ## formatting
 
 ```bash

--- a/examples/your-nova-app/your_nova_app/register_programs.py
+++ b/examples/your-nova-app/your_nova_app/register_programs.py
@@ -22,9 +22,7 @@ app = FastAPI(
 # Include the programs router and auto-register every @nova.program in this app.
 # Importing start_here above is enough — programs register themselves on import.
 # See https://github.com/wandelbotsgmbh/wandelbots-nova/blob/main/README.md#novax for more information
-novax = Novax()
-novax.include_programs_router(app)
-novax.auto_register()
+novax = Novax(app)
 
 app.add_middleware(
     CORSMiddleware,

--- a/examples/your-nova-app/your_nova_app/register_programs.py
+++ b/examples/your-nova-app/your_nova_app/register_programs.py
@@ -1,10 +1,9 @@
 import uvicorn
+import your_nova_app.start_here  # noqa: F401  (import registers the program)
 from decouple import config
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse
-from your_nova_app.start_here import \
-    start  # noqa: F401  (import registers the program)
 
 from nova import Novax
 

--- a/examples/your-nova-app/your_nova_app/register_programs.py
+++ b/examples/your-nova-app/your_nova_app/register_programs.py
@@ -3,7 +3,7 @@ from decouple import config
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse
-from novax import Novax
+from nova import Novax
 
 from your_nova_app.start_here import start  # noqa: F401  (import registers the program)
 

--- a/examples/your-nova-app/your_nova_app/register_programs.py
+++ b/examples/your-nova-app/your_nova_app/register_programs.py
@@ -5,7 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse
 from novax import Novax
 
-from your_nova_app.start_here import start
+from your_nova_app.start_here import start  # noqa: F401  (import registers the program)
 
 CELL_ID = config("CELL_ID", default="cell", cast=str)
 BASE_PATH = config("BASE_PATH", default="", cast=str)
@@ -19,11 +19,12 @@ app = FastAPI(
     root_path=BASE_PATH,
 )
 
-# Include the programs router and register the fist program
+# Include the programs router and auto-register every @nova.program in this app.
+# Importing start_here above is enough — programs register themselves on import.
 # See https://github.com/wandelbotsgmbh/wandelbots-nova/blob/main/README.md#novax for more information
 novax = Novax()
 novax.include_programs_router(app)
-novax.register_program(start)
+novax.auto_register()
 
 app.add_middleware(
     CORSMiddleware,
@@ -79,6 +80,7 @@ def main(host: str = "0.0.0.0", port: int = 3000):
         proxy_headers=True,
         forwarded_allow_ips="*",
     )
+
 
 if __name__ == "__main__":
     main()

--- a/examples/your-nova-app/your_nova_app/register_programs.py
+++ b/examples/your-nova-app/your_nova_app/register_programs.py
@@ -3,9 +3,10 @@ from decouple import config
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse
-from nova import Novax
+from your_nova_app.start_here import \
+    start  # noqa: F401  (import registers the program)
 
-from your_nova_app.start_here import start  # noqa: F401  (import registers the program)
+from nova import Novax
 
 CELL_ID = config("CELL_ID", default="cell", cast=str)
 BASE_PATH = config("BASE_PATH", default="", cast=str)

--- a/nova/__init__.py
+++ b/nova/__init__.py
@@ -1,4 +1,6 @@
 # Import api, types, and actions modules
+from typing import TYPE_CHECKING
+
 from nova import actions, api, exceptions, types, viewers
 from nova.cell import Cell, Controller, MotionGroup
 from nova.config import NovaConfig
@@ -6,6 +8,12 @@ from nova.core.nova import Nova
 from nova.logging import logger
 from nova.program import ProgramContext, ProgramPreconditions, program, run_program
 from nova.version import version
+
+if TYPE_CHECKING:
+    # Declared for static analysis / __all__ export checks only. At runtime
+    # `Novax` is provided lazily via __getattr__ so the optional `novax` extra
+    # stays optional; defining it at module scope would shadow __getattr__.
+    from novax import Novax
 
 __version__ = version
 

--- a/nova/__init__.py
+++ b/nova/__init__.py
@@ -36,13 +36,8 @@ def __getattr__(name: str):
     # `from nova import Novax` only when it is installed. Kept lazy to avoid a
     # hard dependency on FastAPI in the core SDK.
     if name == "Novax":
-        try:
-            from novax import Novax
-        except ImportError as exc:
-            raise ImportError(
-                "Novax requires the optional 'novax' extra. Install it with "
-                "`pip install wandelbots-nova[novax]`."
-            ) from exc
+        from novax import Novax
+
         return Novax
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/nova/__init__.py
+++ b/nova/__init__.py
@@ -26,8 +26,25 @@ __all__ = [
     "ProgramContext",
     "get_current_program_context",
     "ProgramPreconditions",
+    "Novax",
     "__version__",
 ]
+
+
+def __getattr__(name: str):
+    # Lazily expose Novax from the optional `novax` extra so users can do
+    # `from nova import Novax` only when it is installed. Kept lazy to avoid a
+    # hard dependency on FastAPI in the core SDK.
+    if name == "Novax":
+        try:
+            from novax import Novax
+        except ImportError as exc:
+            raise ImportError(
+                "Novax requires the optional 'novax' extra. Install it with "
+                "`pip install wandelbots-nova[novax]`."
+            ) from exc
+        return Novax
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def get_current_program_context() -> ProgramContext | None:

--- a/nova/program/__init__.py
+++ b/nova/program/__init__.py
@@ -1,4 +1,5 @@
 from nova.program.function import Program, ProgramContext, ProgramPreconditions, program
+from nova.program.registry import clear_registry, get_registered_programs
 from nova.program.runner import ProgramRunner, PythonProgramRunner, run_program
 
 __all__ = [
@@ -9,4 +10,6 @@ __all__ = [
     "Program",
     "ProgramContext",
     "run_program",
+    "get_registered_programs",
+    "clear_registry",
 ]

--- a/nova/program/function.py
+++ b/nova/program/function.py
@@ -36,6 +36,7 @@ from pydantic.json_schema import JsonSchemaValue, models_json_schema
 
 from nova import Nova, api
 
+from . import registry
 from .context import ProgramContext, current_program_context_var
 
 logger = logging.getLogger(__name__)
@@ -460,6 +461,7 @@ def program(
             program_obj.description = description
         program_obj.preconditions = preconditions
         program_obj._viewer = viewer
+        registry.register(program_obj)
         return program_obj
 
     # If used as @nova.program(), return the decorator.

--- a/nova/program/registry.py
+++ b/nova/program/registry.py
@@ -1,0 +1,31 @@
+"""Global registry of programs created via the ``@nova.program`` decorator.
+
+Every program created with :func:`nova.program` is automatically added here so that
+tools like Novax can discover all programs in a module without explicit registration
+calls. The registry is keyed by ``program_id``; re-decorating with the same id
+replaces the previous entry.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nova.program.function import Program
+
+_REGISTRY: dict[str, "Program"] = {}
+
+
+def register(program: "Program") -> None:
+    """Add (or replace) a program in the global registry."""
+    _REGISTRY[program.program_id] = program
+
+
+def get_registered_programs() -> list["Program"]:
+    """Return all programs registered via ``@nova.program``."""
+    return list(_REGISTRY.values())
+
+
+def clear_registry() -> None:
+    """Remove all programs from the registry (useful for tests)."""
+    _REGISTRY.clear()

--- a/novax/__init__.py
+++ b/novax/__init__.py
@@ -1,3 +1,16 @@
-from novax.novax import Novax
+try:
+    from novax.novax import Novax
+except ImportError as exc:
+    # Only translate failures caused by the missing optional dependencies; let
+    # any other ImportError (a real bug) surface unchanged.
+    if exc.name in {"fastapi", "uvicorn", "decouple", "starlette"}:
+        raise ImportError(
+            "The 'novax' package requires the optional 'novax' extra, which is not installed.\n"
+            "Install it with one of:\n"
+            "  uv sync --extra novax\n"
+            "  uv pip install 'wandelbots-nova[novax]'\n"
+            "  pip install 'wandelbots-nova[novax]'"
+        ) from exc
+    raise
 
 __all__ = ["Novax"]

--- a/novax/cli.py
+++ b/novax/cli.py
@@ -1,0 +1,45 @@
+"""Command-line entry point for serving Novax programs during development.
+
+Usage:
+    novax run <module-or-file> [--host HOST] [--port PORT] [--cell CELL]
+
+Imports the given module/file (which defines ``@nova.program`` functions), registers
+all of them and serves them against a live NOVA — no Docker build required.
+"""
+
+import argparse
+import os
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="novax", description="Serve NOVA programs locally")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run = sub.add_parser("run", help="Import programs and serve them locally")
+    run.add_argument("target", help="Dotted module path or path to a .py file with programs")
+    run.add_argument("--host", default="0.0.0.0", help="Host to bind (default: 0.0.0.0)")
+    run.add_argument("--port", type=int, default=3000, help="Port to bind (default: 3000)")
+    run.add_argument("--cell", default=None, help="NOVA cell to register programs in")
+    run.add_argument(
+        "--public-url",
+        default=None,
+        help="Public base URL (e.g. ngrok) NOVA should route start/stop to",
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "run":
+        if args.cell:
+            os.environ["CELL_NAME"] = args.cell
+        if args.public_url:
+            os.environ["PROGRAM_ENDPOINT_URL"] = args.public_url
+        # Import lazily so CELL_NAME is set before novax.config reads it.
+        from novax.novax import Novax, _import_module
+
+        _import_module(args.target)
+        novax = Novax()
+        novax.serve(host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/novax/cli.py
+++ b/novax/cli.py
@@ -20,19 +20,12 @@ def main() -> None:
     run.add_argument("--host", default="0.0.0.0", help="Host to bind (default: 0.0.0.0)")
     run.add_argument("--port", type=int, default=3000, help="Port to bind (default: 3000)")
     run.add_argument("--cell", default=None, help="NOVA cell to register programs in")
-    run.add_argument(
-        "--public-url",
-        default=None,
-        help="Public base URL (e.g. ngrok) NOVA should route start/stop to",
-    )
 
     args = parser.parse_args()
 
     if args.command == "run":
         if args.cell:
             os.environ["CELL_NAME"] = args.cell
-        if args.public_url:
-            os.environ["PROGRAM_ENDPOINT_URL"] = args.public_url
         # Import lazily so CELL_NAME is set before novax.config reads it.
         from novax.novax import Novax, _import_module
 

--- a/novax/cli.py
+++ b/novax/cli.py
@@ -27,7 +27,10 @@ def main() -> None:
         if args.cell:
             os.environ["CELL_NAME"] = args.cell
         # Import lazily so CELL_NAME is set before novax.config reads it.
-        from novax.novax import Novax, _import_module
+        # Import Novax via `nova` so a missing `novax` extra surfaces the clear
+        # install hint from novax/__init__.py instead of a raw ModuleNotFoundError.
+        from nova import Novax
+        from novax.novax import _import_module
 
         _import_module(args.target)
         novax = Novax()

--- a/novax/config.py
+++ b/novax/config.py
@@ -9,3 +9,8 @@ logger.info(f"Extracted app name '{APP_NAME}' from BASE_PATH '{BASE_PATH}'")
 
 # Create nats programs bucket name
 CELL_NAME = config("CELL_NAME", default="")
+
+# Optional public base URL (e.g. an ngrok tunnel) the NOVA service-manager should
+# route start/stop requests to. Used for local dev so programs show up and run in
+# remote NOVA without installing the app.
+PROGRAM_ENDPOINT_URL = config("PROGRAM_ENDPOINT_URL", default="")

--- a/novax/config.py
+++ b/novax/config.py
@@ -9,8 +9,3 @@ logger.info(f"Extracted app name '{APP_NAME}' from BASE_PATH '{BASE_PATH}'")
 
 # Create nats programs bucket name
 CELL_NAME = config("CELL_NAME", default="")
-
-# Optional public base URL (e.g. an ngrok tunnel) the NOVA service-manager should
-# route start/stop requests to. Used for local dev so programs show up and run in
-# remote NOVA without installing the app.
-PROGRAM_ENDPOINT_URL = config("PROGRAM_ENDPOINT_URL", default="")

--- a/novax/novax.py
+++ b/novax/novax.py
@@ -1,6 +1,5 @@
 import importlib
 import importlib.util
-import json
 from contextlib import asynccontextmanager
 from pathlib import Path
 from types import ModuleType
@@ -14,7 +13,7 @@ from nova.logging import logger
 from nova.program.function import Program
 from nova.program.registry import get_registered_programs
 from nova.program.store import ProgramStore
-from novax.config import APP_NAME, CELL_NAME, PROGRAM_ENDPOINT_URL
+from novax.config import APP_NAME, CELL_NAME
 from novax.program_manager import ProgramManager
 
 
@@ -123,14 +122,6 @@ class Novax:
         """
         try:
             logger.info("Novax: Starting program discovery and registration to store")
-            if PROGRAM_ENDPOINT_URL:
-                logger.warning(
-                    "PROGRAM_ENDPOINT_URL is set (%s). This routes program start/stop "
-                    "to a custom URL and relies on NOVA's endpoint_url support, which is "
-                    "not yet released. It is a no-op against current NOVA versions and is "
-                    "safe to leave unset.",
-                    PROGRAM_ENDPOINT_URL,
-                )
             programs = await self._program_manager.get_programs()
 
             store_programs = {}
@@ -152,17 +143,7 @@ class Novax:
 
             for program_id, store_program in store_programs.items():
                 try:
-                    if PROGRAM_ENDPOINT_URL:
-                        # Opt-in only. The released Program model has no endpoint_url
-                        # field and NOVA's released routing ignores it, so this is a
-                        # no-op until the matching service-manager change ships. When
-                        # set, write the JSON directly with the extra routing key.
-                        payload = store_program.model_dump(mode="json")
-                        payload["endpoint_url"] = PROGRAM_ENDPOINT_URL
-                        kv = await program_store._key_value()
-                        await kv.put(f"{APP_NAME}.{program_id}", json.dumps(payload).encode())
-                    else:
-                        await program_store.put(f"{APP_NAME}.{program_id}", store_program)
+                    await program_store.put(f"{APP_NAME}.{program_id}", store_program)
                     logger.debug(f"Program {program_id} synced to store")
                 except Exception as e:
                     logger.error(f"Failed to sync program {program_id} to store: {e}")

--- a/novax/novax.py
+++ b/novax/novax.py
@@ -123,6 +123,14 @@ class Novax:
         """
         try:
             logger.info("Novax: Starting program discovery and registration to store")
+            if PROGRAM_ENDPOINT_URL:
+                logger.warning(
+                    "PROGRAM_ENDPOINT_URL is set (%s). This routes program start/stop "
+                    "to a custom URL and relies on NOVA's endpoint_url support, which is "
+                    "not yet released. It is a no-op against current NOVA versions and is "
+                    "safe to leave unset.",
+                    PROGRAM_ENDPOINT_URL,
+                )
             programs = await self._program_manager.get_programs()
 
             store_programs = {}
@@ -145,8 +153,10 @@ class Novax:
             for program_id, store_program in store_programs.items():
                 try:
                     if PROGRAM_ENDPOINT_URL:
-                        # The released Program model has no endpoint_url field, so
-                        # write the JSON directly with the extra key for routing.
+                        # Opt-in only. The released Program model has no endpoint_url
+                        # field and NOVA's released routing ignores it, so this is a
+                        # no-op until the matching service-manager change ships. When
+                        # set, write the JSON directly with the extra routing key.
                         payload = store_program.model_dump(mode="json")
                         payload["endpoint_url"] = PROGRAM_ENDPOINT_URL
                         kv = await program_store._key_value()

--- a/novax/novax.py
+++ b/novax/novax.py
@@ -1,4 +1,9 @@
+import importlib
+import importlib.util
+import json
 from contextlib import asynccontextmanager
+from pathlib import Path
+from types import ModuleType
 from typing import AsyncIterator, Optional
 
 from fastapi import APIRouter, FastAPI
@@ -7,8 +12,9 @@ from nova import api
 from nova.core.nova import Nova
 from nova.logging import logger
 from nova.program.function import Program
+from nova.program.registry import get_registered_programs
 from nova.program.store import ProgramStore
-from novax.config import APP_NAME, CELL_NAME
+from novax.config import APP_NAME, CELL_NAME, PROGRAM_ENDPOINT_URL
 from novax.program_manager import ProgramManager
 
 
@@ -46,6 +52,26 @@ class Novax:
             str: The program ID
         """
         return self._program_manager.register_program(program)
+
+    def auto_register(self) -> list[str]:
+        """Register every program defined with ``@nova.program`` that has been imported.
+
+        Programs add themselves to a global registry when decorated, so importing the
+        modules that define them (directly or via :meth:`register_module`) is enough to
+        expose them. Returns the list of registered program IDs.
+        """
+        registered: list[str] = []
+        for program in get_registered_programs():
+            if not self._program_manager.has_program(program.program_id):
+                self._program_manager.register_program(program)
+            registered.append(program.program_id)
+        return registered
+
+    def register_module(self, module: ModuleType | str) -> list[str]:
+        """Import a module (or a path to a .py file) and register all its programs."""
+        if isinstance(module, str):
+            module = _import_module(module)
+        return self.auto_register()
 
     def deregister_program(self, program_id: str):
         """
@@ -111,7 +137,15 @@ class Novax:
 
             for program_id, store_program in store_programs.items():
                 try:
-                    await program_store.put(f"{APP_NAME}.{program_id}", store_program)
+                    if PROGRAM_ENDPOINT_URL:
+                        # The released Program model has no endpoint_url field, so
+                        # write the JSON directly with the extra key for routing.
+                        payload = store_program.model_dump(mode="json")
+                        payload["endpoint_url"] = PROGRAM_ENDPOINT_URL
+                        kv = await program_store._key_value()
+                        await kv.put(f"{APP_NAME}.{program_id}", json.dumps(payload).encode())
+                    else:
+                        await program_store.put(f"{APP_NAME}.{program_id}", store_program)
                     logger.debug(f"Program {program_id} synced to store")
                 except Exception as e:
                     logger.error(f"Failed to sync program {program_id} to store: {e}")
@@ -197,8 +231,9 @@ class Novax:
         app.dependency_overrides[get_program_manager] = get_program_manager_override
 
         if not CELL_NAME:
-            logger.error(
-                "Novax: CELL_NAME environment variable is not set, your programs will not be registered"
+            logger.info(
+                "Novax: CELL_NAME is not set; programs will not be synced to the NOVA store "
+                "(local dev mode). Set CELL_NAME to make programs visible in NOVA."
             )
         else:
             programs_router.lifespan_context = self.program_store_lifespan
@@ -207,3 +242,48 @@ class Novax:
         app.include_router(programs_router)
 
         return app
+
+    def serve(
+        self,
+        *,
+        host: str = "0.0.0.0",
+        port: int = 3000,
+        title: str = "Novax API",
+        version: str = "1.0.0",
+        root_path: str = "",
+    ) -> None:
+        """Build the app, register all decorated programs and run the server.
+
+        This is the one-call entry point for development: it creates the FastAPI app,
+        wires the programs router, auto-registers every imported ``@nova.program`` and
+        starts uvicorn. CORS is open so the NOVA frontend can reach it.
+        """
+        import uvicorn
+        from fastapi.middleware.cors import CORSMiddleware
+
+        app = self.create_app(title=title, version=version, root_path=root_path)
+        self.include_programs_router(app)
+        self.auto_register()
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+        uvicorn.run(
+            app, host=host, port=port, log_level="info", proxy_headers=True, forwarded_allow_ips="*"
+        )
+
+
+def _import_module(module: str) -> ModuleType:
+    """Import a module by dotted path or a path to a ``.py`` file."""
+    path = Path(module)
+    if path.suffix == ".py" and path.exists():
+        spec = importlib.util.spec_from_file_location(path.stem, path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot import program file: {module}")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    return importlib.import_module(module)

--- a/novax/novax.py
+++ b/novax/novax.py
@@ -19,10 +19,13 @@ from novax.program_manager import ProgramManager
 
 
 class Novax:
-    def __init__(self, *, app_name: str | None = None):
+    def __init__(self, app: FastAPI | None = None, *, app_name: str | None = None):
         """Initialize the Novax class.
 
         Args:
+            app: Optional FastAPI app. If provided, the programs router is included
+                and all imported ``@nova.program`` functions are auto-registered, so
+                ``Novax(app)`` is all you need.
             app_name (str | None, optional): This one is read from the environment variable APP_NAME. Only change it for development purposes. Defaults to None.
         """
         app_name = app_name or APP_NAME
@@ -35,6 +38,10 @@ class Novax:
             cell_id=CELL_NAME, app_name=app_name, nova_config=nova.config
         )
         self._app: FastAPI | None = None
+
+        if app is not None:
+            self.include_programs_router(app)
+            self.auto_register()
 
     @property
     def program_manager(self) -> ProgramManager:

--- a/novax/novax.py
+++ b/novax/novax.py
@@ -76,7 +76,7 @@ class Novax:
     def register_module(self, module: ModuleType | str) -> list[str]:
         """Import a module (or a path to a .py file) and register all its programs."""
         if isinstance(module, str):
-            module = _import_module(module)
+            _import_module(module)
         return self.auto_register()
 
     def deregister_program(self, program_id: str):

--- a/novax/novax.py
+++ b/novax/novax.py
@@ -1,5 +1,6 @@
 import importlib
 import importlib.util
+import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
 from types import ModuleType
@@ -68,8 +69,7 @@ class Novax:
         """
         registered: list[str] = []
         for program in get_registered_programs():
-            if not self._program_manager.has_program(program.program_id):
-                self._program_manager.register_program(program)
+            self._program_manager.register_program(program)
             registered.append(program.program_id)
         return registered
 
@@ -265,7 +265,7 @@ class Novax:
         app.add_middleware(
             CORSMiddleware,
             allow_origins=["*"],
-            allow_credentials=True,
+            allow_credentials=False,
             allow_methods=["*"],
             allow_headers=["*"],
         )
@@ -281,7 +281,17 @@ def _import_module(module: str) -> ModuleType:
         spec = importlib.util.spec_from_file_location(path.stem, path)
         if spec is None or spec.loader is None:
             raise ImportError(f"Cannot import program file: {module}")
+        # Reuse an already-loaded module to avoid duplicate instances on repeated imports.
+        cached = sys.modules.get(spec.name)
+        if cached is not None:
+            return cached
         mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
+        # Register before executing so the module can import itself during execution.
+        sys.modules[spec.name] = mod
+        try:
+            spec.loader.exec_module(mod)
+        except Exception:
+            sys.modules.pop(spec.name, None)
+            raise
         return mod
     return importlib.import_module(module)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ benchmark = [
 download-models = "nova_rerun_bridge.helper_scripts.download_models:update_robot_models"
 wandelscript = "wandelscript.cli:app"
 ws = "wandelscript.cli:app"
+novax = "novax.cli:main"
 
 
 

--- a/tests/novax/fixtures_autodiscover.py
+++ b/tests/novax/fixtures_autodiscover.py
@@ -1,0 +1,16 @@
+"""Fixture module with decorated programs used to test module-based autodiscovery.
+
+Importing this module registers its programs in the global program registry.
+"""
+
+import nova
+
+
+@nova.program(id="fixture_prog_one")
+async def fixture_prog_one(ctx: nova.ProgramContext):
+    pass
+
+
+@nova.program(id="fixture_prog_two")
+async def fixture_prog_two(ctx: nova.ProgramContext):
+    pass

--- a/tests/novax/test_auto_register.py
+++ b/tests/novax/test_auto_register.py
@@ -1,11 +1,26 @@
+import sys
+from pathlib import Path
+
+import pytest
+
 import nova
-from nova.program import clear_registry, get_registered_programs
+from nova.program import Program, clear_registry, get_registered_programs
 from novax import Novax
+from novax.novax import _import_module
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Isolate each test from registry state leaked by other modules/imports."""
+    clear_registry()
+    yield
+    clear_registry()
+
+
+# --- registry -------------------------------------------------------------
 
 
 def test_decorator_registers_program():
-    clear_registry()
-
     @nova.program(id="reg_prog_a")
     async def prog_a(ctx: nova.ProgramContext):
         pass
@@ -14,9 +29,16 @@ def test_decorator_registers_program():
     assert "reg_prog_a" in ids
 
 
-def test_redecorating_same_id_replaces_entry():
-    clear_registry()
+def test_bare_decorator_registers_under_function_name():
+    @nova.program
+    async def bare_program(ctx: nova.ProgramContext):
+        pass
 
+    ids = [p.program_id for p in get_registered_programs()]
+    assert "bare_program" in ids
+
+
+def test_redecorating_same_id_replaces_entry():
     @nova.program(id="reg_dup")
     async def first(ctx: nova.ProgramContext):
         pass
@@ -29,9 +51,33 @@ def test_redecorating_same_id_replaces_entry():
     assert len(matches) == 1
 
 
-def test_auto_register_registers_all():
+def test_clear_registry_empties_registry():
+    @nova.program(id="to_be_cleared")
+    async def prog(ctx: nova.ProgramContext):
+        pass
+
+    assert get_registered_programs()
+
     clear_registry()
 
+    assert get_registered_programs() == []
+
+
+def test_get_registered_programs_returns_program_objects():
+    @nova.program(id="typed_prog")
+    async def prog(ctx: nova.ProgramContext):
+        pass
+
+    programs = get_registered_programs()
+
+    assert all(isinstance(p, Program) for p in programs)
+    assert {p.program_id for p in programs} == {"typed_prog"}
+
+
+# --- Novax.auto_register --------------------------------------------------
+
+
+def test_auto_register_registers_all():
     @nova.program(id="auto_one")
     async def one(ctx: nova.ProgramContext):
         pass
@@ -47,3 +93,126 @@ def test_auto_register_registers_all():
     assert "auto_two" in registered
     assert novax.program_manager.has_program("auto_one")
     assert novax.program_manager.has_program("auto_two")
+
+
+def test_auto_register_empty_registry_returns_empty_list():
+    novax = Novax(app_name="novax_auto_test")
+
+    assert novax.auto_register() == []
+
+
+def test_auto_register_is_idempotent():
+    @nova.program(id="idem_prog")
+    async def prog(ctx: nova.ProgramContext):
+        pass
+
+    novax = Novax(app_name="novax_auto_test")
+
+    first = novax.auto_register()
+    second = novax.auto_register()
+
+    assert first == ["idem_prog"]
+    assert second == ["idem_prog"]
+    # Still registered exactly once.
+    assert novax.program_manager.has_program("idem_prog")
+
+
+def test_auto_register_updates_redecorated_program():
+    @nova.program(id="update_prog", name="Original")
+    async def original(ctx: nova.ProgramContext):
+        pass
+
+    novax = Novax(app_name="novax_auto_test")
+    novax.auto_register()
+    assert novax.program_manager._programs["update_prog"].name == "Original"
+
+    # Re-decorate the same id with a new definition and re-run auto_register.
+    @nova.program(id="update_prog", name="Updated")
+    async def updated(ctx: nova.ProgramContext):
+        pass
+
+    novax.auto_register()
+
+    assert novax.program_manager._programs["update_prog"].name == "Updated"
+
+
+def test_constructor_with_app_auto_registers():
+    @nova.program(id="ctor_prog")
+    async def prog(ctx: nova.ProgramContext):
+        pass
+
+    app = Novax(app_name="novax_ctor_test").create_app()
+    novax = Novax(app, app_name="novax_ctor_test")
+
+    assert novax.program_manager.has_program("ctor_prog")
+
+
+# --- Novax.register_module ------------------------------------------------
+
+
+def test_register_module_from_module_object():
+    # Drop any cached import so the decorators re-run and re-populate the registry.
+    sys.modules.pop("tests.novax.fixtures_autodiscover", None)
+    import tests.novax.fixtures_autodiscover as fixture_module
+
+    novax = Novax(app_name="novax_module_test")
+    registered = novax.register_module(fixture_module)
+
+    assert "fixture_prog_one" in registered
+    assert "fixture_prog_two" in registered
+    assert novax.program_manager.has_program("fixture_prog_one")
+    assert novax.program_manager.has_program("fixture_prog_two")
+
+
+def test_register_module_from_dotted_path():
+    # Drop any cached import so the decorators re-run and re-populate the registry.
+    sys.modules.pop("tests.novax.fixtures_autodiscover", None)
+
+    novax = Novax(app_name="novax_module_test")
+    registered = novax.register_module("tests.novax.fixtures_autodiscover")
+
+    assert "fixture_prog_one" in registered
+    assert "fixture_prog_two" in registered
+
+
+def test_register_module_from_file_path():
+    # Drop any cached import so the decorators re-run and re-populate the registry.
+    sys.modules.pop("fixtures_autodiscover", None)
+    fixture_file = str(Path(__file__).parent / "fixtures_autodiscover.py")
+
+    novax = Novax(app_name="novax_module_test")
+    registered = novax.register_module(fixture_file)
+
+    assert "fixture_prog_one" in registered
+    assert "fixture_prog_two" in registered
+
+
+# --- _import_module -------------------------------------------------------
+
+
+def test_import_module_dotted_path():
+    module = _import_module("tests.novax.fixtures_autodiscover")
+
+    assert hasattr(module, "fixture_prog_one")
+
+
+def test_import_module_file_path():
+    fixture_file = str(Path(__file__).parent / "fixtures_autodiscover.py")
+
+    module = _import_module(fixture_file)
+
+    assert hasattr(module, "fixture_prog_one")
+
+
+def test_import_module_file_path_reuses_cached_instance():
+    fixture_file = str(Path(__file__).parent / "fixtures_autodiscover.py")
+
+    first = _import_module(fixture_file)
+    second = _import_module(fixture_file)
+
+    assert first is second
+
+
+def test_import_module_unknown_raises():
+    with pytest.raises(ModuleNotFoundError):
+        _import_module("tests.novax.does_not_exist_module")

--- a/tests/novax/test_auto_register.py
+++ b/tests/novax/test_auto_register.py
@@ -1,0 +1,49 @@
+import nova
+from nova.program import clear_registry, get_registered_programs
+from novax import Novax
+
+
+def test_decorator_registers_program():
+    clear_registry()
+
+    @nova.program(id="reg_prog_a")
+    async def prog_a(ctx: nova.ProgramContext):
+        pass
+
+    ids = [p.program_id for p in get_registered_programs()]
+    assert "reg_prog_a" in ids
+
+
+def test_redecorating_same_id_replaces_entry():
+    clear_registry()
+
+    @nova.program(id="reg_dup")
+    async def first(ctx: nova.ProgramContext):
+        pass
+
+    @nova.program(id="reg_dup")
+    async def second(ctx: nova.ProgramContext):
+        pass
+
+    matches = [p for p in get_registered_programs() if p.program_id == "reg_dup"]
+    assert len(matches) == 1
+
+
+def test_auto_register_registers_all():
+    clear_registry()
+
+    @nova.program(id="auto_one")
+    async def one(ctx: nova.ProgramContext):
+        pass
+
+    @nova.program(id="auto_two")
+    async def two(ctx: nova.ProgramContext):
+        pass
+
+    novax = Novax(app_name="novax_auto_test")
+    registered = novax.auto_register()
+
+    assert "auto_one" in registered
+    assert "auto_two" in registered
+    assert novax.program_manager.has_program("auto_one")
+    assert novax.program_manager.has_program("auto_two")

--- a/uv.lock
+++ b/uv.lock
@@ -1920,7 +1920,7 @@ wheels = [
 
 [[package]]
 name = "wandelbots-nova"
-version = "5.6.2"
+version = "5.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiostream" },

--- a/uv.lock
+++ b/uv.lock
@@ -1920,7 +1920,7 @@ wheels = [
 
 [[package]]
 name = "wandelbots-nova"
-version = "5.6.1"
+version = "5.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiostream" },


### PR DESCRIPTION
## Make novax programs easier to register and serve

Previously each program needed an explicit `register_program(...)` call and hand-wired FastAPI setup. Now `@nova.program` functions self-register and wiring is a single line.

### Implicit registration + one-line setup
```python
import nova
from fastapi import FastAPI

@nova.program(id="hello")
async def hello(ctx: nova.ProgramContext):
    ...

app = FastAPI()
novax = nova.Novax(app)  # includes router + auto-registers all imported programs
```
- `@nova.program` adds itself to a global registry (`nova/program/registry.py`).
- `Novax(app)` includes the programs router and auto-registers; `auto_register()` / `register_module()` / `register_program()` remain available.
- `Novax` is importable from the SDK (`from nova import Novax`) when the optional `novax` extra is installed, with a clear error otherwise:
  ```
  The 'novax' package requires the optional 'novax' extra, which is not installed.
  Install it with: uv sync --extra novax
  ```

### One-command dev serve (no Docker)
```bash
uv run novax run examples/start_here.py --cell cell
```
- New `novax` CLI: `novax run <module|file> [--host] [--port] [--cell]`.
- Missing `CELL_NAME` is now an info-level dev hint instead of an error.

### Misc
- Slimmed the example app + README to the one-liner.
- Tests: `tests/novax/test_auto_register.py` (registry dedupe + `auto_register`).
