### PR TITLE
feat: migrate jogging to action chunk streaming

### DIFF
--- a/nova/core/gateway.py
+++ b/nova/core/gateway.py
@@ -127,6 +127,9 @@ class ApiGateway:
             api.api.ControllerInputsOutputsApi(api_client=self._api_client), self
         )
         self.jogging_api = _intercept(api.api.JoggingApi(api_client=self._api_client), self)
+        self.action_chunk_streaming_api = _intercept(
+            api.api.ActionChunkStreamingApi(api_client=self._api_client), self
+        )
         self.store_object_api = _intercept(
             api.api.StoreObjectApi(api_client=self._api_client), self
         )

--- a/novapolicy/README.md
+++ b/novapolicy/README.md
@@ -120,7 +120,7 @@ This produces observations like:
 }
 ```
 
-The policy returns an `ActionChunk` keyed by motion-group id. Joint targets are sent as `JointWaypointsRequest`, TCP targets as `PoseWaypointsRequest`, and IO values get written to hardware (use `BoolMapping`/`Mapping` on the matching observation so a learned policy's scaled outputs map back to hardware values).
+The policy returns an `ActionChunk` keyed by motion-group id. Joint targets are sent as `ActionChunkRequest` messages with `JOINTS` waypoints, TCP targets use `POSE` waypoints, and IO values get written to hardware (use `BoolMapping`/`Mapping` on the matching observation so a learned policy's scaled outputs map back to hardware values).
 
 ### Cameras
 

--- a/novapolicy/docs/executor.md
+++ b/novapolicy/docs/executor.md
@@ -10,8 +10,8 @@ API (`jog_joints` / `jog_tcp`), see [jogging.md](jogging.md).
 flowchart LR
     Policy["Policy"] -->|"action chunk\n(positions + dt_ms)"| Executor
     Executor -->|"trimmed chunk"| Session["WaypointJoggingSession"]
-    Session -->|"JointWaypointsRequest\nor PoseWaypointsRequest"| NOVA["NOVA Jogging API"]
-    NOVA -->|"state stream\n(jogger_session_timestamp_ms)"| Session
+    Session -->|"ActionChunkRequest\n(JOINTS or POSE waypoints)"| NOVA["NOVA action-chunk API"]
+    NOVA -->|"state stream\n(session_timestamp_ms)"| Session
 ```
 
 ## Execution Loop
@@ -102,12 +102,13 @@ consecutive chunks, providing ample buffer.
 ## Timestamp Protocol
 
 Each waypoint carries a timestamp (milliseconds since session start). The server
-maintains an internal clock that starts when the first `JointWaypointsRequest`
-or `PoseWaypointsRequest` is received.
+maintains an internal clock that starts when the first `ActionChunkRequest` is
+received.
 
-The server exposes its current clock as `jogger_session_timestamp_ms` in the
-state stream (`JoggingDetails`). The client uses this to compute a **speed ratio**
-(server_time / client_time) and scales outgoing timestamps accordingly.
+The server exposes its current clock as `session_timestamp_ms` in the state
+stream (`ActionChunkStreamingDetails`). The client uses this to compute a
+**speed ratio** (server_time / client_time) and scales outgoing timestamps
+accordingly.
 
 ```
 client sends:    timestamps = [start_ms * ratio, start_ms * ratio + dt * ratio, ...]

--- a/novapolicy/docs/jogging.md
+++ b/novapolicy/docs/jogging.md
@@ -109,35 +109,36 @@ async with jog_tcp({mg1: "Flange", mg2: "Gripper"}) as jogger:
         jogger.set_target({mg1: pose1, mg2: pose2})
 ```
 
-## Waypoint request types
+## Waypoint payloads
 
-The NOVA Jogging API accepts **timestamped waypoints** — either joint positions
-or TCP poses:
+The NOVA action-chunk streaming API accepts **timestamped waypoints** — either
+joint positions or TCP poses — in `ActionChunkRequest` messages:
 
-| Mode | Request | Steps format | Use case |
-|------|---------|--------------|----------|
-| `"joint"` | `JointWaypointsRequest` | Joint radians `[j1, j2, ..., j6]` | Joint-space (default) |
-| `"cartesian"` | `PoseWaypointsRequest` | TCP pose `[x, y, z, rx, ry, rz]` (mm + rad) | Cartesian-space |
+| Mode | Waypoint kind | Steps format | Use case |
+|------|---------------|--------------|----------|
+| `"joint"` | `JOINTS` | Joint radians `[j1, j2, ..., j6]` | Joint-space (default) |
+| `"cartesian"` | `POSE` | TCP pose `[x, y, z, rx, ry, rz]` (mm + rad) | Cartesian-space |
 
-`jog_joints` / `jog_tcp` pick the request type for you. Under a policy, the mode
-is selected automatically based on whether the schema contains
+`jog_joints` / `jog_tcp` pick the waypoint kind for you. Under a policy, the
+mode is selected automatically based on whether the schema contains
 `Observation.tcp(..., action=True)` entries.
 
 ## Error detection
 
-The session monitors the NOVA jogging state stream for pause conditions.
-Three of them are **blocking faults** — after consecutive ticks in one of these
+The session monitors the NOVA action-chunk state stream for braking conditions.
+Four of them are **blocking faults** — after consecutive ticks in one of these
 states, a `MotionError` is raised:
 
 | State | Meaning |
 |-------|---------|
-| `PAUSED_NEAR_JOINT_LIMIT` | Joint reached its limit |
-| `PAUSED_NEAR_COLLISION` | Self-collision detected |
-| `PAUSED_NEAR_SINGULARITY` | Kinematic singularity |
+| `BRAKING_NEAR_JOINT_LIMIT` | Joint reached its limit |
+| `BRAKING_NEAR_COLLISION` | Self-collision detected |
+| `BRAKING_NEAR_SINGULARITY` | Kinematic singularity |
+| `BRAKING_NEAR_WORKSPACE_BOUNDARY` | Workspace boundary reached |
 
-One pause is **recoverable** and never raises — the robot resumes on its own
-once a fresh chunk arrives:
+User pause/stop states are reported but do not become motion errors:
 
 | State | Meaning |
 |-------|---------|
 | `PAUSED_BY_USER` | Waypoint buffer exhausted (send chunks faster) |
+| `STOPPED_BY_USER` | Streaming session stopped by the client/operator |

--- a/novapolicy/docs/schema.md
+++ b/novapolicy/docs/schema.md
@@ -58,8 +58,9 @@ Observation.joint_positions("arm", source=mg, mode="relative")
 ## TCP actions
 
 Policies that output Cartesian targets instead of joint positions. Set
-`action=True` on `Observation.tcp()` — the executor sends `PoseWaypointsRequest`
-for that motion group, and the server handles inverse kinematics internally:
+`action=True` on `Observation.tcp()` — the executor sends `ActionChunkRequest`
+messages with `POSE` waypoints for that motion group, and the server handles
+inverse kinematics internally:
 
 ```python
 Observation.tcp("eef_pose", source=mg, tcp="Flange", action=True)

--- a/novapolicy/jogging/clock.py
+++ b/novapolicy/jogging/clock.py
@@ -1,9 +1,10 @@
 """Server jogger-clock synchronization for waypoint jogging.
 
-The NOVA server exposes ``jogger_session_timestamp_ms`` in the state stream.
-``JoggingTimeClock`` observes it, compares to the client wall-clock, and derives
-a speed ratio used to scale outgoing waypoint timestamps so the robot moves at
-real-time speed regardless of the server's internal rate.
+The NOVA server exposes ``session_timestamp_ms`` in the state stream
+(field on ``ActionChunkStreamingDetails``). ``JoggingTimeClock`` observes it,
+compares to the client wall-clock, and derives a speed ratio used to scale
+outgoing waypoint timestamps so the robot moves at real-time speed regardless
+of the server's internal rate.
 """
 
 from __future__ import annotations
@@ -19,9 +20,10 @@ logger = logging.getLogger(__name__)
 class JoggingTimeClock:
     """Tracks the server's jogger session clock and computes the speed ratio.
 
-    The server exposes ``jogger_session_timestamp_ms`` in the state stream
-    (field on ``JoggingDetails``). It starts at 0 after ``InitializeJoggingRequest``
-    and increments while waypoints are being executed.
+    The server exposes ``session_timestamp_ms`` in the state stream
+    (field on ``ActionChunkStreamingDetails``). It starts at 0 after
+    ``InitializeActionChunksRequest`` and increments while waypoints are being
+    executed.
 
     This class observes that timestamp, compares it to the client's wall-clock
     elapsed time, and derives the speed ratio (server_time / client_time).
@@ -95,7 +97,7 @@ class JoggingTimeClock:
     def _note_stall(self, drift_ms: float) -> None:
         """Warn once when the server timer stops advancing (edge-triggered).
 
-        Fires when no fresh ``jogger_session_timestamp_ms`` has arrived for
+        Fires when no fresh ``session_timestamp_ms`` has arrived for
         longer than one lookahead window, i.e. the jog clock has frozen at the
         cap. Recovery is logged from :meth:`update` when server time resumes.
         """
@@ -109,18 +111,18 @@ class JoggingTimeClock:
             )
 
     def update(self, timestamp_ms: int) -> None:
-        """Feed a new ``jogger_session_timestamp_ms`` reading from the state stream."""
+        """Feed a new ``session_timestamp_ms`` reading from the state stream."""
         if timestamp_ms <= 0:
             return
         if not self.synced:
             self.synced = True
             logger.info(
-                "Server time sync established (jogger_session_timestamp_ms=%d)", timestamp_ms
+                "Server time sync established (session_timestamp_ms=%d)", timestamp_ms
             )
         if self._stalled:
             self._stalled = False
             logger.info(
-                "Jogging connection recovered (jogger_session_timestamp_ms=%d); "
+                "Jogging connection recovered (session_timestamp_ms=%d); "
                 "server time advancing again.",
                 timestamp_ms,
             )
@@ -145,14 +147,18 @@ class JoggingTimeClock:
 
     @staticmethod
     def extract_from_state(state: object) -> int | None:
-        """Extract jogger_session_timestamp_ms from a MotionGroupState, or None."""
+        """Extract the action-chunk session timestamp from a MotionGroupState.
+
+        Reads ``execute.details.session_timestamp_ms`` (the field on
+        ``ActionChunkStreamingDetails``). Returns None if not present.
+        """
         execute = getattr(state, "execute", None)
         if execute is None:
             return None
         details = getattr(execute, "details", None)
         if details is None:
             return None
-        ts = getattr(details, "jogger_session_timestamp_ms", None)
+        ts = getattr(details, "session_timestamp_ms", None)
         if isinstance(ts, int):
             return ts
         return None

--- a/novapolicy/jogging/clock.py
+++ b/novapolicy/jogging/clock.py
@@ -1,4 +1,4 @@
-"""Server jogger-clock synchronization for waypoint jogging.
+"""Server jogger-clock synchronization for action-chunk streaming.
 
 The NOVA server exposes ``session_timestamp_ms`` in the state stream
 (field on ``ActionChunkStreamingDetails``). ``JoggingTimeClock`` observes it,

--- a/novapolicy/jogging/session.py
+++ b/novapolicy/jogging/session.py
@@ -1,7 +1,8 @@
-"""Jogging state tracking — detects blocking pause conditions.
+"""Jogging state tracking — detects blocking braking conditions.
 
-Monitors the NOVA jogging state stream and raises ``MotionError``
-after a confirmed blocking pause (joint limit, collision, singularity).
+Monitors the NOVA action-chunk-streaming state stream and raises ``MotionError``
+after a confirmed blocking brake (joint limit, collision, singularity, or
+workspace boundary).
 """
 
 from __future__ import annotations
@@ -13,24 +14,25 @@ from novapolicy.types import MotionError
 
 logger = logging.getLogger(__name__)
 
-_BLOCKING_PAUSES = frozenset(
+_BLOCKING_BRAKES = frozenset(
     {
-        "PAUSED_NEAR_JOINT_LIMIT",
-        "PAUSED_NEAR_COLLISION",
-        "PAUSED_NEAR_SINGULARITY",
+        "BRAKING_NEAR_JOINT_LIMIT",
+        "BRAKING_NEAR_COLLISION",
+        "BRAKING_NEAR_SINGULARITY",
+        "BRAKING_NEAR_WORKSPACE_BOUNDARY",
     }
 )
 
 
 class JoggingStateTracker:
-    """Tracks NOVA jogging pause state and raises on confirmed standstill."""
+    """Tracks NOVA action-chunk state and raises on confirmed braking."""
 
     def __init__(self, motion_group_id: str, *, confirm_ticks: int = 10) -> None:
         self.motion_group_id = motion_group_id
         self._confirm_ticks = confirm_ticks
-        self._paused_reason: str | None = None
-        self._paused_detail: str = ""
-        self._paused_count: int = 0
+        self._braking_reason: str | None = None
+        self._braking_detail: str = ""
+        self._braking_count: int = 0
         self._last_kind: str | None = None
         self._t0 = time.monotonic()
 
@@ -43,12 +45,12 @@ class JoggingStateTracker:
         return self._last_kind
 
     def update_from_state(self, state: object) -> None:
-        """Extract jogging pause reason from MotionGroupState.execute.details."""
+        """Extract braking reason from MotionGroupState.execute.details.state."""
         jog_state = self._extract_jogging_state(state)
 
         if jog_state is None:
-            self._paused_reason = None
-            self._paused_detail = ""
+            self._braking_reason = None
+            self._braking_detail = ""
             return
 
         kind: str = getattr(jog_state, "kind", "RUNNING")
@@ -61,16 +63,16 @@ class JoggingStateTracker:
             )
             self._last_kind = kind
         if kind == "RUNNING":
-            self._paused_reason = None
-            self._paused_detail = ""
+            self._braking_reason = None
+            self._braking_detail = ""
         else:
-            self._paused_reason = kind
+            self._braking_reason = kind
             if hasattr(jog_state, "joint_indices"):
-                self._paused_detail = f"joints: {jog_state.joint_indices}"
+                self._braking_detail = f"joints: {jog_state.joint_indices}"
             elif hasattr(jog_state, "description"):
-                self._paused_detail = jog_state.description
+                self._braking_detail = jog_state.description
             else:
-                self._paused_detail = ""
+                self._braking_detail = ""
 
     @staticmethod
     def _extract_jogging_state(state: object) -> object | None:
@@ -84,16 +86,16 @@ class JoggingStateTracker:
         return getattr(details, "state", None)
 
     def check(self) -> None:
-        """Raise MotionError after confirmed blocking pause."""
-        if self._paused_reason is None or self._paused_reason not in _BLOCKING_PAUSES:
-            self._paused_count = 0
+        """Raise MotionError after confirmed blocking brake."""
+        if self._braking_reason is None or self._braking_reason not in _BLOCKING_BRAKES:
+            self._braking_count = 0
             return
 
-        self._paused_count += 1
-        if self._paused_count >= self._confirm_ticks:
-            reason = self._paused_reason.replace("PAUSED_NEAR_", "").lower()
-            detail = f" ({self._paused_detail})" if self._paused_detail else ""
+        self._braking_count += 1
+        if self._braking_count >= self._confirm_ticks:
+            reason = self._braking_reason.replace("BRAKING_NEAR_", "").lower()
+            detail = f" ({self._braking_detail})" if self._braking_detail else ""
             raise MotionError(
                 self.motion_group_id,
-                f"Jogging paused: {reason}{detail}",
+                f"Jogging braking: {reason}{detail}",
             )

--- a/novapolicy/jogging/waypoint_session.py
+++ b/novapolicy/jogging/waypoint_session.py
@@ -1,8 +1,8 @@
 """Waypoint jogging session — sends timestamped position waypoints directly.
 
-Uses NOVA's JointWaypointsRequest and PoseWaypointsRequest to stream action
-chunks. The server handles velocity profiling, interpolation, and limits
-internally.
+Uses NOVA's action-chunk-streaming API (``ActionChunkRequest`` with unified
+joint/pose waypoints) to stream action chunks. The server handles velocity
+profiling, interpolation, and limits internally.
 """
 
 from __future__ import annotations
@@ -190,7 +190,7 @@ class WaypointJoggingSession:
     ) -> None:
         """Queue a new action chunk as waypoints.
 
-        Builds a JointWaypointsRequest or PoseWaypointsRequest (based on mode)
+        Builds an ActionChunkRequest (joint or pose waypoints, based on mode)
         with absolute server-time timestamps laid out as ``base + i*dt``. The
         request is sent on the next jogging loop iteration; the timestamps are
         computed at *yield time* (see :func:`make_waypoints_request`).
@@ -351,13 +351,15 @@ class WaypointJoggingSession:
         tcp = await self._resolve_tcp()
 
         async def client_request_generator(
-            response_stream: AsyncGenerator[api.models.ExecuteWaypointJoggingResponse, None],
-        ) -> AsyncGenerator[api.models.ExecuteWaypointJoggingRequest, None]:
-            # 1. Initialize the jogging session.
+            response_stream: AsyncGenerator[api.models.ExecuteActionChunksResponse, None],
+        ) -> AsyncGenerator[api.models.ExecuteActionChunksRequest, None]:
+            # 1. Initialize the action-chunk-streaming session.
             # The server starts its internal timer when the first waypoint
-            # request arrives (not on InitializeJoggingRequest).
-            yield api.models.ExecuteWaypointJoggingRequest(
-                api.models.InitializeJoggingRequest(motion_group=self._motion_group.id, tcp=tcp)
+            # request arrives (not on InitializeActionChunksRequest).
+            yield api.models.ExecuteActionChunksRequest(
+                api.models.InitializeActionChunksRequest(
+                    motion_group=self._motion_group.id, tcp=tcp
+                )
             )
 
             # 2. Main loop: for each server response, either send a new
@@ -368,7 +370,7 @@ class WaypointJoggingSession:
                     return
 
                 # Signal that the session is ready on first server response.
-                # This means InitializeJoggingRequest was acknowledged and
+                # This means InitializeActionChunksRequest was acknowledged and
                 # the server is ready to accept waypoints.
                 if not self._ready.is_set():
                     self._ready.set()
@@ -412,10 +414,10 @@ class WaypointJoggingSession:
                     anchor_offset_steps=pending.anchor_offset_steps,
                 )
 
-                yield api.models.ExecuteWaypointJoggingRequest(request)
+                yield api.models.ExecuteActionChunksRequest(request)
 
         try:
-            await api_gateway.jogging_api.execute_waypoint_jogging(
+            await api_gateway.action_chunk_streaming_api.execute_action_chunks(
                 cell=cell,
                 controller=controller_id,
                 client_request_generator=client_request_generator,
@@ -424,7 +426,7 @@ class WaypointJoggingSession:
             # Expected on shutdown; cancellation is not a jogging failure.
             pass
         except InvalidStatus as e:
-            # An old api-gateway (< 26.5) has no executeWaypointJogging endpoint
+            # An old api-gateway (< 26.6) has no executeActionChunks endpoint
             # and rejects the websocket upgrade with HTTP 404. Surface that as an
             # actionable error rather than a generic connection loss.
             if e.response.status_code == _HTTP_NOT_FOUND:

--- a/novapolicy/jogging/waypoints.py
+++ b/novapolicy/jogging/waypoints.py
@@ -1,8 +1,11 @@
-"""Waypoint request construction for jogging.
+"""Timestamped waypoint construction for action-chunk jogging.
 
-Pure helpers that turn raw action steps + timing into NOVA API request models
-(``JointWaypointsRequest`` / ``PoseWaypointsRequest``), plus the small
-pending-chunk record. No session state lives here — the session passes in its
+The NOVA endpoint is now named action-chunk streaming, but each chunk is still
+serialized as a list of timestamped waypoints. Keep this module focused on that
+lower-level waypoint shape: pure helpers that turn raw action steps + timing into
+a NOVA API ``ActionChunkRequest`` (a single list of timestamped waypoints, each
+carrying either joint or Cartesian coordinates), plus the small pending-chunk
+record. No session state lives here — the session passes in its
 :class:`~novapolicy.jogging.clock.JoggingTimeClock` and mode.
 """
 
@@ -44,7 +47,7 @@ def make_waypoints_request(
     anchor_ms: int = NOW,
     anchor_offset_steps: int = 0,
 ) -> object:
-    """Build a JointWaypointsRequest or PoseWaypointsRequest at stream-yield time.
+    """Build an ActionChunkRequest at stream-yield time.
 
     Every waypoint carries an absolute server-time timestamp laid out as
     ``base + i*dt``. The only decision is where ``base`` (step 0) sits:
@@ -75,24 +78,30 @@ def make_waypoints_request(
 
 
 def _build_joint_request(timestamps: list[int], steps: list[list[float]]) -> object:
-    """Build a JointWaypointsRequest from timestamps and joint steps.
+    """Build an ActionChunkRequest of joint waypoints from timestamps and steps.
 
-    The request uses the array-of-structs layout: a single ``waypoints``
-    list where each ``JointWaypoint`` bundles its timestamp with its joints.
+    Each ``Waypoint`` bundles its timestamp with a ``JointWaypoint`` (discriminated
+    by ``kind == "JOINTS"``) carrying the joint positions.
     """
-    return api.models.JointWaypointsRequest(
+    return api.models.ActionChunkRequest(
         waypoints=[
-            api.models.JointWaypoint(timestamp=ts, joints=api.models.Joints(root=step))
+            api.models.Waypoint(
+                timestamp=ts,
+                waypoint=api.models.WaypointCoordinates(
+                    api.models.JointWaypoint(joints=api.models.Joints(root=step))
+                ),
+            )
             for ts, step in zip(timestamps, steps, strict=True)
         ],
     )
 
 
 def _build_pose_request(timestamps: list[int], steps: list[list[float]]) -> object:
-    """Build a PoseWaypointsRequest from timestamps and TCP pose steps.
+    """Build an ActionChunkRequest of pose waypoints from timestamps and steps.
 
     Each step is [x, y, z, rx, ry, rz] where position is in mm and
-    orientation is a rotation vector in radians.
+    orientation is a rotation vector in radians. Each ``Waypoint`` bundles its
+    timestamp with a ``PoseWaypoint`` (discriminated by ``kind == "POSE"``).
     """
     from wandelbots_api_client.v2_pydantic.models.models import (  # noqa: PLC0415
         Pose as ApiPose,
@@ -106,7 +115,12 @@ def _build_pose_request(timestamps: list[int], steps: list[list[float]]) -> obje
         pos = Vector3d(root=list(step[:3]))
         orient = RotationVector(root=list(step[3:6]))
         waypoints.append(
-            api.models.PoseWaypoint(timestamp=ts, pose=ApiPose(position=pos, orientation=orient))
+            api.models.Waypoint(
+                timestamp=ts,
+                waypoint=api.models.WaypointCoordinates(
+                    api.models.PoseWaypoint(pose=ApiPose(position=pos, orientation=orient))
+                ),
+            )
         )
 
-    return api.models.PoseWaypointsRequest(waypoints=waypoints)
+    return api.models.ActionChunkRequest(waypoints=waypoints)

--- a/novapolicy/tests/api/test_executor.py
+++ b/novapolicy/tests/api/test_executor.py
@@ -254,9 +254,9 @@ async def test_a_tcp_action_schema_opens_a_cartesian_session_and_sends_pose_wayp
 
     The README/jogging.md claim is that request type is picked from the schema,
     not configured by hand. So a policy returning a flat pose dict must (1) open
-    its session in ``mode="cartesian"`` (the PoseWaypointsRequest path) and (2)
-    have its six pose values routed through as a single 6-D waypoint — never
-    mistaken for joint targets.
+    its session in ``mode="cartesian"`` (the POSE waypoint path) and (2) have
+    its six pose values routed through as a single 6-D waypoint — never mistaken
+    for joint targets.
     """
     mg = _mg()
     schema = PolicySchema(observations=[Observation.tcp("eef", source=mg, action=True)])

--- a/novapolicy/tests/api/test_waypoint_session.py
+++ b/novapolicy/tests/api/test_waypoint_session.py
@@ -3,7 +3,7 @@
 These drive the *real* async jogging + state-stream loops, substituting only
 the NOVA SDK boundary: the motion group, the API gateway, and the small
 ``_sdk`` accessors. The fake gateway plays the role of the server — it feeds the
-session a response stream and records the ``ExecuteWaypointJoggingRequest`` messages the
+session a response stream and records the ``ExecuteActionChunksRequest`` messages the
 session yields back.
 
 Assertions are on the contract, not internals:
@@ -38,12 +38,13 @@ _SESSION = "novapolicy.jogging.waypoint_session"
 
 
 # ---------------------------------------------------------------------------
-# Fake server: stands in for api_gateway.jogging_api.execute_waypoint_jogging
+# Fake server: stands in for
+# api_gateway.action_chunk_streaming_api.execute_action_chunks
 # ---------------------------------------------------------------------------
 
 
 def _ok() -> object:
-    """A normal jogging response (no motion error)."""
+    """A normal action-chunk response (no motion error)."""
     return SimpleNamespace(root=SimpleNamespace())
 
 
@@ -55,10 +56,10 @@ def _motion_error(message: str = "joint_limit") -> object:
 class FakeJoggingServer:
     """Consumes the session's request generator and replays scripted responses.
 
-    The session yields an ``InitializeJoggingRequest`` first, then one waypoint
-    request per response it receives (once a chunk is queued). We keep emitting
-    ``_ok()`` responses on a short cadence until stopped, recording every
-    request the session produces.
+    The session yields an ``InitializeActionChunksRequest`` first, then one
+    ActionChunkRequest per response it receives (once a chunk is queued). We keep
+    emitting ``_ok()`` responses on a short cadence until stopped, recording
+    every request the session produces.
     """
 
     def __init__(
@@ -69,7 +70,7 @@ class FakeJoggingServer:
         self._raise_exc = raise_exc
         self._stop = asyncio.Event()
 
-    async def execute_waypoint_jogging(
+    async def execute_action_chunks(
         self,
         *,
         cell: str,
@@ -116,7 +117,7 @@ def _initial_state() -> object:
 def _stream_state(state: object, *, ts_ms: int = 0, kind: str | None = None) -> object:
     """One MotionGroupState as yielded by ``stream_state``."""
     jog_state = SimpleNamespace(kind=kind) if kind is not None else None
-    details = SimpleNamespace(jogger_session_timestamp_ms=ts_ms, state=jog_state)
+    details = SimpleNamespace(session_timestamp_ms=ts_ms, state=jog_state)
     return SimpleNamespace(
         joint_position=list(state.joints),
         tcp_pose=None,  # keep the initial pose; avoids constructing a Pose here
@@ -150,7 +151,7 @@ def _build_session(
     mg.tcp_names = AsyncMock(return_value=["Flange"])
 
     gateway = MagicMock()
-    gateway.jogging_api.execute_waypoint_jogging = server.execute_waypoint_jogging
+    gateway.action_chunk_streaming_api.execute_action_chunks = server.execute_action_chunks
 
     session = WaypointJoggingSession(
         motion_group=mg,
@@ -181,7 +182,7 @@ async def _wait_until(predicate: Callable[[], bool], *, timeout: float = 1.0) ->
 
 
 def _inner(request: object) -> object:
-    """Unwrap the ExecuteWaypointJoggingRequest envelope to the concrete message."""
+    """Unwrap the ExecuteActionChunksRequest envelope to the concrete message."""
     return getattr(request, "root", request)
 
 
@@ -192,13 +193,13 @@ def _inner(request: object) -> object:
 
 @pytest.mark.asyncio
 async def test_it_initializes_the_jogging_session_before_any_waypoints():
-    """The very first message to the server is an InitializeJoggingRequest."""
+    """The very first message to the server is an InitializeActionChunksRequest."""
     session, server = _build_session()
     try:
         await session.start()
         await session.wait_ready()
         await _wait_until(lambda: len(server.requests) >= 1)
-        assert isinstance(_inner(server.requests[0]), api.models.InitializeJoggingRequest)
+        assert isinstance(_inner(server.requests[0]), api.models.InitializeActionChunksRequest)
     finally:
         server.stop()
         await session.stop()
@@ -208,7 +209,7 @@ async def test_it_initializes_the_jogging_session_before_any_waypoints():
 
 @pytest.mark.asyncio
 async def test_a_queued_joint_chunk_is_sent_as_a_timestamped_waypoint():
-    """update_chunk(step) reaches the server as a JointWaypointsRequest."""
+    """update_chunk(step) reaches the server as an ActionChunkRequest."""
     session, server = _build_session()
     try:
         await session.start()
@@ -218,10 +219,11 @@ async def test_a_queued_joint_chunk_is_sent_as_a_timestamped_waypoint():
 
         await _wait_until(lambda: len(server.requests) >= 2)
         waypoint_req = _inner(server.requests[1])
-        assert isinstance(waypoint_req, api.models.JointWaypointsRequest)
+        assert isinstance(waypoint_req, api.models.ActionChunkRequest)
         assert len(waypoint_req.waypoints) == 1
         sent = waypoint_req.waypoints[0]
-        assert list(sent.joints.root) == target
+        assert sent.waypoint.root.kind == "JOINTS"
+        assert list(sent.waypoint.root.joints.root) == target
         assert sent.timestamp == 0  # absolute anchor at 0, single step
     finally:
         server.stop()
@@ -323,7 +325,7 @@ async def test_a_fired_stop_condition_ends_the_session_without_failing():
 @pytest.mark.asyncio
 async def test_jog_tcp_chunk_is_sent_as_evenly_spaced_pose_waypoints():
     """A TCP chunk pushed through ``jog_tcp`` reaches the server as a single
-    ``PoseWaypointsRequest`` whose waypoints carry the chunk's poses and
+    ``ActionChunkRequest`` whose POSE waypoints carry the chunk's poses and
     timestamps laid out exactly as the waypoint API expects: absolute,
     non-negative, strictly increasing, and spaced by ``dt_ms``.
 
@@ -334,7 +336,7 @@ async def test_jog_tcp_chunk_is_sent_as_evenly_spaced_pose_waypoints():
     server = FakeJoggingServer()
 
     async def state_stream(**_kw: object) -> AsyncGenerator[object, None]:
-        # No jogger_session_timestamp_ms (ts_ms=0 is ignored), so the clock's
+        # No session_timestamp_ms (ts_ms=0 is ignored), so the clock's
         # speed_ratio stays 1.0 and server-time == client-time: dt is unscaled.
         while True:
             yield _stream_state(_initial_state(), kind="RUNNING")
@@ -348,7 +350,7 @@ async def test_jog_tcp_chunk_is_sent_as_evenly_spaced_pose_waypoints():
     mg.tcp_names = AsyncMock(return_value=["Flange"])
 
     gateway = MagicMock()
-    gateway.jogging_api.execute_waypoint_jogging = server.execute_waypoint_jogging
+    gateway.action_chunk_streaming_api.execute_action_chunks = server.execute_action_chunks
 
     estop = MagicMock()
     estop.start = AsyncMock()
@@ -375,22 +377,23 @@ async def test_jog_tcp_chunk_is_sent_as_evenly_spaced_pose_waypoints():
             jogger.set_target(chunk, dt_ms=dt_ms)
             await _wait_until(
                 lambda: any(
-                    isinstance(_inner(r), api.models.PoseWaypointsRequest) for r in server.requests
+                    isinstance(_inner(r), api.models.ActionChunkRequest) for r in server.requests
                 )
             )
 
         pose_req = next(
             _inner(r)
             for r in server.requests
-            if isinstance(_inner(r), api.models.PoseWaypointsRequest)
+            if isinstance(_inner(r), api.models.ActionChunkRequest)
         )
         waypoints = pose_req.waypoints
 
         # Every chunk step became one pose waypoint, in order.
         assert len(waypoints) == len(chunk)
         for sent, expected in zip(waypoints, chunk, strict=True):
-            assert [sent.pose.position.root[k] for k in range(3)] == expected[:3]
-            assert [sent.pose.orientation.root[k] for k in range(3)] == expected[3:6]
+            assert sent.waypoint.root.kind == "POSE"
+            assert [sent.waypoint.root.pose.position.root[k] for k in range(3)] == expected[:3]
+            assert [sent.waypoint.root.pose.orientation.root[k] for k in range(3)] == expected[3:6]
 
         # Timestamps: the layout the waypoint API expects.
         timestamps = [w.timestamp for w in waypoints]
@@ -424,7 +427,9 @@ async def test_overlapping_tcp_chunks_share_one_absolute_timeline():
         return [
             r
             for r in (_inner(x) for x in server.requests)
-            if isinstance(r, api.models.PoseWaypointsRequest)
+            if isinstance(r, api.models.ActionChunkRequest)
+            and r.waypoints
+            and r.waypoints[0].waypoint.root.kind == "POSE"
         ]
 
     try:
@@ -445,10 +450,12 @@ async def test_overlapping_tcp_chunks_share_one_absolute_timeline():
 
         first, second = _pose_requests()[0], _pose_requests()[1]
         a_by_ts = {
-            w.timestamp: tuple(w.pose.position.root[k] for k in range(3)) for w in first.waypoints
+            w.timestamp: tuple(w.waypoint.root.pose.position.root[k] for k in range(3))
+            for w in first.waypoints
         }
         b_by_ts = {
-            w.timestamp: tuple(w.pose.position.root[k] for k in range(3)) for w in second.waypoints
+            w.timestamp: tuple(w.waypoint.root.pose.position.root[k] for k in range(3))
+            for w in second.waypoints
         }
 
         # The two chunks share four absolute timestamps...
@@ -471,8 +478,8 @@ async def test_overlapping_joint_chunks_share_one_absolute_timeline():
     joint targets at identical absolute timestamps.
 
     Same per-tick resend as the TCP case, but the joint path emits
-    ``JointWaypointsRequest`` messages. The absolute-timeline guarantee is
-    mode-independent, so the overlap must coincide here too.
+    ``ActionChunkRequest`` messages with JOINTS waypoints. The absolute-timeline
+    guarantee is mode-independent, so the overlap must coincide here too.
     """
     session, server = _build_session(mode="joint")
 
@@ -480,7 +487,9 @@ async def test_overlapping_joint_chunks_share_one_absolute_timeline():
         return [
             r
             for r in (_inner(x) for x in server.requests)
-            if isinstance(r, api.models.JointWaypointsRequest)
+            if isinstance(r, api.models.ActionChunkRequest)
+            and r.waypoints
+            and r.waypoints[0].waypoint.root.kind == "JOINTS"
         ]
 
     try:
@@ -499,8 +508,8 @@ async def test_overlapping_joint_chunks_share_one_absolute_timeline():
         await _wait_until(lambda: len(_joint_requests()) >= 2)
 
         first, second = _joint_requests()[0], _joint_requests()[1]
-        a_by_ts = {w.timestamp: tuple(w.joints.root) for w in first.waypoints}
-        b_by_ts = {w.timestamp: tuple(w.joints.root) for w in second.waypoints}
+        a_by_ts = {w.timestamp: tuple(w.waypoint.root.joints.root) for w in first.waypoints}
+        b_by_ts = {w.timestamp: tuple(w.waypoint.root.joints.root) for w in second.waypoints}
 
         overlap = set(a_by_ts) & set(b_by_ts)
         assert overlap == {150, 200, 250, 300}

--- a/novapolicy/tests/unit/test_jogging_clock.py
+++ b/novapolicy/tests/unit/test_jogging_clock.py
@@ -1,6 +1,7 @@
 """Tests for JoggingTimeClock — pins the server-time-sync heuristic behavior.
 
-The clock keys off ``jogger_session_timestamp_ms`` from the state stream:
+The clock keys off ``session_timestamp_ms`` from the state stream
+(``ActionChunkStreamingDetails``):
   * while that field stays 0 (never wired up / not yet advancing) the clock
     never syncs and ``speed_ratio`` stays 1.0 (scaling is a no-op);
   * once it advances, ``speed_ratio`` becomes an active multiplier applied to
@@ -24,7 +25,7 @@ def test_unsynced_clock_is_identity():
 
 
 def test_zero_timestamp_never_syncs():
-    """A jogger_session_timestamp_ms stuck at 0 must not flip the clock to synced."""
+    """A session_timestamp_ms stuck at 0 must not flip the clock to synced."""
     clock = JoggingTimeClock()
     clock.start()
     for _ in range(5):
@@ -59,10 +60,10 @@ def test_ratio_clamped_to_at_least_one():
 
 
 def test_extract_from_state_walks_execute_details():
-    """extract_from_state reads execute.details.jogger_session_timestamp_ms."""
+    """extract_from_state reads execute.details.session_timestamp_ms."""
 
     class _Details:
-        jogger_session_timestamp_ms = 123
+        session_timestamp_ms = 123
 
     class _Execute:
         details = _Details()

--- a/novapolicy/tests/unit/test_jogging_state.py
+++ b/novapolicy/tests/unit/test_jogging_state.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from novapolicy.jogging import JoggingStateTracker
-from novapolicy.jogging.session import _BLOCKING_PAUSES
+from novapolicy.jogging.session import _BLOCKING_BRAKES
 from novapolicy.types import MotionError
 
 
@@ -38,11 +38,11 @@ def test_collision_raises_after_confirm():
 
     # First 2 ticks — confirmed but not yet at threshold
     for _ in range(2):
-        t.update_from_state(_state("PAUSED_NEAR_COLLISION"))
+        t.update_from_state(_state("BRAKING_NEAR_COLLISION"))
         t.check()  # Should not raise yet
 
     # 3rd tick → should raise
-    t.update_from_state(_state("PAUSED_NEAR_COLLISION"))
+    t.update_from_state(_state("BRAKING_NEAR_COLLISION"))
     with pytest.raises(MotionError, match="collision"):
         t.check()
 
@@ -50,9 +50,9 @@ def test_collision_raises_after_confirm():
 def test_joint_limit_raises():
     t = JoggingStateTracker("0@ur10e", confirm_ticks=3)
     for _ in range(2):
-        t.update_from_state(_state("PAUSED_NEAR_JOINT_LIMIT", joint_indices=[2, 4]))
+        t.update_from_state(_state("BRAKING_NEAR_JOINT_LIMIT", joint_indices=[2, 4]))
         t.check()  # Should not raise yet (count < 3)
-    t.update_from_state(_state("PAUSED_NEAR_JOINT_LIMIT", joint_indices=[2, 4]))
+    t.update_from_state(_state("BRAKING_NEAR_JOINT_LIMIT", joint_indices=[2, 4]))
     with pytest.raises(MotionError, match="joint_limit"):
         t.check()
 
@@ -60,29 +60,39 @@ def test_joint_limit_raises():
 def test_singularity_raises():
     t = JoggingStateTracker("0@ur10e", confirm_ticks=3)
     for _ in range(2):
-        t.update_from_state(_state("PAUSED_NEAR_SINGULARITY"))
+        t.update_from_state(_state("BRAKING_NEAR_SINGULARITY"))
         t.check()
-    t.update_from_state(_state("PAUSED_NEAR_SINGULARITY"))
+    t.update_from_state(_state("BRAKING_NEAR_SINGULARITY"))
     with pytest.raises(MotionError, match="singularity"):
         t.check()
 
 
-def test_transient_pause_resets():
-    """A brief pause followed by RUNNING doesn't accumulate."""
+def test_workspace_boundary_raises():
+    t = JoggingStateTracker("0@ur10e", confirm_ticks=3)
+    for _ in range(2):
+        t.update_from_state(_state("BRAKING_NEAR_WORKSPACE_BOUNDARY"))
+        t.check()
+    t.update_from_state(_state("BRAKING_NEAR_WORKSPACE_BOUNDARY"))
+    with pytest.raises(MotionError, match="workspace_boundary"):
+        t.check()
+
+
+def test_transient_braking_resets():
+    """A brief braking state followed by RUNNING doesn't accumulate."""
     t = JoggingStateTracker("0@ur10e", confirm_ticks=5)
 
-    # 2 ticks paused
+    # 2 braking ticks
     for _ in range(2):
-        t.update_from_state(_state("PAUSED_NEAR_COLLISION"))
+        t.update_from_state(_state("BRAKING_NEAR_COLLISION"))
         t.check()
 
     # Back to running — resets counter
     t.update_from_state(_state("RUNNING"))
     t.check()
 
-    # 2 more ticks paused — still below threshold
+    # 2 more braking ticks — still below threshold
     for _ in range(2):
-        t.update_from_state(_state("PAUSED_NEAR_COLLISION"))
+        t.update_from_state(_state("BRAKING_NEAR_COLLISION"))
         t.check()  # Should not raise (only 2, not 5)
 
 
@@ -96,8 +106,8 @@ def test_no_execute_details_is_safe():
         t.check()
 
 
-def test_unknown_pause_type_does_not_trigger():
-    """Only _BLOCKING_PAUSES trigger — other kinds are ignored."""
+def test_unknown_state_type_does_not_trigger():
+    """Only _BLOCKING_BRAKES trigger — other kinds are ignored."""
     t = JoggingStateTracker("0@ur10e", confirm_ticks=1)
     t.update_from_state(_state("PAUSED_SOME_OTHER_REASON"))
     t.check()  # Should not raise
@@ -106,17 +116,25 @@ def test_unknown_pause_type_does_not_trigger():
 def test_paused_by_user_is_recoverable_and_never_raises():
     """PAUSED_BY_USER (waypoint buffer exhausted) is recoverable, not a fault.
 
-    jogging.md lists PAUSED_BY_USER alongside the fatal pause states, but it
-    means "the buffer emptied, send chunks faster" — the robot resumes once a
-    new chunk arrives. It must NOT be in _BLOCKING_PAUSES and must never raise,
+    It means "the buffer emptied, send chunks faster" — the robot resumes once a
+    new chunk arrives. It must NOT be in _BLOCKING_BRAKES and must never raise,
     no matter how many consecutive ticks report it. This pins that contract so a
     well-meaning edit that "completes" the table by adding PAUSED_BY_USER to the
     blocking set would fail here.
     """
-    assert "PAUSED_BY_USER" not in _BLOCKING_PAUSES
+    assert "PAUSED_BY_USER" not in _BLOCKING_BRAKES
     t = JoggingStateTracker("0@ur10e", confirm_ticks=2)
     for _ in range(20):
         t.update_from_state(_state("PAUSED_BY_USER"))
+        t.check()  # never raises
+
+
+def test_stopped_by_user_is_terminal_but_not_motion_error():
+    """STOPPED_BY_USER is reported by the stream but must not look like braking."""
+    assert "STOPPED_BY_USER" not in _BLOCKING_BRAKES
+    t = JoggingStateTracker("0@ur10e", confirm_ticks=2)
+    for _ in range(20):
+        t.update_from_state(_state("STOPPED_BY_USER"))
         t.check()  # never raises
 
 
@@ -138,9 +156,11 @@ from hypothesis.stateful import (  # noqa: E402
     rule,
 )
 
-# Kinds that must NOT count toward a trip: RUNNING, no execute details, and a
-# pause type that isn't one of the blocking pauses.
-_CLEARING_KINDS = st.sampled_from(["RUNNING", "PAUSED_SOME_OTHER_REASON", None])
+# Kinds that must NOT count toward a trip: RUNNING, user pause/stop, no execute
+# details, and a state type that isn't one of the blocking brakes.
+_CLEARING_KINDS = st.sampled_from(
+    ["RUNNING", "PAUSED_BY_USER", "STOPPED_BY_USER", "PAUSED_SOME_OTHER_REASON", None]
+)
 
 
 def _tick_state(kind):
@@ -162,7 +182,7 @@ class JoggingDebounceMachine(RuleBasedStateMachine):
         self.tracker = JoggingStateTracker("0@ur10e", confirm_ticks=ticks)
         self.streak = 0  # consecutive blocking ticks that have been checked
 
-    @rule(kind=st.sampled_from(sorted(_BLOCKING_PAUSES)))
+    @rule(kind=st.sampled_from(sorted(_BLOCKING_BRAKES)))
     def blocking_tick(self, kind):
         self.tracker.update_from_state(_tick_state(kind))
         self.streak += 1

--- a/novapolicy/tests/unit/test_waypoints.py
+++ b/novapolicy/tests/unit/test_waypoints.py
@@ -1,8 +1,9 @@
 """Tests for make_waypoints_request — the documented jogging timestamp protocol.
 
 This pure function turns raw steps + dt + an anchor into a NOVA
-JointWaypointsRequest or PoseWaypointsRequest, scaling every timestamp by the
-clock's speed ratio. Every waypoint is ``base + i*dt``; only ``base`` varies:
+``ActionChunkRequest`` (a single list of timestamped waypoints, each carrying
+either joint or Cartesian coordinates), scaling every timestamp by the clock's
+speed ratio. Every waypoint is ``base + i*dt``; only ``base`` varies:
   * explicit anchor (``anchor_ms >= 0``): base is that anchor;
   * "now" anchor (``anchor_ms == NOW``): base is the clock's current elapsed;
   * ``anchor_offset_steps`` then shifts base by whole dt steps (+1 ahead for
@@ -25,7 +26,7 @@ def _joint_timestamps(req) -> list[int]:
 
 
 def _joint_steps(req) -> list[list[float]]:
-    return [list(w.joints.root) for w in req.waypoints]
+    return [list(w.waypoint.root.joints.root) for w in req.waypoints]
 
 
 # ---------------------------------------------------------------------------
@@ -38,7 +39,7 @@ def test_absolute_mode_places_timestamps_starting_at_the_scaled_base():
     clock = JoggingTimeClock(speed_ratio=1.0)
     steps = [[0.0] * 6, [0.1] * 6, [0.2] * 6]
     req = make_waypoints_request(clock, "joint", steps=steps, effective_dt_ms=10.0, anchor_ms=100)
-    assert isinstance(req, api.models.JointWaypointsRequest)
+    assert isinstance(req, api.models.ActionChunkRequest)
     assert _joint_timestamps(req) == [100, 110, 120]
     assert _joint_steps(req) == steps
 
@@ -128,20 +129,22 @@ def test_cartesian_mode_builds_a_pose_request_splitting_position_and_orientation
     clock = JoggingTimeClock(speed_ratio=1.0)
     steps = [[500.0, 200.0, 300.0, 0.1, 0.2, 0.3]]
     req = make_waypoints_request(clock, "cartesian", steps=steps, effective_dt_ms=10.0, anchor_ms=0)
-    assert isinstance(req, api.models.PoseWaypointsRequest)
+    assert isinstance(req, api.models.ActionChunkRequest)
     wp = req.waypoints[0]
     assert wp.timestamp == 0
-    assert list(wp.pose.position.root) == [500.0, 200.0, 300.0]
-    assert list(wp.pose.orientation.root) == [0.1, 0.2, 0.3]
+    assert wp.waypoint.root.kind == "POSE"
+    assert list(wp.waypoint.root.pose.position.root) == [500.0, 200.0, 300.0]
+    assert list(wp.waypoint.root.pose.orientation.root) == [0.1, 0.2, 0.3]
 
 
 def test_joint_mode_builds_a_joint_request():
-    """The mode argument selects the request type: 'joint' -> JointWaypointsRequest."""
+    """The mode argument selects the waypoint kind: 'joint' -> JOINTS waypoints."""
     clock = JoggingTimeClock(speed_ratio=1.0)
     req = make_waypoints_request(
         clock, "joint", steps=[[0.0] * 6], effective_dt_ms=10.0, anchor_ms=0
     )
-    assert isinstance(req, api.models.JointWaypointsRequest)
+    assert isinstance(req, api.models.ActionChunkRequest)
+    assert req.waypoints[0].waypoint.root.kind == "JOINTS"
 
 
 def test_empty_steps_produce_no_waypoints():

--- a/novapolicy/types.py
+++ b/novapolicy/types.py
@@ -172,7 +172,7 @@ class JoggingNotSupportedError(Exception):
     def __init__(self, motion_group_id: str) -> None:
         self.motion_group_id = motion_group_id
         super().__init__(
-            f"Waypoint jogging is not available for '{motion_group_id}' on this "
+            f"Action-chunk streaming is not available for '{motion_group_id}' on this "
             "NOVA instance (the executeActionChunks endpoint returned HTTP 404). "
             "It requires api-gateway >= 26.6."
         )

--- a/novapolicy/types.py
+++ b/novapolicy/types.py
@@ -160,10 +160,10 @@ class MotionError(Exception):
 
 
 class JoggingNotSupportedError(Exception):
-    """Raised when the NOVA instance does not expose waypoint jogging.
+    """Raised when the NOVA instance does not expose action-chunk streaming.
 
-    The waypoint jogging websocket endpoint (``executeWaypointJogging``) only
-    exists on api-gateway ``>= 26.5``. Older gateways reject the upgrade with
+    The action-chunk-streaming websocket endpoint (``executeActionChunks``) only
+    exists on api-gateway ``>= 26.6``. Older gateways reject the upgrade with
     HTTP 404; we surface that as this actionable error instead of a generic
     connection failure, so callers know to upgrade NOVA rather than chase a
     network problem.
@@ -173,6 +173,6 @@ class JoggingNotSupportedError(Exception):
         self.motion_group_id = motion_group_id
         super().__init__(
             f"Waypoint jogging is not available for '{motion_group_id}' on this "
-            "NOVA instance (the executeWaypointJogging endpoint returned HTTP 404). "
-            "It requires api-gateway >= 26.5."
+            "NOVA instance (the executeActionChunks endpoint returned HTTP 404). "
+            "It requires api-gateway >= 26.6."
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,10 @@ requires-python = ">=3.11, <3.13"
 readme = "README.md"
 dependencies = [
     "httpx>=0.28.0,<0.29",
-    "wandelbots_api_client==26.5.0",
+    # Experimental action-chunk-streaming API (jogging endpoints refactored).
+    # Not yet on public PyPI; served from the Wandelbots internal GitLab index
+    # (see [[tool.uv.index]] below). Bump to the public 26.6.0 once released.
+    "wandelbots_api_client==26.6.0+a2441.9139a223.421798",
     "websockets>=14.1.0,<15",
     "loguru>=0.7.2,<0.8",
     "pydantic>=2.11.4,<3",
@@ -106,6 +109,17 @@ dev = [
 
 [tool.hatch.metadata]
 allow-direct-references = true
+
+[tool.uv.sources]
+wandelbots_api_client = { index = "wandelbots-internal" }
+
+[[tool.uv.index]]
+# Internal GitLab PyPI registry that serves per-MR api-client dev builds.
+# Auth via env: UV_INDEX_WANDELBOTS_INTERNAL_USERNAME=__token__
+#               UV_INDEX_WANDELBOTS_INTERNAL_PASSWORD=<gitlab-token>
+name = "wandelbots-internal"
+url = "https://code.wabo.run/api/v4/projects/889/packages/pypi/simple"
+explicit = true
 
 [tool.hatch.build.targets.sdist]
 include = ["nova", "nova_rerun_bridge", "wandelscript", "novax", "novapolicy"]

--- a/uv.lock
+++ b/uv.lock
@@ -1898,8 +1898,8 @@ sdist = { url = "https://files.pythonhosted.org/packages/91/26/430de0d8aaf5aad9f
 
 [[package]]
 name = "wandelbots-api-client"
-version = "26.5.0"
-source = { registry = "https://pypi.org/simple" }
+version = "26.6.0+a2441.9139a223.421798"
+source = { registry = "https://code.wabo.run/api/v4/projects/889/packages/pypi/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiohttp-retry" },
@@ -1913,14 +1913,14 @@ dependencies = [
     { name = "urllib3" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/db/9ee2b8464eea12442121e68920c3f287a401e36f3a8c60fbc5293d1a8c23/wandelbots_api_client-26.5.0.tar.gz", hash = "sha256:84541ef2670d50bc0ff234d61915d5484afdb32bc752b4781e3f516c43336346", size = 648166, upload-time = "2026-06-18T11:36:08.906Z" }
+sdist = { url = "https://code.wabo.run/api/v4/projects/889/packages/pypi/files/8984c7ff28326dde9973dd3de52404d96cadbbafd14688097ae2184485b70a07/wandelbots_api_client-26.6.0+a2441.9139a223.421798.tar.gz", hash = "sha256:8984c7ff28326dde9973dd3de52404d96cadbbafd14688097ae2184485b70a07" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/e0/d99c836c94dac05242e8fb5bdf6cecbda04a28de1f8cd828d672b08729e7/wandelbots_api_client-26.5.0-py3-none-any.whl", hash = "sha256:e699e255092402870a7330f2cbd4d28634f6fa930455b761f7f49696598b43ac", size = 1549405, upload-time = "2026-06-18T11:36:16.762Z" },
+    { url = "https://code.wabo.run/api/v4/projects/889/packages/pypi/files/31743bd206a5db1c8a6d94be53dc8cabbe7abc2dfb7c1a586a213f5817e465a5/wandelbots_api_client-26.6.0+a2441.9139a223.421798-py3-none-any.whl", hash = "sha256:31743bd206a5db1c8a6d94be53dc8cabbe7abc2dfb7c1a586a213f5817e465a5" },
 ]
 
 [[package]]
 name = "wandelbots-nova"
-version = "5.6.3"
+version = "5.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiostream" },
@@ -2034,7 +2034,7 @@ requires-dist = [
     { name = "trimesh", marker = "extra == 'nova-rerun-bridge'", specifier = ">=4.5.3" },
     { name = "typer", extras = ["all"], marker = "extra == 'wandelscript'", specifier = ">=0.12,<0.20" },
     { name = "uvicorn", marker = "extra == 'novax'", specifier = ">=0.34.0" },
-    { name = "wandelbots-api-client", specifier = "==26.5.0" },
+    { name = "wandelbots-api-client", specifier = "==26.6.0+a2441.9139a223.421798", index = "https://code.wabo.run/api/v4/projects/889/packages/pypi/simple" },
     { name = "websockets", specifier = ">=14.1.0,<15" },
 ]
 provides-extras = ["nova-rerun-bridge", "wandelscript", "novax", "novapolicy", "benchmark"]


### PR DESCRIPTION
Switch to action chunk streaming API. Old waypoint jogging API is removed in 26.6