### PR TITLE
fix: GR00T schema validation for IO state observations

### DIFF
--- a/novapolicy/gr00t/client.py
+++ b/novapolicy/gr00t/client.py
@@ -121,6 +121,7 @@ class Gr00tPolicyClient(PolicyClient):
         server_state_keys = _extract_modality_keys(config, "state")
         schema_state_keys = {m.key for m in schema.joint_mappings}
         schema_state_keys |= {m.key for m in schema.tcp_mappings}
+        schema_state_keys |= {m.key for m in schema.obs_io_mappings}
         missing_state = server_state_keys - schema_state_keys
         if missing_state:
             errors.append(f"Missing state observations: {sorted(missing_state)}")

--- a/novapolicy/tests/api/test_gr00t_client.py
+++ b/novapolicy/tests/api/test_gr00t_client.py
@@ -732,6 +732,35 @@ async def test_validate_schema_passes_when_keys_match() -> None:
 
 
 @pytest.mark.asyncio
+async def test_validate_schema_passes_when_state_key_is_io_observation() -> None:
+    """validate_schema accepts IO observations as state keys."""
+    port = _find_free_port()
+    server = _RecordingGr00tServer(port)
+    server._modality_config = {
+        "state": {
+            "__ModalityConfig_class__": True,
+            "as_json": {
+                "modality_keys": ["gripper"],
+            },
+        },
+    }
+    server.start()
+    try:
+        mg = _mg()
+        schema = PolicySchema(
+            observations=[
+                Observation.io("gripper", source=mg, io="digital_out[0]"),
+            ]
+        )
+        client = Gr00tPolicyClient(host="127.0.0.1", port=port)
+        await client.connect(["0@ur10e"])
+        await client.validate_schema(schema)  # should not raise
+        await client.close()
+    finally:
+        server.close()
+
+
+@pytest.mark.asyncio
 async def test_validate_schema_fails_on_missing_state_key() -> None:
     """validate_schema raises ValueError when a state key is missing."""
     port = _find_free_port()


### PR DESCRIPTION
## Summary
- include observation IO mappings when validating GR00T state modality keys
- add a regression test for IO-backed state keys such as gripper signals

## Testing
- `uv run --extra novapolicy pytest novapolicy/tests/api/test_gr00t_client.py -k validate_schema`