### PR TITLE
fix: Rerun visualization for DH theta robot meshes

### DIFF
--- a/nova_rerun_bridge/robot_visualizer.py
+++ b/nova_rerun_bridge/robot_visualizer.py
@@ -251,8 +251,7 @@ class RobotVisualizer:
         if len(self.robot.dh_parameters) <= link_index:
             return identity_transform
 
-        theta = self.robot.dh_parameters[link_index].theta or 0.0
-        if abs(theta) < 1e-12:
+        if abs(theta := self.robot.dh_parameters[link_index].theta or 0.0) < 1e-12:
             return identity_transform
 
         root_rotation = root_transform[:3, :3]
@@ -263,19 +262,17 @@ class RobotVisualizer:
 
         theta_rotation = Rotation.from_euler("z", theta, degrees=False).as_matrix()
         base_rotation = root_rotation.T @ zero_link_transform[:3, :3]
-        joint_rotation_inverse = joint_transform[:3, :3].T
-
-        def rotation_error(correction: np.ndarray) -> float:
-            return Rotation.from_matrix(
-                base_rotation @ correction @ root_rotation @ joint_rotation_inverse
-            ).magnitude()
-
-        if rotation_error(theta_rotation) >= rotation_error(np.eye(3)) - 1e-9:
+        target_rotation = root_rotation @ joint_transform[:3, :3].T
+        current_error = Rotation.from_matrix(base_rotation @ target_rotation).magnitude()
+        corrected_error = Rotation.from_matrix(
+            base_rotation @ theta_rotation @ target_rotation
+        ).magnitude()
+        if corrected_error >= current_error - 1e-9:
             return identity_transform
 
-        theta_transform = np.eye(4)
-        theta_transform[:3, :3] = theta_rotation
-        return theta_transform
+        correction_transform = np.eye(4)
+        correction_transform[:3, :3] = theta_rotation
+        return correction_transform
 
     def get_transform_matrix(self):
         """

--- a/nova_rerun_bridge/robot_visualizer.py
+++ b/nova_rerun_bridge/robot_visualizer.py
@@ -226,10 +226,7 @@ class RobotVisualizer:
         return color
 
     def get_dh_theta_mesh_correction(
-        self,
-        link_index: int,
-        root_transform: np.ndarray,
-        joint_transform: np.ndarray,
+        self, link_index: int, root_transform: np.ndarray, joint_transform: np.ndarray
     ) -> np.ndarray:
         """Return the extra theta rotation needed after flattening a GLB link mesh.
 

--- a/nova_rerun_bridge/robot_visualizer.py
+++ b/nova_rerun_bridge/robot_visualizer.py
@@ -234,17 +234,19 @@ class RobotVisualizer:
     ) -> np.ndarray:
         """Return the extra theta rotation needed after flattening a GLB link mesh.
 
-        Three.js keeps the GLB as a parent/child tree: rotate a joint node and all child
-        meshes follow automatically. Here we log each mesh as its own Rerun entity instead,
-        so that tree is gone and we have to recreate the missing joint-to-mesh offset.
+        The Rerun visualizer flattens GLB meshes and logs each mesh as its own Rerun
+        entity. Once flattened, meshes no longer inherit the original GLB joint
+        transforms, so the visualizer has to recreate the missing joint-to-mesh offset.
 
-        Most models need the old DH-theta correction for that offset. Some GLB files already
-        include the theta offset in the joint frame, and applying it again breaks the mesh.
-        To avoid model-name special cases, check the zero pose:
-        - if the DH joint origin and GLB joint origin are not the same, do not rotate around
-          the DH origin because that would move the mesh to a wrong place;
-        - if the origins match, apply the theta rotation only when it makes the zero-pose
-          mesh frame line up better with Rerun's coordinate system.
+        Some GLB joint frames already contain the DH theta offset. Applying the offset
+        again would rotate those meshes twice.
+
+        Apply the extra DH theta correction only when static zero-pose frame checks show
+        that the flattened GLB mesh needs it:
+        - if the DH zero-pose joint origin and GLB joint origin differ, do not rotate
+          around the DH origin because that would move the mesh incorrectly;
+        - if the origins match, apply the theta correction only when it improves zero-pose
+          frame alignment with Rerun's coordinate system.
         """
         identity_transform = np.eye(4)
         if len(self.robot.dh_parameters) <= link_index:

--- a/nova_rerun_bridge/robot_visualizer.py
+++ b/nova_rerun_bridge/robot_visualizer.py
@@ -67,6 +67,15 @@ class RobotVisualizer:
         self.base_entity_path = base_entity_path.rstrip("/")
         self.albedo_factor = albedo_factor
         self.mesh_loaded = False
+        self.inverse_mounting_transform = np.linalg.inv(
+            self.robot.pose_to_matrix(self.robot.mounting)
+        )
+        self.zero_link_transforms_without_mounting = [
+            self.inverse_mounting_transform @ transform
+            for transform in self.compute_forward_kinematics(
+                joint_positions=[0.0] * len(self.robot.dh_parameters)
+            )
+        ]
         # Group collision geometries by link
         self.collision_link_geometries: list[Any] = (
             cast(list[Any], collision_link_chain.root) if collision_link_chain else []
@@ -219,7 +228,6 @@ class RobotVisualizer:
     def get_dh_theta_mesh_correction(
         self,
         link_index: int,
-        link_transform: np.ndarray,
         inverse_transform: np.ndarray,
         root_transform: np.ndarray,
         joint_transform: np.ndarray,
@@ -250,14 +258,9 @@ class RobotVisualizer:
         joint_transform_scaled[:3, 3] *= 1000
         glb_joint_transform = root_transform @ joint_transform_scaled
 
-        zero_link_transforms = self.compute_forward_kinematics(
-            joint_positions=[0.0] * len(self.robot.dh_parameters)
-        )
-        zero_link_transform = zero_link_transforms[link_index]
-        mounting_transform = self.robot.pose_to_matrix(self.robot.mounting)
-        zero_link_transform_without_mounting = np.linalg.inv(mounting_transform) @ zero_link_transform
+        zero_link_transform = self.zero_link_transforms_without_mounting[link_index]
         joint_position_error = np.linalg.norm(
-            zero_link_transform_without_mounting[:3, 3] - glb_joint_transform[:3, 3]
+            zero_link_transform[:3, 3] - glb_joint_transform[:3, 3]
         )
         if joint_position_error > 1.0:
             return identity_transform
@@ -266,8 +269,8 @@ class RobotVisualizer:
         theta_transform[:3, :3] = Rotation.from_euler("z", theta, degrees=False).as_matrix()
 
         transform = root_transform @ inverse_transform
-        without_theta = link_transform @ transform
-        with_theta = link_transform @ theta_transform @ transform
+        without_theta = zero_link_transform @ transform
+        with_theta = zero_link_transform @ theta_transform @ transform
         target_rotation = root_transform[:3, :3]
 
         def rotation_error(candidate: np.ndarray) -> float:
@@ -707,7 +710,7 @@ class RobotVisualizer:
 
                     root_transform = self.get_transform_matrix()
                     theta_correction_transform = self.get_dh_theta_mesh_correction(
-                        link_index, link_transform, inverse_transform, root_transform, ctransform
+                        link_index, inverse_transform, root_transform, ctransform
                     )
 
                     transform = root_transform @ inverse_transform
@@ -799,7 +802,7 @@ class RobotVisualizer:
 
                         root_transform = self.get_transform_matrix()
                         theta_correction_transform = self.get_dh_theta_mesh_correction(
-                            link_index, link_transform, inverse_transform, root_transform, ctransform
+                            link_index, inverse_transform, root_transform, ctransform
                         )
 
                         transform = root_transform @ inverse_transform

--- a/nova_rerun_bridge/robot_visualizer.py
+++ b/nova_rerun_bridge/robot_visualizer.py
@@ -216,6 +216,67 @@ class RobotVisualizer:
 
         return color
 
+    def get_dh_theta_mesh_correction(
+        self,
+        link_index: int,
+        link_transform: np.ndarray,
+        inverse_transform: np.ndarray,
+        root_transform: np.ndarray,
+        joint_transform: np.ndarray,
+    ) -> np.ndarray:
+        """Return the extra theta rotation needed after flattening a GLB link mesh.
+
+        Three.js keeps the GLB as a parent/child tree: rotate a joint node and all child
+        meshes follow automatically. Here we log each mesh as its own Rerun entity instead,
+        so that tree is gone and we have to recreate the missing joint-to-mesh offset.
+
+        Most models need the old DH-theta correction for that offset. Some GLB files already
+        include the theta offset in the joint frame, and applying it again breaks the mesh.
+        To avoid model-name special cases, check the zero pose:
+        - if the DH joint origin and GLB joint origin are not the same, do not rotate around
+          the DH origin because that would move the mesh to a wrong place;
+        - if the origins match, apply the theta rotation only when it makes the zero-pose
+          mesh frame line up better with Rerun's coordinate system.
+        """
+        identity_transform = np.eye(4)
+        if len(self.robot.dh_parameters) <= link_index:
+            return identity_transform
+
+        theta = self.robot.dh_parameters[link_index].theta or 0.0
+        if abs(theta) < 1e-12:
+            return identity_transform
+
+        joint_transform_scaled = joint_transform.copy()
+        joint_transform_scaled[:3, 3] *= 1000
+        glb_joint_transform = root_transform @ joint_transform_scaled
+
+        zero_link_transforms = self.compute_forward_kinematics(
+            joint_positions=[0.0] * len(self.robot.dh_parameters)
+        )
+        zero_link_transform = zero_link_transforms[link_index]
+        mounting_transform = self.robot.pose_to_matrix(self.robot.mounting)
+        zero_link_transform_without_mounting = np.linalg.inv(mounting_transform) @ zero_link_transform
+        joint_position_error = np.linalg.norm(
+            zero_link_transform_without_mounting[:3, 3] - glb_joint_transform[:3, 3]
+        )
+        if joint_position_error > 1.0:
+            return identity_transform
+
+        theta_transform = np.eye(4)
+        theta_transform[:3, :3] = Rotation.from_euler("z", theta, degrees=False).as_matrix()
+
+        transform = root_transform @ inverse_transform
+        without_theta = link_transform @ transform
+        with_theta = link_transform @ theta_transform @ transform
+        target_rotation = root_transform[:3, :3]
+
+        def rotation_error(candidate: np.ndarray) -> float:
+            return Rotation.from_matrix(target_rotation.T @ candidate[:3, :3]).magnitude()
+
+        if rotation_error(with_theta) < rotation_error(without_theta) - 1e-9:
+            return theta_transform
+        return identity_transform
+
     def get_transform_matrix(self):
         """
         Creates a transformation matrix that converts from glTF's right-handed Y-up
@@ -641,23 +702,17 @@ class RobotVisualizer:
                     ctransform = _copy_graph_matrix(cumulative_transform)
                     inverse_transform = np.linalg.inv(ctransform)
 
-                    # DH theta is rotated, rotate mesh around z in direction of theta
-                    rotation_matrix_z_4x4 = np.eye(4)
-                    if len(self.robot.dh_parameters) > link_index:
-                        theta = self.robot.dh_parameters[link_index].theta or 0.0
-                        rotation_z_minus_90 = Rotation.from_euler(
-                            "z", theta, degrees=False
-                        ).as_matrix()
-                        rotation_matrix_z_4x4[:3, :3] = rotation_z_minus_90
-
                     # scale positions to mm
                     inverse_transform[:3, 3] *= 1000
 
                     root_transform = self.get_transform_matrix()
+                    theta_correction_transform = self.get_dh_theta_mesh_correction(
+                        link_index, link_transform, inverse_transform, root_transform, ctransform
+                    )
 
                     transform = root_transform @ inverse_transform
 
-                    final_transform = link_transform @ rotation_matrix_z_4x4 @ transform
+                    final_transform = link_transform @ theta_correction_transform @ transform
 
                     self.init_mesh(entity_path, geom, joint_name)
                     log_geometry(entity_path, final_transform)
@@ -739,23 +794,17 @@ class RobotVisualizer:
                         ctransform = _copy_graph_matrix(cumulative_transform)
                         inverse_transform = np.linalg.inv(ctransform)
 
-                        # DH theta is rotated, rotate mesh around z in direction of theta
-                        rotation_matrix_z_4x4 = np.eye(4)
-                        if len(self.robot.dh_parameters) > link_index:
-                            theta = self.robot.dh_parameters[link_index].theta or 0.0
-                            rotation_z_minus_90 = Rotation.from_euler(
-                                "z", theta, degrees=False
-                            ).as_matrix()
-                            rotation_matrix_z_4x4[:3, :3] = rotation_z_minus_90
-
                         # scale positions to mm
                         inverse_transform[:3, 3] *= 1000
 
                         root_transform = self.get_transform_matrix()
+                        theta_correction_transform = self.get_dh_theta_mesh_correction(
+                            link_index, link_transform, inverse_transform, root_transform, ctransform
+                        )
 
                         transform = root_transform @ inverse_transform
 
-                        final_transform = link_transform @ rotation_matrix_z_4x4 @ transform
+                        final_transform = link_transform @ theta_correction_transform @ transform
 
                         self.init_mesh(entity_path, geom, joint_name)
                         collect_geometry_data(entity_path, final_transform)

--- a/nova_rerun_bridge/robot_visualizer.py
+++ b/nova_rerun_bridge/robot_visualizer.py
@@ -228,7 +228,6 @@ class RobotVisualizer:
     def get_dh_theta_mesh_correction(
         self,
         link_index: int,
-        inverse_transform: np.ndarray,
         root_transform: np.ndarray,
         joint_transform: np.ndarray,
     ) -> np.ndarray:
@@ -256,31 +255,27 @@ class RobotVisualizer:
         if abs(theta) < 1e-12:
             return identity_transform
 
-        joint_transform_scaled = joint_transform.copy()
-        joint_transform_scaled[:3, 3] *= 1000
-        glb_joint_transform = root_transform @ joint_transform_scaled
-
+        root_rotation = root_transform[:3, :3]
         zero_link_transform = self.zero_link_transforms_without_mounting[link_index]
-        joint_position_error = np.linalg.norm(
-            zero_link_transform[:3, 3] - glb_joint_transform[:3, 3]
-        )
-        if joint_position_error > 1.0:
+        glb_joint_position = root_rotation @ (joint_transform[:3, 3] * 1000)
+        if np.linalg.norm(zero_link_transform[:3, 3] - glb_joint_position) > 1.0:
+            return identity_transform
+
+        theta_rotation = Rotation.from_euler("z", theta, degrees=False).as_matrix()
+        base_rotation = root_rotation.T @ zero_link_transform[:3, :3]
+        joint_rotation_inverse = joint_transform[:3, :3].T
+
+        def rotation_error(correction: np.ndarray) -> float:
+            return Rotation.from_matrix(
+                base_rotation @ correction @ root_rotation @ joint_rotation_inverse
+            ).magnitude()
+
+        if rotation_error(theta_rotation) >= rotation_error(np.eye(3)) - 1e-9:
             return identity_transform
 
         theta_transform = np.eye(4)
-        theta_transform[:3, :3] = Rotation.from_euler("z", theta, degrees=False).as_matrix()
-
-        transform = root_transform @ inverse_transform
-        without_theta = zero_link_transform @ transform
-        with_theta = zero_link_transform @ theta_transform @ transform
-        target_rotation = root_transform[:3, :3]
-
-        def rotation_error(candidate: np.ndarray) -> float:
-            return Rotation.from_matrix(target_rotation.T @ candidate[:3, :3]).magnitude()
-
-        if rotation_error(with_theta) < rotation_error(without_theta) - 1e-9:
-            return theta_transform
-        return identity_transform
+        theta_transform[:3, :3] = theta_rotation
+        return theta_transform
 
     def get_transform_matrix(self):
         """
@@ -712,7 +707,7 @@ class RobotVisualizer:
 
                     root_transform = self.get_transform_matrix()
                     theta_correction_transform = self.get_dh_theta_mesh_correction(
-                        link_index, inverse_transform, root_transform, ctransform
+                        link_index, root_transform, ctransform
                     )
 
                     transform = root_transform @ inverse_transform
@@ -804,7 +799,7 @@ class RobotVisualizer:
 
                         root_transform = self.get_transform_matrix()
                         theta_correction_transform = self.get_dh_theta_mesh_correction(
-                            link_index, inverse_transform, root_transform, ctransform
+                            link_index, root_transform, ctransform
                         )
 
                         transform = root_transform @ inverse_transform


### PR DESCRIPTION
## Summary

Fix Rerun visual mesh placement for robot GLB models with DH `theta` offsets, especially `Yaskawa_HC10DTP`, without using model-name special cases.

## Why this is needed

The Rerun visualizer flattens GLB meshes and logs each mesh as its own Rerun entity. Once flattened, meshes no longer inherit the original GLB joint transforms, so the visualizer must manually recreate the missing joint-to-mesh offset.

This was done by always applying the DH `theta` offset. This breaks for models whose GLB joint frame already contains the theta offset (for example parts of `Yaskawa_HC10DTP`) because theta is applied twice.

## What changed

The visualizer now applies the extra DH theta mesh correction only when static zero-pose frame checks show that the flattened GLB mesh needs it:

- if the DH zero-pose joint origin and GLB joint origin differ, do not rotate around the DH origin because that would move the mesh incorrectly;
- if the origins match, apply the theta correction only when it improves zero-pose frame alignment with Rerun's coordinate system.

<img width="632" height="642" alt="Screenshot 2026-07-02 at 18 47 59" src="https://github.com/user-attachments/assets/f39a26ee-6c39-4217-905f-e29aeea190b4" />
