### PR TITLE
feat(novapolicy): buffered jogging targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,5 +185,6 @@ DEV.md
 policy/examples/apps/gr00t/
 
 
-# Local-only clone examples (real-robot dry-runs, not for the repo)
+# Local-only clone/dev examples (real-robot dry-runs, not for the repo)
 policy/examples/**/*_clone.py
+novapolicy/examples/jogging/jogging_single_tcp_teleop_oscillation.py

--- a/novapolicy/docs/jogging.md
+++ b/novapolicy/docs/jogging.md
@@ -52,12 +52,14 @@ async with jog_joints(mg) as jogger:
         jogger.set_target(chunk, dt_ms=33.0)
 ```
 
-## Buffered teleop targets (`append_target`)
+## Buffered teleop targets (`buffer_ms`)
 
-For live teleoperation, prefer `append_target(...)` over one-point
-`set_target(...)`. It first fills a small local buffer (`buffer_ms`, default from
-`WaypointConfig.min_buffer_ms`, 100 ms), then sends a rolling chunk. This adds a
-fixed latency but prevents the controller from running out of waypoints.
+For live teleoperation, pass `buffer_ms` to `jog_joints(...)` or `jog_tcp(...)`.
+The user-facing loop stays the same: keep calling `set_target(...)`. Internally,
+the jogger first fills a small local time-based buffer, then sends a rolling
+chunk. This adds fixed latency but prevents the controller from running out of
+waypoints. The default is `buffer_ms=0.0`, which preserves immediate one-target
+jogging.
 
 When `dt_ms` is omitted, timing has two phases: while priming, sample spacing is
 estimated from input arrival time because `jogger.elapsed` cannot advance before
@@ -65,10 +67,10 @@ the first chunk is sent; after the first chunk starts jogging, timing follows
 `jogger.elapsed` / acknowledged controller time.
 
 ```python
-async with jog_tcp(mg, tcp="Flange") as jogger:
+async with jog_tcp(mg, tcp="Flange", buffer_ms=100.0) as jogger:
     async for state in jogger:
         pose = read_controller_pose()
-        jogger.append_target(pose, buffer_ms=100.0)
+        jogger.set_target(pose)
 ```
 
 ## Timing targets (`jogger.elapsed`)

--- a/novapolicy/docs/jogging.md
+++ b/novapolicy/docs/jogging.md
@@ -52,6 +52,25 @@ async with jog_joints(mg) as jogger:
         jogger.set_target(chunk, dt_ms=33.0)
 ```
 
+## Buffered teleop targets (`append_target`)
+
+For live teleoperation, prefer `append_target(...)` over one-point
+`set_target(...)`. It first fills a small local buffer (`buffer_ms`, default from
+`WaypointConfig.min_buffer_ms`, 100 ms), then sends a rolling chunk. This adds a
+fixed latency but prevents the controller from running out of waypoints.
+
+When `dt_ms` is omitted, timing has two phases: while priming, sample spacing is
+estimated from input arrival time because `jogger.elapsed` cannot advance before
+the first chunk is sent; after the first chunk starts jogging, timing follows
+`jogger.elapsed` / acknowledged controller time.
+
+```python
+async with jog_tcp(mg, tcp="Flange") as jogger:
+    async for state in jogger:
+        pose = read_controller_pose()
+        jogger.append_target(pose, buffer_ms=100.0)
+```
+
 ## Timing targets (`jogger.elapsed`)
 
 For time-parameterised motion (e.g. a sinusoid), drive it with `jogger.elapsed`

--- a/novapolicy/executor.py
+++ b/novapolicy/executor.py
@@ -377,6 +377,8 @@ class PolicyExecutor:
                 self._rerun.log_action_chunk(action, step, n_action_steps=self._n_action_steps)
 
             trimmed = trim_chunk(action, self._n_action_steps)
+            if self._rerun is not None:
+                self._rerun.log_target_tracking(trimmed, robot_states, step)
             self._send(trimmed)
             step += 1
             self.status.step = step

--- a/novapolicy/jogging/jogger.py
+++ b/novapolicy/jogging/jogger.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import math
 import time
 from typing import TYPE_CHECKING, overload
 
@@ -70,6 +71,10 @@ class _BaseJogger:
         self._first_yield_t: float | None = None
         self._ease_in_s = ease_in_s
         self._ease_baseline: dict[MotionGroup, list[float]] = {}
+        self._target_buffers: dict[MotionGroup, list[list[float]]] = {}
+        self._last_append_elapsed: dict[MotionGroup, float] = {}
+        self._last_append_wall: dict[MotionGroup, float] = {}
+        self._append_buffer_sent: set[MotionGroup] = set()
 
     @property
     def elapsed(self) -> float:
@@ -151,10 +156,7 @@ class _BaseJogger:
 
     def _validate_and_push(self, mg: MotionGroup, values: list[float]) -> None:
         """Validate target dimensions and push to session."""
-        expected = self._expected_dims(mg)
-        if expected is not None and len(values) != expected:
-            msg = f"Target has {len(values)} values but motion group '{mg.id}' expects {expected}"
-            raise ValueError(msg)
+        self._validate_target_dims(mg, values)
         session = self._sessions.get(mg)
         if session is not None:
             # Single-step live target: anchor at "now", one step ahead so the
@@ -164,7 +166,9 @@ class _BaseJogger:
             )
         self._log_target(mg.id, [values], 0.0)
 
-    def _push_target(self, mg: MotionGroup, value: list, dt_ms: float) -> list[float]:
+    def _push_target(
+        self, mg: MotionGroup, value: list, dt_ms: float, *, extend_buffer: bool = True
+    ) -> list[float]:
         """Push a single or chunk target to a session. Returns the final target."""
         session = self._sessions.get(mg)
         if session is None:
@@ -173,15 +177,109 @@ class _BaseJogger:
             # Chunked: absolute anchor on the jogger's own session timeline so
             # overlapping per-tick resends land identical steps at identical
             # timestamps (one coherent trajectory, no seam jump).
-            session.update_chunk(
-                steps=self._ease_steps(mg, value, dt_ms),
-                dt_ms=dt_ms,
-                anchor_ms=session.session_elapsed_ms,
-            )
+            kwargs = {
+                "steps": self._ease_steps(mg, value, dt_ms),
+                "dt_ms": dt_ms,
+                "anchor_ms": session.session_elapsed_ms,
+            }
+            if not extend_buffer:
+                kwargs["extend_buffer"] = False
+            session.update_chunk(**kwargs)
             self._log_target(mg.id, value, dt_ms)
             return value[-1]
         self._validate_and_push(mg, value)
         return value
+
+    def _append_target(
+        self,
+        mg: MotionGroup,
+        values: list[float],
+        *,
+        dt_ms: float | None,
+        buffer_ms: float | None = None,
+    ) -> bool:
+        """Append one live target sample and send a rolling buffered chunk once primed.
+
+        Timing has two phases when ``dt_ms`` is omitted:
+        * Priming: before the first buffered chunk is sent, sample spacing is
+          estimated from input arrival time because the jogger clock cannot run
+          until waypoints are sent.
+        * Streaming: after the first chunk starts jogging, sample spacing is
+          derived only from ``jogger.elapsed`` / acknowledged controller time.
+        """
+        self._validate_target_dims(mg, values)
+
+        effective_dt_ms = self._append_dt_ms(mg, dt_ms)
+        buffer = self._target_buffers.setdefault(mg, [])
+        if effective_dt_ms is None:
+            if mg not in self._append_buffer_sent and not buffer:
+                buffer.append(list(values))
+            return False
+
+        buffer.append(list(values))
+        min_buffer_ms = self._buffer_ms(mg, buffer_ms)
+        min_steps = max(1, math.ceil(min_buffer_ms / effective_dt_ms))
+        if len(buffer) > min_steps:
+            del buffer[: len(buffer) - min_steps]
+        if len(buffer) < min_steps:
+            return False
+
+        self._push_target(mg, [list(step) for step in buffer], effective_dt_ms, extend_buffer=False)
+        self._append_buffer_sent.add(mg)
+        return True
+
+    def _append_dt_ms(self, mg: MotionGroup, dt_ms: float | None) -> float | None:
+        if dt_ms is not None:
+            if dt_ms <= 0:
+                msg = "append_target requires dt_ms > 0"
+                raise ValueError(msg)
+            self._last_append_elapsed[mg] = self.elapsed
+            self._last_append_wall[mg] = time.monotonic()
+            return dt_ms
+
+        now_elapsed = self.elapsed
+        now_wall = time.monotonic()
+        previous_elapsed = self._last_append_elapsed.get(mg)
+        previous_wall = self._last_append_wall.get(mg)
+        self._last_append_elapsed[mg] = now_elapsed
+        self._last_append_wall[mg] = now_wall
+
+        if previous_elapsed is not None:
+            elapsed_ms = (now_elapsed - previous_elapsed) * 1000.0
+            if elapsed_ms > 0:
+                return elapsed_ms
+
+        # Startup only: before the first chunk is sent, jogger.elapsed may be
+        # frozen at 0 because the robot cannot enter RUNNING until it receives
+        # waypoints. Use wall-clock only to estimate input sample spacing for
+        # initial buffer priming; chunk timestamps are still anchored later on
+        # the server-synchronized jogging clock.
+        if mg not in self._append_buffer_sent and previous_wall is not None:
+            wall_ms = (now_wall - previous_wall) * 1000.0
+            return wall_ms if wall_ms > 0 else None
+
+        return None
+
+    def _clear_append_buffer(self, mg: MotionGroup) -> None:
+        """Forget buffered teleop samples when switching back to immediate targets."""
+        self._target_buffers.pop(mg, None)
+        self._last_append_elapsed.pop(mg, None)
+        self._last_append_wall.pop(mg, None)
+        self._append_buffer_sent.discard(mg)
+
+    def _validate_target_dims(self, mg: MotionGroup, values: list[float]) -> None:
+        expected = self._expected_dims(mg)
+        if expected is not None and len(values) != expected:
+            msg = f"Target has {len(values)} values but motion group '{mg.id}' expects {expected}"
+            raise ValueError(msg)
+
+    def _buffer_ms(self, mg: MotionGroup, buffer_ms: float | None) -> float:
+        if buffer_ms is not None:
+            return max(0.0, buffer_ms)
+        session = self._sessions.get(mg)
+        if session is None:
+            return 0.0
+        return max(0.0, session.config.min_buffer_ms)
 
     def _log_target(self, mg_id: str, steps: list[list[float]], dt_ms: float) -> None:
         """Log jogging target to Rerun as an action chunk visualization."""
@@ -192,10 +290,15 @@ class _BaseJogger:
         # Determine if this is joint or TCP based on session mode
         session_by_id = self._sessions_by_id()
         session = session_by_id.get(mg_id)
+        state = session.current_state if session is not None else None
         if session is not None and session.mode == "cartesian":
             chunk = ActionChunk(tcp={mg_id: steps}, dt_ms=dt_ms)
+            if steps and state is not None:
+                self._rerun.log_tcp_tracking(mg_id, steps[0], state, step=0)
         else:
             chunk = ActionChunk(joints={mg_id: steps}, dt_ms=dt_ms)
+            if steps and state is not None:
+                self._rerun.log_joint_tracking(mg_id, steps[0], state, step=0)
         self._rerun.log_action_chunk(chunk, step=0)
 
     def state(self) -> dict[MotionGroup, RobotState] | RobotState | None:
@@ -379,6 +482,47 @@ class JointJogger(_BaseJogger):
             return self._target.get(self._mg_list[0])
         return self._target
 
+    def append_target(
+        self,
+        target: list[float] | dict[MotionGroup, list[float]],
+        *,
+        dt_ms: float | None = None,
+        buffer_ms: float | None = None,
+    ) -> bool:
+        """Append one joint target sample to a rolling teleop buffer.
+
+        The first calls only fill the buffer. Once it contains ``buffer_ms`` of
+        samples, the first chunk is sent and starts the jogger/controller clock.
+        From then on, automatic timing uses ``jogger.elapsed``. This
+        intentionally adds latency equal to the buffer size, but keeps the
+        controller fed with future waypoints instead of one point at a time.
+
+        Returns ``True`` once a chunk was sent, ``False`` while the buffer is
+        still priming or while acknowledged jogger time has not advanced.
+        """
+        if isinstance(target, list):
+            if target and isinstance(target[0], list):
+                msg = "append_target accepts one target sample, not a chunk"
+                raise TypeError(msg)
+            if self._multi:
+                msg = "For multiple motion groups, pass a dict[MotionGroup, list[float]]"
+                raise TypeError(msg)
+            mg = self._mg_list[0]
+            sent = self._append_target(mg, target, dt_ms=dt_ms, buffer_ms=buffer_ms)
+            self._target = {mg: target}
+            return sent
+        if isinstance(target, dict):
+            self._target = self._target or {}
+            sent_any = False
+            for mg, values in target.items():
+                sent_any = (
+                    self._append_target(mg, values, dt_ms=dt_ms, buffer_ms=buffer_ms) or sent_any
+                )
+                self._target[mg] = values
+            return sent_any
+        msg = f"Expected list or dict, got {type(target)}"
+        raise TypeError(msg)
+
     def set_target(
         self,
         target: (
@@ -404,11 +548,13 @@ class JointJogger(_BaseJogger):
                 raise TypeError(msg)
             mg = self._mg_list[0]
             final = self._push_target(mg, target, dt_ms)
+            self._clear_append_buffer(mg)
             self._target = {mg: final}
         elif isinstance(target, dict):
             self._target = self._target or {}
             for mg, mg_value in target.items():
                 self._target[mg] = self._push_target(mg, mg_value, dt_ms)
+                self._clear_append_buffer(mg)
         else:
             msg = f"Expected list or dict, got {type(target)}"
             raise TypeError(msg)
@@ -471,6 +617,48 @@ class TcpJogger(_BaseJogger):
             return self._target.get(self._mg_list[0])
         return self._target
 
+    def append_target(
+        self,
+        target: Pose | dict[MotionGroup, Pose],
+        *,
+        dt_ms: float | None = None,
+        buffer_ms: float | None = None,
+    ) -> bool:
+        """Append one TCP target sample to a rolling teleop buffer.
+
+        The first calls only fill the buffer. Once it contains ``buffer_ms`` of
+        samples, the first chunk is sent and starts the jogger/controller clock.
+        From then on, automatic timing uses ``jogger.elapsed``. This
+        intentionally adds latency equal to the buffer size, but keeps the
+        controller fed with future waypoints instead of one point at a time.
+
+        Returns ``True`` once a chunk was sent, ``False`` while the buffer is
+        still priming or while acknowledged jogger time has not advanced.
+        """
+        from nova.types import Pose  # noqa: PLC0415
+
+        if isinstance(target, Pose):
+            if self._multi:
+                msg = "For multiple motion groups, pass a dict[MotionGroup, Pose]"
+                raise TypeError(msg)
+            mg = self._mg_list[0]
+            values = list(target.position) + list(target.orientation)
+            sent = self._append_target(mg, values, dt_ms=dt_ms, buffer_ms=buffer_ms)
+            self._target = {mg: target}
+            return sent
+        if isinstance(target, dict):
+            self._target = self._target or {}
+            sent_any = False
+            for mg, pose in target.items():
+                values = list(pose.position) + list(pose.orientation)
+                sent_any = (
+                    self._append_target(mg, values, dt_ms=dt_ms, buffer_ms=buffer_ms) or sent_any
+                )
+                self._target[mg] = pose
+            return sent_any
+        msg = f"Expected Pose or dict, got {type(target)}"
+        raise TypeError(msg)
+
     def set_target(
         self,
         target: Pose | list[list[float]] | dict[MotionGroup, Pose | list[list[float]]],
@@ -495,6 +683,7 @@ class TcpJogger(_BaseJogger):
                 raise TypeError(msg)
             mg = self._mg_list[0]
             self._validate_and_push(mg, list(target.position) + list(target.orientation))
+            self._clear_append_buffer(mg)
             self._target = {mg: target}
         elif isinstance(target, list):
             if self._multi:
@@ -502,6 +691,7 @@ class TcpJogger(_BaseJogger):
                 raise TypeError(msg)
             mg = self._mg_list[0]
             self._push_target(mg, target, dt_ms)
+            self._clear_append_buffer(mg)
             self._target = {mg: target[-1] if target and isinstance(target[0], list) else target}
         elif isinstance(target, dict):
             self._target = self._target or {}
@@ -512,6 +702,7 @@ class TcpJogger(_BaseJogger):
                 else:
                     self._push_target(mg, value, dt_ms)
                     self._target[mg] = value[-1] if value and isinstance(value[0], list) else value
+                self._clear_append_buffer(mg)
         else:
             msg = f"Expected Pose, list, or dict, got {type(target)}"
             raise TypeError(msg)

--- a/novapolicy/jogging/jogger.py
+++ b/novapolicy/jogging/jogger.py
@@ -59,6 +59,7 @@ class _BaseJogger:
         *,
         start_joint_position: dict[MotionGroup, list[float]] | None = None,
         ease_in_s: float = 0.0,
+        buffer_ms: float = 0.0,
     ) -> None:
         self._mg_list = mg_list
         self._multi = len(mg_list) > 1
@@ -71,10 +72,14 @@ class _BaseJogger:
         self._first_yield_t: float | None = None
         self._ease_in_s = ease_in_s
         self._ease_baseline: dict[MotionGroup, list[float]] = {}
+        if buffer_ms < 0:
+            msg = "buffer_ms must be greater than or equal to 0"
+            raise ValueError(msg)
+        self._buffer_ms = buffer_ms
         self._target_buffers: dict[MotionGroup, list[list[float]]] = {}
-        self._last_append_elapsed: dict[MotionGroup, float] = {}
-        self._last_append_wall: dict[MotionGroup, float] = {}
-        self._append_buffer_sent: set[MotionGroup] = set()
+        self._last_target_elapsed: dict[MotionGroup, float] = {}
+        self._last_target_wall: dict[MotionGroup, float] = {}
+        self._buffer_started: set[MotionGroup] = set()
 
     @property
     def elapsed(self) -> float:
@@ -190,96 +195,69 @@ class _BaseJogger:
         self._validate_and_push(mg, value)
         return value
 
-    def _append_target(
-        self,
-        mg: MotionGroup,
-        values: list[float],
-        *,
-        dt_ms: float | None,
-        buffer_ms: float | None = None,
-    ) -> bool:
-        """Append one live target sample and send a rolling buffered chunk once primed.
+    def _set_live_target(self, mg: MotionGroup, values: list[float], *, dt_ms: float = 0.0) -> None:
+        """Send one live target immediately or through the configured rolling buffer."""
+        if self._buffer_ms == 0:
+            self._validate_and_push(mg, values)
+            return
 
-        Timing has two phases when ``dt_ms`` is omitted:
-        * Priming: before the first buffered chunk is sent, sample spacing is
-          estimated from input arrival time because the jogger clock cannot run
-          until waypoints are sent.
-        * Streaming: after the first chunk starts jogging, sample spacing is
-          derived only from ``jogger.elapsed`` / acknowledged controller time.
-        """
         self._validate_target_dims(mg, values)
-
-        effective_dt_ms = self._append_dt_ms(mg, dt_ms)
+        effective_dt_ms = self._target_dt_ms(mg, dt_ms if dt_ms > 0 else None)
         buffer = self._target_buffers.setdefault(mg, [])
         if effective_dt_ms is None:
-            if mg not in self._append_buffer_sent and not buffer:
+            if mg not in self._buffer_started and not buffer:
                 buffer.append(list(values))
-            return False
+            return
 
         buffer.append(list(values))
-        min_buffer_ms = self._buffer_ms(mg, buffer_ms)
-        min_steps = max(1, math.ceil(min_buffer_ms / effective_dt_ms))
+        min_steps = max(1, math.ceil(self._buffer_ms / effective_dt_ms))
         if len(buffer) > min_steps:
             del buffer[: len(buffer) - min_steps]
         if len(buffer) < min_steps:
-            return False
+            return
 
         self._push_target(mg, [list(step) for step in buffer], effective_dt_ms, extend_buffer=False)
-        self._append_buffer_sent.add(mg)
-        return True
+        self._buffer_started.add(mg)
 
-    def _append_dt_ms(self, mg: MotionGroup, dt_ms: float | None) -> float | None:
+    def _target_dt_ms(self, mg: MotionGroup, dt_ms: float | None) -> float | None:
+        """Determine live-sample spacing from explicit or acknowledged timing."""
         if dt_ms is not None:
-            if dt_ms <= 0:
-                msg = "append_target requires dt_ms > 0"
-                raise ValueError(msg)
-            self._last_append_elapsed[mg] = self.elapsed
-            self._last_append_wall[mg] = time.monotonic()
+            self._last_target_elapsed[mg] = self.elapsed
+            self._last_target_wall[mg] = time.monotonic()
             return dt_ms
 
         now_elapsed = self.elapsed
         now_wall = time.monotonic()
-        previous_elapsed = self._last_append_elapsed.get(mg)
-        previous_wall = self._last_append_wall.get(mg)
-        self._last_append_elapsed[mg] = now_elapsed
-        self._last_append_wall[mg] = now_wall
+        previous_elapsed = self._last_target_elapsed.get(mg)
+        previous_wall = self._last_target_wall.get(mg)
+        self._last_target_elapsed[mg] = now_elapsed
+        self._last_target_wall[mg] = now_wall
 
         if previous_elapsed is not None:
             elapsed_ms = (now_elapsed - previous_elapsed) * 1000.0
             if elapsed_ms > 0:
                 return elapsed_ms
 
-        # Startup only: before the first chunk is sent, jogger.elapsed may be
-        # frozen at 0 because the robot cannot enter RUNNING until it receives
-        # waypoints. Use wall-clock only to estimate input sample spacing for
-        # initial buffer priming; chunk timestamps are still anchored later on
-        # the server-synchronized jogging clock.
-        if mg not in self._append_buffer_sent and previous_wall is not None:
+        # Startup only: before the first chunk is sent, jogger.elapsed cannot
+        # advance. Wall time is used only to estimate initial sample spacing.
+        if mg not in self._buffer_started and previous_wall is not None:
             wall_ms = (now_wall - previous_wall) * 1000.0
             return wall_ms if wall_ms > 0 else None
 
         return None
 
-    def _clear_append_buffer(self, mg: MotionGroup) -> None:
-        """Forget buffered teleop samples when switching back to immediate targets."""
+    def _clear_target_buffer(self, mg: MotionGroup) -> None:
+        """Forget rolling samples when an explicit chunk replaces live targets."""
         self._target_buffers.pop(mg, None)
-        self._last_append_elapsed.pop(mg, None)
-        self._last_append_wall.pop(mg, None)
-        self._append_buffer_sent.discard(mg)
+        self._last_target_elapsed.pop(mg, None)
+        self._last_target_wall.pop(mg, None)
+        self._buffer_started.discard(mg)
 
     def _validate_target_dims(self, mg: MotionGroup, values: list[float]) -> None:
         expected = self._expected_dims(mg)
         if expected is not None and len(values) != expected:
             msg = f"Target has {len(values)} values but motion group '{mg.id}' expects {expected}"
             raise ValueError(msg)
-
-    def _buffer_ms(self, mg: MotionGroup, buffer_ms: float | None) -> float:
-        if buffer_ms is not None:
-            return max(0.0, buffer_ms)
-        session = self._sessions.get(mg)
-        if session is None:
-            return 0.0
-        return max(0.0, session.config.min_buffer_ms)
 
     def _log_target(self, mg_id: str, steps: list[list[float]], dt_ms: float) -> None:
         """Log jogging target to Rerun as an action chunk visualization."""
@@ -451,6 +429,7 @@ class JointJogger(_BaseJogger):
         stop_conditions: list[StopCondition] | None = None,
         start_joint_position: list[float] | dict[MotionGroup, list[float]] | None = None,
         ease_in_s: float = 0.0,
+        buffer_ms: float = 0.0,
     ) -> None:
         cfg = config or WaypointConfig()
         sessions: dict[MotionGroup, WaypointJoggingSession] = {}
@@ -469,7 +448,11 @@ class JointJogger(_BaseJogger):
             else:
                 home_dict = {motion_groups[0]: start_joint_position}
         super().__init__(
-            motion_groups, sessions, start_joint_position=home_dict, ease_in_s=ease_in_s
+            motion_groups,
+            sessions,
+            start_joint_position=home_dict,
+            ease_in_s=ease_in_s,
+            buffer_ms=buffer_ms,
         )
         self._target: dict[MotionGroup, list[float]] | None = None
 
@@ -481,47 +464,6 @@ class JointJogger(_BaseJogger):
         if not self._multi:
             return self._target.get(self._mg_list[0])
         return self._target
-
-    def append_target(
-        self,
-        target: list[float] | dict[MotionGroup, list[float]],
-        *,
-        dt_ms: float | None = None,
-        buffer_ms: float | None = None,
-    ) -> bool:
-        """Append one joint target sample to a rolling teleop buffer.
-
-        The first calls only fill the buffer. Once it contains ``buffer_ms`` of
-        samples, the first chunk is sent and starts the jogger/controller clock.
-        From then on, automatic timing uses ``jogger.elapsed``. This
-        intentionally adds latency equal to the buffer size, but keeps the
-        controller fed with future waypoints instead of one point at a time.
-
-        Returns ``True`` once a chunk was sent, ``False`` while the buffer is
-        still priming or while acknowledged jogger time has not advanced.
-        """
-        if isinstance(target, list):
-            if target and isinstance(target[0], list):
-                msg = "append_target accepts one target sample, not a chunk"
-                raise TypeError(msg)
-            if self._multi:
-                msg = "For multiple motion groups, pass a dict[MotionGroup, list[float]]"
-                raise TypeError(msg)
-            mg = self._mg_list[0]
-            sent = self._append_target(mg, target, dt_ms=dt_ms, buffer_ms=buffer_ms)
-            self._target = {mg: target}
-            return sent
-        if isinstance(target, dict):
-            self._target = self._target or {}
-            sent_any = False
-            for mg, values in target.items():
-                sent_any = (
-                    self._append_target(mg, values, dt_ms=dt_ms, buffer_ms=buffer_ms) or sent_any
-                )
-                self._target[mg] = values
-            return sent_any
-        msg = f"Expected list or dict, got {type(target)}"
-        raise TypeError(msg)
 
     def set_target(
         self,
@@ -538,23 +480,31 @@ class JointJogger(_BaseJogger):
                 - ``list[float]`` — single target (one motion group)
                 - ``list[list[float]]`` — chunk of future targets (one motion group)
                 - ``dict[MotionGroup, ...]`` — per-MG targets or chunks
-            dt_ms: Time between chunk steps in milliseconds.
-                Only used when ``target`` contains chunks (nested lists).
-                Enables interpolation and feedforward velocity.
+            dt_ms: Sample spacing for buffered single targets, or time between
+                explicit chunk steps, in milliseconds. When omitted for buffered
+                targets, spacing is inferred automatically.
         """
         if isinstance(target, list):
             if self._multi:
                 msg = "For multiple motion groups, pass a dict[MotionGroup, ...]"
                 raise TypeError(msg)
             mg = self._mg_list[0]
-            final = self._push_target(mg, target, dt_ms)
-            self._clear_append_buffer(mg)
+            if target and isinstance(target[0], list):
+                final = self._push_target(mg, target, dt_ms)
+                self._clear_target_buffer(mg)
+            else:
+                self._set_live_target(mg, target, dt_ms=dt_ms)
+                final = target
             self._target = {mg: final}
         elif isinstance(target, dict):
             self._target = self._target or {}
             for mg, mg_value in target.items():
-                self._target[mg] = self._push_target(mg, mg_value, dt_ms)
-                self._clear_append_buffer(mg)
+                if mg_value and isinstance(mg_value[0], list):
+                    self._target[mg] = self._push_target(mg, mg_value, dt_ms)
+                    self._clear_target_buffer(mg)
+                else:
+                    self._set_live_target(mg, mg_value, dt_ms=dt_ms)
+                    self._target[mg] = mg_value
         else:
             msg = f"Expected list or dict, got {type(target)}"
             raise TypeError(msg)
@@ -583,6 +533,7 @@ class TcpJogger(_BaseJogger):
         stop_conditions: list[StopCondition] | None = None,
         start_joint_position: list[float] | dict[MotionGroup, list[float]] | None = None,
         ease_in_s: float = 0.0,
+        buffer_ms: float = 0.0,
     ) -> None:
         cfg = config or WaypointConfig()
         sessions: dict[MotionGroup, WaypointJoggingSession] = {}
@@ -602,7 +553,13 @@ class TcpJogger(_BaseJogger):
                 home_dict = start_joint_position
             else:
                 home_dict = {mg_list[0]: start_joint_position}
-        super().__init__(mg_list, sessions, start_joint_position=home_dict, ease_in_s=ease_in_s)
+        super().__init__(
+            mg_list,
+            sessions,
+            start_joint_position=home_dict,
+            ease_in_s=ease_in_s,
+            buffer_ms=buffer_ms,
+        )
         self._target: dict[MotionGroup, Pose] | None = None
 
     def _expected_dims(self, mg: MotionGroup) -> int | None:  # noqa: ARG002
@@ -617,48 +574,6 @@ class TcpJogger(_BaseJogger):
             return self._target.get(self._mg_list[0])
         return self._target
 
-    def append_target(
-        self,
-        target: Pose | dict[MotionGroup, Pose],
-        *,
-        dt_ms: float | None = None,
-        buffer_ms: float | None = None,
-    ) -> bool:
-        """Append one TCP target sample to a rolling teleop buffer.
-
-        The first calls only fill the buffer. Once it contains ``buffer_ms`` of
-        samples, the first chunk is sent and starts the jogger/controller clock.
-        From then on, automatic timing uses ``jogger.elapsed``. This
-        intentionally adds latency equal to the buffer size, but keeps the
-        controller fed with future waypoints instead of one point at a time.
-
-        Returns ``True`` once a chunk was sent, ``False`` while the buffer is
-        still priming or while acknowledged jogger time has not advanced.
-        """
-        from nova.types import Pose  # noqa: PLC0415
-
-        if isinstance(target, Pose):
-            if self._multi:
-                msg = "For multiple motion groups, pass a dict[MotionGroup, Pose]"
-                raise TypeError(msg)
-            mg = self._mg_list[0]
-            values = list(target.position) + list(target.orientation)
-            sent = self._append_target(mg, values, dt_ms=dt_ms, buffer_ms=buffer_ms)
-            self._target = {mg: target}
-            return sent
-        if isinstance(target, dict):
-            self._target = self._target or {}
-            sent_any = False
-            for mg, pose in target.items():
-                values = list(pose.position) + list(pose.orientation)
-                sent_any = (
-                    self._append_target(mg, values, dt_ms=dt_ms, buffer_ms=buffer_ms) or sent_any
-                )
-                self._target[mg] = pose
-            return sent_any
-        msg = f"Expected Pose or dict, got {type(target)}"
-        raise TypeError(msg)
-
     def set_target(
         self,
         target: Pose | list[list[float]] | dict[MotionGroup, Pose | list[list[float]]],
@@ -672,8 +587,9 @@ class TcpJogger(_BaseJogger):
                 - ``Pose`` — single position target (one motion group)
                 - ``list[list[float]]`` — chunk of future TCP targets [x,y,z,rx,ry,rz]
                 - ``dict[MotionGroup, ...]`` — per-MG targets or chunks
-            dt_ms: Time between chunk steps in milliseconds.
-                Only used when target is a chunk (list of lists).
+            dt_ms: Sample spacing for buffered poses, or time between explicit
+                chunk steps, in milliseconds. When omitted for buffered poses,
+                spacing is inferred automatically.
         """
         from nova.types import Pose  # noqa: PLC0415
 
@@ -682,8 +598,7 @@ class TcpJogger(_BaseJogger):
                 msg = "For multiple motion groups, pass a dict[MotionGroup, Pose]"
                 raise TypeError(msg)
             mg = self._mg_list[0]
-            self._validate_and_push(mg, list(target.position) + list(target.orientation))
-            self._clear_append_buffer(mg)
+            self._set_live_target(mg, list(target.position) + list(target.orientation), dt_ms=dt_ms)
             self._target = {mg: target}
         elif isinstance(target, list):
             if self._multi:
@@ -691,18 +606,20 @@ class TcpJogger(_BaseJogger):
                 raise TypeError(msg)
             mg = self._mg_list[0]
             self._push_target(mg, target, dt_ms)
-            self._clear_append_buffer(mg)
+            self._clear_target_buffer(mg)
             self._target = {mg: target[-1] if target and isinstance(target[0], list) else target}
         elif isinstance(target, dict):
             self._target = self._target or {}
             for mg, value in target.items():
                 if isinstance(value, Pose):
-                    self._validate_and_push(mg, list(value.position) + list(value.orientation))
+                    self._set_live_target(
+                        mg, list(value.position) + list(value.orientation), dt_ms=dt_ms
+                    )
                     self._target[mg] = value
                 else:
                     self._push_target(mg, value, dt_ms)
+                    self._clear_target_buffer(mg)
                     self._target[mg] = value[-1] if value and isinstance(value[0], list) else value
-                self._clear_append_buffer(mg)
         else:
             msg = f"Expected Pose, list, or dict, got {type(target)}"
             raise TypeError(msg)
@@ -725,6 +642,7 @@ def jog_joints(
     stop_conditions: list[StopCondition] | None = ...,
     start_joint_position: list[float] | None = ...,
     ease_in_s: float = ...,
+    buffer_ms: float = ...,
 ) -> JointJogger:
     pass
 
@@ -737,6 +655,7 @@ def jog_joints(
     stop_conditions: list[StopCondition] | None = ...,
     start_joint_position: dict[MotionGroup, list[float]] | None = ...,
     ease_in_s: float = ...,
+    buffer_ms: float = ...,
 ) -> JointJogger:
     pass
 
@@ -748,6 +667,7 @@ def jog_joints(
     stop_conditions: list[StopCondition] | None = None,
     start_joint_position: list[float] | dict[MotionGroup, list[float]] | None = None,
     ease_in_s: float = 0.0,
+    buffer_ms: float = 0.0,
 ) -> JointJogger:
     """Create a joint position jogger using server-side waypoint jogging.
 
@@ -762,6 +682,8 @@ def jog_joints(
         ease_in_s: If > 0, ramp motion up from a standstill over this many
             seconds at the start, so velocity begins at zero instead of jumping
             to the target's initial speed. Default 0 (disabled).
+        buffer_ms: Rolling live-target buffer duration in milliseconds.
+            Default 0 sends each ``set_target`` live target immediately.
 
     Returns:
         A :class:`JointJogger` async context manager.
@@ -785,6 +707,7 @@ def jog_joints(
         stop_conditions=stop_conditions,
         start_joint_position=start_joint_position,
         ease_in_s=ease_in_s,
+        buffer_ms=buffer_ms,
     )
 
 
@@ -797,6 +720,7 @@ def jog_tcp(
     stop_conditions: list[StopCondition] | None = ...,
     start_joint_position: list[float] | None = ...,
     ease_in_s: float = ...,
+    buffer_ms: float = ...,
 ) -> TcpJogger:
     pass
 
@@ -808,6 +732,8 @@ def jog_tcp(
     config: WaypointConfig | None = ...,
     stop_conditions: list[StopCondition] | None = ...,
     start_joint_position: dict[MotionGroup, list[float]] | None = ...,
+    ease_in_s: float = ...,
+    buffer_ms: float = ...,
 ) -> TcpJogger:
     pass
 
@@ -820,6 +746,7 @@ def jog_tcp(
     stop_conditions: list[StopCondition] | None = None,
     start_joint_position: list[float] | dict[MotionGroup, list[float]] | None = None,
     ease_in_s: float = 0.0,
+    buffer_ms: float = 0.0,
 ) -> TcpJogger:
     """Create a TCP pose jogger using server-side waypoint jogging.
 
@@ -836,6 +763,8 @@ def jog_tcp(
         ease_in_s: If > 0, ramp motion up from a standstill over this many
             seconds at the start, so velocity begins at zero instead of jumping
             to the target's initial speed. Default 0 (disabled).
+        buffer_ms: Rolling live-target buffer duration in milliseconds.
+            Default 0 sends each ``set_target`` pose immediately.
 
     Returns:
         A :class:`TcpJogger` async context manager.
@@ -858,6 +787,7 @@ def jog_tcp(
             stop_conditions=stop_conditions,
             start_joint_position=start_joint_position,
             ease_in_s=ease_in_s,
+            buffer_ms=buffer_ms,
         )
     return TcpJogger(
         {motion_groups: tcp},
@@ -865,4 +795,5 @@ def jog_tcp(
         stop_conditions=stop_conditions,
         start_joint_position=start_joint_position,
         ease_in_s=ease_in_s,
+        buffer_ms=buffer_ms,
     )

--- a/novapolicy/jogging/waypoint_session.py
+++ b/novapolicy/jogging/waypoint_session.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import math
 import time
 from typing import TYPE_CHECKING
 
@@ -119,6 +120,11 @@ class WaypointJoggingSession:
         return self._mode
 
     @property
+    def config(self) -> WaypointConfig:
+        """Waypoint jogging configuration used by this session."""
+        return self._config
+
+    @property
     def current_state(self) -> RobotState | None:
         if self._current_joints is None or self._current_tcp_pose is None:
             return None
@@ -186,6 +192,7 @@ class WaypointJoggingSession:
         *,
         anchor_ms: int = NOW,
         anchor_offset_steps: int = 0,
+        extend_buffer: bool = True,
         **_kwargs: object,
     ) -> None:
         """Queue a new action chunk as waypoints.
@@ -210,19 +217,22 @@ class WaypointJoggingSession:
         if not steps:
             return
 
-        # Single-step target: use a default step time
-        effective_dt_ms = dt_ms if dt_ms > 0 else 100.0
+        # Single-step target: use a default step time.
+        effective_dt_ms = dt_ms if dt_ms > 0 else self._config.single_step_dt_ms
+        buffered_steps = (
+            self._extend_to_min_buffer(steps, effective_dt_ms) if extend_buffer else steps
+        )
 
         # Cap how far the session clock may run ahead of acknowledged server
         # time at this chunk's horizon, so a stalled link drifts at most one
         # lookahead window before "now" freezes (see acknowledged_elapsed_ms).
-        self._clock.max_lookahead_ms = len(steps) * effective_dt_ms
+        self._clock.max_lookahead_ms = len(buffered_steps) * effective_dt_ms
 
         # Store raw chunk data. Timestamps are computed in _jogging_loop
         # immediately before yielding to the server, avoiding drift from any
         # internal await/scheduling delay between policy and stream send.
         self._pending_request = PendingChunk(
-            steps=steps,
+            steps=buffered_steps,
             dt_ms=effective_dt_ms,
             anchor_ms=anchor_ms,
             anchor_offset_steps=anchor_offset_steps,
@@ -237,10 +247,11 @@ class WaypointJoggingSession:
             anchor_offset_steps >= 0
             and self._mode == "joint"
             and self._current_joints is not None
-            and len(steps) > 0
+            and len(buffered_steps) > 0
         ):
             delta = [
-                abs(steps[0][j] - self._current_joints[j]) for j in range(min(3, len(steps[0])))
+                abs(buffered_steps[0][j] - self._current_joints[j])
+                for j in range(min(3, len(buffered_steps[0])))
             ]
             max_delta = max(delta) * 57.3
             log = logger.warning if max_delta > _DISCONTINUITY_WARN_DEG else logger.debug
@@ -252,12 +263,26 @@ class WaypointJoggingSession:
                 self._current_joints[0],
                 self._current_joints[1],
                 self._current_joints[2],
-                steps[0][0],
-                steps[0][1],
-                steps[0][2],
+                buffered_steps[0][0],
+                buffered_steps[0][1],
+                buffered_steps[0][2],
             )
 
         # Request is built later at yield time.
+
+    def _extend_to_min_buffer(
+        self, steps: list[list[float]], effective_dt_ms: float
+    ) -> list[list[float]]:
+        """Extend short chunks to cover ``min_buffer_ms`` by holding the final target."""
+        min_buffer_ms = max(0.0, self._config.min_buffer_ms)
+        if min_buffer_ms <= 0 or effective_dt_ms <= 0:
+            return steps
+
+        min_steps = max(1, math.ceil(min_buffer_ms / effective_dt_ms))
+        if len(steps) >= min_steps:
+            return steps
+
+        return [*steps, *[list(steps[-1]) for _ in range(min_steps - len(steps))]]
 
     async def write_ios(self, ios: dict[str, ValueType]) -> None:
         """Write IO values (delegated to IOWriter for deduplication)."""
@@ -350,7 +375,7 @@ class WaypointJoggingSession:
         controller_id = get_controller_id(self._motion_group)
         tcp = await self._resolve_tcp()
 
-        async def client_request_generator(
+        async def client_request_generator(  # noqa: C901
             response_stream: AsyncGenerator[api.models.ExecuteWaypointJoggingResponse, None],
         ) -> AsyncGenerator[api.models.ExecuteWaypointJoggingRequest, None]:
             # 1. Initialize the jogging session.
@@ -360,59 +385,72 @@ class WaypointJoggingSession:
                 api.models.InitializeJoggingRequest(motion_group=self._motion_group.id, tcp=tcp)
             )
 
-            # 2. Main loop: for each server response, either send a new
-            #    chunk (if ready) or sleep until one is ready.
+            async def consume_responses() -> None:
+                async for response in response_stream:
+                    if not self._running:
+                        return
+                    if not self._ready.is_set():
+                        self._ready.set()
+                    if hasattr(response.root, "kind") and response.root.kind == "MOTION_ERROR":
+                        msg = getattr(response.root, "message", "unknown motion error")
+                        raise MotionError(self.motion_group_id, msg)
+                    self._check_stop_conditions()
+                    self._jog_tracker.check()
+
+            response_task = asyncio.create_task(
+                consume_responses(), name=f"wp-jog-responses-{self.motion_group_id}"
+            )
             first_chunk = True
-            async for response in response_stream:
-                if not self._running:
-                    return
+            try:
+                # 2. Main loop: send chunks as soon as they are queued. Do not
+                # gate outgoing waypoints on incoming response cadence; a weak
+                # response stream must not make the controller run out of
+                # already-prepared waypoints.
+                while self._running:
+                    if response_task.done():
+                        exc = response_task.exception()
+                        if exc is not None:
+                            raise exc
+                        return
 
-                # Signal that the session is ready on first server response.
-                # This means InitializeJoggingRequest was acknowledged and
-                # the server is ready to accept waypoints.
-                if not self._ready.is_set():
-                    self._ready.set()
+                    self._check_stop_conditions()
+                    self._jog_tracker.check()
 
-                if hasattr(response.root, "kind") and response.root.kind == "MOTION_ERROR":
-                    msg = getattr(response.root, "message", "unknown motion error")
-                    raise MotionError(self.motion_group_id, msg)
+                    if not self._ready.is_set() or self._pending_request is None:
+                        await asyncio.sleep(0.001)
+                        continue
 
-                self._check_stop_conditions()
-                self._jog_tracker.check()
+                    # Capture and clear BEFORE yielding: while this async
+                    # generator is suspended at yield, the executor may write
+                    # the next _pending_request. Clearing after yield would
+                    # delete that fresh chunk and create gaps that let the
+                    # server exhaust its current action chunk.
+                    pending = self._pending_request
+                    self._pending_request = None
 
-                # Wait until a new chunk is available (sleep, don't send junk)
-                while self._pending_request is None and self._running:
-                    await asyncio.sleep(0.001)
+                    # Start the clock on the first chunk — this is when the
+                    # server's internal timer begins (first waypoint message).
+                    if first_chunk:
+                        self._clock.start()
+                        first_chunk = False
 
-                if not self._running:
-                    return
+                    # Build the request now so timestamps are aligned to the
+                    # server session timer at the last possible moment.
+                    request = make_waypoints_request(
+                        self._clock,
+                        self._mode,
+                        steps=pending.steps,
+                        effective_dt_ms=pending.dt_ms,
+                        anchor_ms=pending.anchor_ms,
+                        anchor_offset_steps=pending.anchor_offset_steps,
+                    )
 
-                # Send the chunk. Capture and clear BEFORE yielding: while this
-                # async generator is suspended at yield, the executor may write
-                # the next _pending_request. Clearing after yield would delete
-                # that fresh chunk and create gaps that let the server exhaust
-                # its current action chunk.
-                pending = self._pending_request
-                self._pending_request = None
-
-                # Start the clock on the first chunk — this is when the
-                # server's internal timer begins (first waypoint message).
-                if first_chunk:
-                    self._clock.start()
-                    first_chunk = False
-
-                # Build the request now so timestamps are aligned to the server
-                # session timer at the last possible moment.
-                request = make_waypoints_request(
-                    self._clock,
-                    self._mode,
-                    steps=pending.steps,
-                    effective_dt_ms=pending.dt_ms,
-                    anchor_ms=pending.anchor_ms,
-                    anchor_offset_steps=pending.anchor_offset_steps,
-                )
-
-                yield api.models.ExecuteWaypointJoggingRequest(request)
+                    yield api.models.ExecuteWaypointJoggingRequest(request)
+            finally:
+                if not response_task.done():
+                    response_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, OSError, RuntimeError):
+                    await response_task
 
         try:
             await api_gateway.jogging_api.execute_waypoint_jogging(

--- a/novapolicy/rerun/blueprint.py
+++ b/novapolicy/rerun/blueprint.py
@@ -35,6 +35,25 @@ def send_blueprint(
         rrb.TimeSeriesView(contents=[f"policy/{mg_id}/joints/**"], name=f"Joints {mg_id}")
         for mg_id in escaped_ids
     ]
+    tcp_tracking_views = []
+    for mg_id in escaped_ids:
+        tcp_tracking_views.extend(
+            [
+                rrb.TimeSeriesView(
+                    contents=[
+                        f"policy/{mg_id}/tcp_target/position/**",
+                        f"policy/{mg_id}/tcp_target/orientation/**",
+                        f"policy/{mg_id}/tcp_actual/position/**",
+                        f"policy/{mg_id}/tcp_actual/orientation/**",
+                    ],
+                    name=f"TCP target/actual {mg_id}",
+                ),
+                rrb.TimeSeriesView(
+                    contents=[f"policy/{mg_id}/tcp_error/**"],
+                    name=f"TCP error {mg_id}",
+                ),
+            ]
+        )
     text_views = [
         rrb.TextLogView(
             contents=["policy/action_chunks", "policy/status"],
@@ -47,6 +66,8 @@ def send_blueprint(
         right_panels.append(rrb.Grid(*camera_views))
     if joint_views:
         right_panels.append(rrb.Vertical(*joint_views))
+    if tcp_tracking_views:
+        right_panels.append(rrb.Vertical(*tcp_tracking_views))
     if text_views:
         right_panels.append(rrb.Vertical(*text_views))
 

--- a/novapolicy/rerun/constants.py
+++ b/novapolicy/rerun/constants.py
@@ -6,6 +6,8 @@ MIN_LINE_STEPS = 2
 MIN_TCP_COMPONENTS = 3
 TEMPORAL_FRAME_NDIM = 4
 TCP_TRAIL_COLOR = (50, 220, 100)  # green — actual TCP path
+TCP_TARGET_TRAIL_COLOR = (255, 220, 40)  # yellow — commanded TCP path
+TCP_ERROR_VECTOR_COLOR = (255, 60, 60)  # red — actual→commanded TCP error
 
 # Action chunk gradient: orange (start) → yellow (end)
 CHUNK_COLOR_START = (255, 80, 20)

--- a/novapolicy/rerun/logger.py
+++ b/novapolicy/rerun/logger.py
@@ -39,6 +39,7 @@ class PolicyRerunLogger:
         self._initialized = False
         self._start_time: float = 0.0
         self._tcp_trail: dict[str, list[list[float]]] = {}  # mg_id -> [[x,y,z], ...]
+        self._tcp_target_trail: dict[str, list[list[float]]] = {}
         self._max_trail_points = 500
         self._streamer: StateStreamer | None = None
 
@@ -117,6 +118,7 @@ class PolicyRerunLogger:
                     model_data=model_data,
                 )
                 self._tcp_trail[mg.id] = []
+                self._tcp_target_trail[mg.id] = []
 
             send_blueprint([mg.id for mg in self._motion_groups], self._camera_names)
 
@@ -175,6 +177,64 @@ class PolicyRerunLogger:
             )
         except (OSError, RuntimeError, ValueError, TypeError) as e:
             logger.debug("log_action_chunk error: %s", e)
+
+    def log_target_tracking(
+        self, chunk: ActionChunk, states: dict[str, RobotState], step: int
+    ) -> None:
+        """Log first commanded target in ``chunk`` against the latest actual state."""
+        if not self._initialized:
+            return
+        for mg_id, steps in chunk.joints.items():
+            state = states.get(mg_id)
+            if steps and state is not None:
+                self.log_joint_tracking(mg_id, steps[0], state, step)
+        for mg_id, steps in chunk.tcp.items():
+            state = states.get(mg_id)
+            if steps and state is not None:
+                self.log_tcp_tracking(mg_id, steps[0], state, step)
+
+    def log_joint_tracking(
+        self, mg_id: str, target: list[float], actual: RobotState, step: int
+    ) -> None:
+        """Log commanded/actual joint positions and tracking error."""
+        if not self._initialized:
+            return
+        try:
+            from novapolicy.rerun.target_tracking import log_joint_tracking  # noqa: PLC0415
+
+            log_joint_tracking(
+                mg_id,
+                target,
+                list(actual.joints),
+                step,
+                start_time=self._start_time,
+            )
+        except (OSError, RuntimeError, ValueError, TypeError) as e:
+            logger.debug("log_joint_tracking error: %s", e)
+
+    def log_tcp_tracking(
+        self, mg_id: str, target: list[float], actual: RobotState, step: int
+    ) -> None:
+        """Log commanded/actual TCP pose and tracking error."""
+        if not self._initialized:
+            return
+        pose = getattr(actual, "pose", None)
+        if pose is None:
+            return
+        try:
+            from novapolicy.rerun.target_tracking import log_tcp_tracking  # noqa: PLC0415
+
+            log_tcp_tracking(
+                mg_id,
+                target,
+                pose,
+                step,
+                start_time=self._start_time,
+                target_trail=self._tcp_target_trail.get(mg_id),
+                max_trail_points=self._max_trail_points,
+            )
+        except (OSError, RuntimeError, ValueError, TypeError) as e:
+            logger.debug("log_tcp_tracking error: %s", e)
 
     def log_images(self, images: dict[str, Any]) -> None:
         """Log camera images to Rerun."""

--- a/novapolicy/rerun/target_tracking.py
+++ b/novapolicy/rerun/target_tracking.py
@@ -1,0 +1,169 @@
+"""Target-vs-actual tracking time-series logging."""
+
+from __future__ import annotations
+
+import math
+import time
+from typing import TYPE_CHECKING
+
+from novapolicy.rerun.constants import (
+    MIN_LINE_STEPS,
+    TCP_ERROR_VECTOR_COLOR,
+    TCP_TARGET_TRAIL_COLOR,
+    TRAIL_WIDTH_UI,
+)
+import rerun as rr
+
+_TCP_DIMS = 6
+
+if TYPE_CHECKING:
+    from nova.types import Pose
+
+
+def log_joint_tracking(
+    mg_id: str,
+    target: list[float],
+    actual: list[float],
+    step: int,
+    *,
+    start_time: float,
+) -> None:
+    """Log commanded joint positions, actual joint positions, and tracking error."""
+    if not target or not actual:
+        return
+
+    n = min(len(target), len(actual))
+    target_joints = target[:n]
+    actual_joints = actual[:n]
+    joint_error = [target_joints[i] - actual_joints[i] for i in range(n)]
+
+    _set_time(step, start_time)
+    for i, value in enumerate(target_joints):
+        rr.log(f"policy/{mg_id}/joint_target/j{i}", rr.Scalars(value))
+    for i, value in enumerate(actual_joints):
+        rr.log(f"policy/{mg_id}/joint_actual/j{i}", rr.Scalars(value))
+    for i, value in enumerate(joint_error):
+        rr.log(f"policy/{mg_id}/joint_error/j{i}", rr.Scalars(value))
+    rr.log(
+        f"policy/{mg_id}/joint_error/norm_rad",
+        rr.Scalars(math.dist(target_joints, actual_joints)),
+    )
+
+
+def log_tcp_tracking(
+    mg_id: str,
+    target: list[float],
+    actual: Pose,
+    step: int,
+    *,
+    start_time: float,
+    target_trail: list[list[float]] | None = None,
+    max_trail_points: int = 500,
+) -> None:
+    """Log commanded TCP pose, actual TCP pose, and tracking error."""
+    if len(target) < _TCP_DIMS:
+        return
+
+    target_position = target[:3]
+    target_orientation = target[3:6]
+    actual_position = list(actual.position)
+    actual_orientation = list(actual.orientation)
+    position_error = [target_position[i] - actual_position[i] for i in range(3)]
+    orientation_error = [target_orientation[i] - actual_orientation[i] for i in range(3)]
+
+    _set_time(step, start_time)
+    _log_tcp_scalar_series(
+        mg_id,
+        target_position,
+        target_orientation,
+        actual_position,
+        actual_orientation,
+        position_error,
+        orientation_error,
+    )
+    _log_tcp_3d(
+        mg_id,
+        target_position,
+        actual_position,
+        target_trail=target_trail,
+        max_trail_points=max_trail_points,
+    )
+
+
+def _log_tcp_scalar_series(
+    mg_id: str,
+    target_position: list[float],
+    target_orientation: list[float],
+    actual_position: list[float],
+    actual_orientation: list[float],
+    position_error: list[float],
+    orientation_error: list[float],
+) -> None:
+    for name, value in zip(("x", "y", "z"), target_position, strict=True):
+        rr.log(f"policy/{mg_id}/tcp_target/position/{name}", rr.Scalars(value))
+    for name, value in zip(("rx", "ry", "rz"), target_orientation, strict=True):
+        rr.log(f"policy/{mg_id}/tcp_target/orientation/{name}", rr.Scalars(value))
+    for name, value in zip(("x", "y", "z"), actual_position, strict=True):
+        rr.log(f"policy/{mg_id}/tcp_actual/position/{name}", rr.Scalars(value))
+    for name, value in zip(("rx", "ry", "rz"), actual_orientation, strict=True):
+        rr.log(f"policy/{mg_id}/tcp_actual/orientation/{name}", rr.Scalars(value))
+    for name, value in zip(("dx", "dy", "dz"), position_error, strict=True):
+        rr.log(f"policy/{mg_id}/tcp_error/position/{name}", rr.Scalars(value))
+    for name, value in zip(("drx", "dry", "drz"), orientation_error, strict=True):
+        rr.log(f"policy/{mg_id}/tcp_error/orientation/{name}", rr.Scalars(value))
+
+    rr.log(
+        f"policy/{mg_id}/tcp_error/position_norm_mm",
+        rr.Scalars(math.dist(target_position, actual_position)),
+    )
+    rr.log(
+        f"policy/{mg_id}/tcp_error/orientation_norm_rad",
+        rr.Scalars(math.dist(target_orientation, actual_orientation)),
+    )
+
+
+def _log_tcp_3d(
+    mg_id: str,
+    target_position: list[float],
+    actual_position: list[float],
+    *,
+    target_trail: list[list[float]] | None,
+    max_trail_points: int,
+) -> None:
+    if target_trail is not None:
+        target_trail.append(target_position)
+        if len(target_trail) > max_trail_points:
+            target_trail.pop(0)
+        if len(target_trail) >= MIN_LINE_STEPS:
+            rr.log(
+                f"policy/{mg_id}/tcp_target_trail",
+                rr.LineStrips3D(
+                    [target_trail],
+                    colors=[TCP_TARGET_TRAIL_COLOR],
+                    radii=rr.components.Radius.ui_points(TRAIL_WIDTH_UI),
+                ),
+            )
+        else:
+            rr.log(
+                f"policy/{mg_id}/tcp_target_point",
+                rr.Points3D(
+                    [target_position],
+                    colors=[TCP_TARGET_TRAIL_COLOR],
+                    radii=rr.components.Radius.ui_points(4.0),
+                ),
+            )
+
+    rr.log(
+        f"policy/{mg_id}/tcp_error_vector",
+        rr.LineStrips3D(
+            [[actual_position, target_position]],
+            colors=[TCP_ERROR_VECTOR_COLOR],
+            radii=rr.components.Radius.ui_points(TRAIL_WIDTH_UI),
+        ),
+    )
+
+
+def _set_time(step: int, start_time: float) -> None:
+    elapsed = time.monotonic() - start_time
+    rr.set_time("policy_time", duration=elapsed)
+    rr.set_time("policy_step", sequence=step)

--- a/novapolicy/tests/api/test_jogger.py
+++ b/novapolicy/tests/api/test_jogger.py
@@ -15,7 +15,7 @@ import pytest
 
 from novapolicy.jogging import jog_joints, jog_tcp
 from novapolicy.jogging.jogger import JointJogger, TcpJogger
-from novapolicy.types import MotionError
+from novapolicy.types import MotionError, WaypointConfig
 
 _JOGGER = "novapolicy.jogging.jogger"
 
@@ -51,6 +51,7 @@ def _fake_session(num_joints: int = 6, *, mode: str = "joint") -> MagicMock:
     session.failure_exception = None
     session.stop_condition_triggered = None
     session.session_elapsed_ms = 0
+    session.config = WaypointConfig(min_buffer_ms=30.0)
     session.current_state = MagicMock(joints=(0.0,) * num_joints)
     session.update_chunk = MagicMock()
     session.start = AsyncMock()
@@ -127,6 +128,54 @@ def test_setting_a_chunk_streams_every_step_and_tracks_the_last():
     jogger.set_target(chunk, dt_ms=33.0)
     sessions[mg].update_chunk.assert_called_once_with(steps=chunk, dt_ms=33.0, anchor_ms=0)
     assert jogger.target == chunk[-1]
+
+
+def test_appending_joint_targets_primes_then_sends_a_rolling_buffer():
+    """append_target adds latency, then streams a moving buffered chunk."""
+    jogger, (mg,), sessions = _build_joint_jogger("0@ur10e")
+
+    assert jogger.append_target([1.0] * 6, dt_ms=10.0) is False
+    assert jogger.append_target([2.0] * 6, dt_ms=10.0) is False
+    sessions[mg].update_chunk.assert_not_called()
+
+    assert jogger.append_target([3.0] * 6, dt_ms=10.0) is True
+    sessions[mg].update_chunk.assert_called_once_with(
+        steps=[[1.0] * 6, [2.0] * 6, [3.0] * 6],
+        dt_ms=10.0,
+        anchor_ms=0,
+        extend_buffer=False,
+    )
+
+    assert jogger.append_target([4.0] * 6, dt_ms=10.0) is True
+    assert sessions[mg].update_chunk.call_args.kwargs["steps"] == [
+        [2.0] * 6,
+        [3.0] * 6,
+        [4.0] * 6,
+    ]
+
+
+def test_set_target_clears_append_target_buffer():
+    """Switching to immediate targets must not reuse stale buffered samples."""
+    jogger, (mg,), sessions = _build_joint_jogger("0@ur10e")
+
+    assert jogger.append_target([1.0] * 6, dt_ms=10.0) is False
+    assert jogger.append_target([2.0] * 6, dt_ms=10.0) is False
+    assert jogger.append_target([3.0] * 6, dt_ms=10.0) is True
+    assert sessions[mg].update_chunk.call_count == 1
+
+    jogger.set_target([9.0] * 6)
+    assert sessions[mg].update_chunk.call_count == 2
+
+    assert jogger.append_target([10.0] * 6, dt_ms=10.0) is False
+    assert jogger.append_target([11.0] * 6, dt_ms=10.0) is False
+    assert sessions[mg].update_chunk.call_count == 2
+
+    assert jogger.append_target([12.0] * 6, dt_ms=10.0) is True
+    assert sessions[mg].update_chunk.call_args.kwargs["steps"] == [
+        [10.0] * 6,
+        [11.0] * 6,
+        [12.0] * 6,
+    ]
 
 
 def test_each_arm_in_a_dual_setup_receives_its_own_target():
@@ -220,6 +269,128 @@ def test_tcp_jogging_streams_a_chunk_of_future_poses():
     jogger, mg, sessions = _build_tcp_jogger("0@ur10e", tcp="Flange")
     jogger.set_target(chunk, dt_ms=33.0)
     sessions[mg].update_chunk.assert_called_once_with(steps=chunk, dt_ms=33.0, anchor_ms=0)
+
+
+def test_appending_tcp_targets_primes_then_sends_a_rolling_buffer():
+    """TCP append_target buffers samples before sending a rolling chunk."""
+    from nova.types import Pose
+
+    jogger, mg, sessions = _build_tcp_jogger("0@ur10e", tcp="Flange")
+
+    assert jogger.append_target(Pose(500, 200, 300, 0, 3.14, 0), dt_ms=10.0) is False
+    assert jogger.append_target(Pose(510, 200, 300, 0, 3.14, 0), dt_ms=10.0) is False
+    sessions[mg].update_chunk.assert_not_called()
+
+    assert jogger.append_target(Pose(520, 200, 300, 0, 3.14, 0), dt_ms=10.0) is True
+    sessions[mg].update_chunk.assert_called_once_with(
+        steps=[
+            [500, 200, 300, 0, 3.14, 0],
+            [510, 200, 300, 0, 3.14, 0],
+            [520, 200, 300, 0, 3.14, 0],
+        ],
+        dt_ms=10.0,
+        anchor_ms=0,
+        extend_buffer=False,
+    )
+
+
+def test_appending_tcp_targets_uses_wall_time_only_to_prime_before_elapsed_advances(monkeypatch):
+    """Startup cannot wait for elapsed: first chunk is needed before RUNNING."""
+    from nova.types import Pose
+
+    times = iter([0.00, 0.01, 0.02])
+    monkeypatch.setattr("novapolicy.jogging.jogger.time.monotonic", lambda: next(times))
+
+    jogger, mg, sessions = _build_tcp_jogger("0@ur10e", tcp="Flange")
+    # elapsed stays at zero before the first chunk makes the robot RUNNING.
+    jogger._loop_t0 = 0.0  # type: ignore[attr-defined]
+    jogger._ack0_ms = 0.0  # type: ignore[attr-defined]
+    sessions[mg].session_elapsed_ms = 0
+
+    assert jogger.append_target(Pose(500, 200, 300, 0, 3.14, 0)) is False
+    assert jogger.append_target(Pose(510, 200, 300, 0, 3.14, 0)) is False
+    assert jogger.append_target(Pose(520, 200, 300, 0, 3.14, 0)) is True
+
+    sessions[mg].update_chunk.assert_called_once_with(
+        steps=[
+            [500, 200, 300, 0, 3.14, 0],
+            [510, 200, 300, 0, 3.14, 0],
+            [520, 200, 300, 0, 3.14, 0],
+        ],
+        dt_ms=10.0,
+        anchor_ms=0,
+        extend_buffer=False,
+    )
+
+
+def test_append_target_does_not_use_wall_time_after_first_buffered_chunk(monkeypatch):
+    """After priming, automatic timing waits for acknowledged jogger time."""
+    from nova.types import Pose
+
+    times = iter([0.00, 0.01, 0.02, 0.03, 0.04, 0.05])
+    monkeypatch.setattr("novapolicy.jogging.jogger.time.monotonic", lambda: next(times))
+
+    jogger, mg, sessions = _build_tcp_jogger("0@ur10e", tcp="Flange")
+    jogger._loop_t0 = 0.0  # type: ignore[attr-defined]
+    jogger._ack0_ms = 0.0  # type: ignore[attr-defined]
+    sessions[mg].session_elapsed_ms = 0
+
+    assert jogger.append_target(Pose(500, 200, 300, 0, 3.14, 0)) is False
+    assert jogger.append_target(Pose(510, 200, 300, 0, 3.14, 0)) is False
+    assert jogger.append_target(Pose(520, 200, 300, 0, 3.14, 0)) is True
+    sessions[mg].update_chunk.reset_mock()
+
+    assert jogger.append_target(Pose(530, 200, 300, 0, 3.14, 0)) is False
+    assert jogger.append_target(Pose(540, 200, 300, 0, 3.14, 0)) is False
+    assert jogger.append_target(Pose(550, 200, 300, 0, 3.14, 0)) is False
+    sessions[mg].update_chunk.assert_not_called()
+    assert len(jogger._target_buffers[mg]) == 3  # type: ignore[attr-defined]
+
+
+def test_append_target_uses_each_motion_groups_default_buffer_horizon():
+    """Default append buffering comes from the matching motion group's session."""
+    jogger, (left, right), sessions = _build_joint_jogger("0@ur5e-left", "0@ur5e-right")
+    sessions[left].config = WaypointConfig(min_buffer_ms=10.0)
+    sessions[right].config = WaypointConfig(min_buffer_ms=30.0)
+
+    sent = jogger.append_target(
+        {
+            left: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            right: [7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
+        },
+        dt_ms=10.0,
+    )
+
+    assert sent is True
+    sessions[left].update_chunk.assert_called_once()
+    sessions[right].update_chunk.assert_not_called()
+
+
+def test_appending_tcp_targets_can_infer_dt_from_jogger_elapsed():
+    """After startup, append_target uses acknowledged jogger time between samples."""
+    from nova.types import Pose
+
+    jogger, mg, sessions = _build_tcp_jogger("0@ur10e", tcp="Flange")
+    jogger._loop_t0 = 0.0  # type: ignore[attr-defined]
+    jogger._ack0_ms = 0.0  # type: ignore[attr-defined]
+
+    sessions[mg].session_elapsed_ms = 0
+    assert jogger.append_target(Pose(500, 200, 300, 0, 3.14, 0)) is False
+    sessions[mg].session_elapsed_ms = 10
+    assert jogger.append_target(Pose(510, 200, 300, 0, 3.14, 0)) is False
+    sessions[mg].session_elapsed_ms = 20
+    assert jogger.append_target(Pose(520, 200, 300, 0, 3.14, 0)) is True
+
+    sessions[mg].update_chunk.assert_called_once_with(
+        steps=[
+            [500, 200, 300, 0, 3.14, 0],
+            [510, 200, 300, 0, 3.14, 0],
+            [520, 200, 300, 0, 3.14, 0],
+        ],
+        dt_ms=10.0,
+        anchor_ms=20,
+        extend_buffer=False,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/novapolicy/tests/api/test_jogger.py
+++ b/novapolicy/tests/api/test_jogger.py
@@ -60,7 +60,9 @@ def _fake_session(num_joints: int = 6, *, mode: str = "joint") -> MagicMock:
     return session
 
 
-def _build_joint_jogger(*mg_ids: str, num_joints: int = 6, ease_in_s: float = 0.0) -> _JointSetup:
+def _build_joint_jogger(
+    *mg_ids: str, num_joints: int = 6, ease_in_s: float = 0.0, buffer_ms: float = 0.0
+) -> _JointSetup:
     """Build a real joint jogger over fake robot transports.
 
     The transport is only patched while the jogger is being constructed (that
@@ -75,11 +77,15 @@ def _build_joint_jogger(*mg_ids: str, num_joints: int = 6, ease_in_s: float = 0.
         return sessions[motion_group]
 
     with patch("novapolicy.jogging.jogger.WaypointJoggingSession", side_effect=make_session):
-        jogger = jog_joints(mgs if len(mgs) > 1 else mgs[0], ease_in_s=ease_in_s)
+        jogger = jog_joints(
+            mgs if len(mgs) > 1 else mgs[0], ease_in_s=ease_in_s, buffer_ms=buffer_ms
+        )
     return jogger, mgs, sessions
 
 
-def _build_tcp_jogger(mg_id: str, tcp: str = "Flange", *, num_joints: int = 6) -> _TcpSetup:
+def _build_tcp_jogger(
+    mg_id: str, tcp: str = "Flange", *, num_joints: int = 6, buffer_ms: float = 0.0
+) -> _TcpSetup:
     """Build a real single-arm TCP jogger over a fake robot transport."""
     mg = _mg(mg_id)
     sessions: dict[object, MagicMock] = {}
@@ -89,7 +95,7 @@ def _build_tcp_jogger(mg_id: str, tcp: str = "Flange", *, num_joints: int = 6) -
         return sessions[motion_group]
 
     with patch("novapolicy.jogging.jogger.WaypointJoggingSession", side_effect=make_session):
-        jogger = jog_tcp(mg, tcp=tcp)
+        jogger = jog_tcp(mg, tcp=tcp, buffer_ms=buffer_ms)
     return jogger, mg, sessions
 
 
@@ -130,15 +136,15 @@ def test_setting_a_chunk_streams_every_step_and_tracks_the_last():
     assert jogger.target == chunk[-1]
 
 
-def test_appending_joint_targets_primes_then_sends_a_rolling_buffer():
-    """append_target adds latency, then streams a moving buffered chunk."""
-    jogger, (mg,), sessions = _build_joint_jogger("0@ur10e")
+def test_buffered_joint_set_target_primes_then_sends_a_rolling_buffer():
+    """With buffer_ms configured, set_target streams a moving buffered chunk."""
+    jogger, (mg,), sessions = _build_joint_jogger("0@ur10e", buffer_ms=30.0)
 
-    assert jogger.append_target([1.0] * 6, dt_ms=10.0) is False
-    assert jogger.append_target([2.0] * 6, dt_ms=10.0) is False
+    jogger.set_target([1.0] * 6, dt_ms=10.0)
+    jogger.set_target([2.0] * 6, dt_ms=10.0)
     sessions[mg].update_chunk.assert_not_called()
 
-    assert jogger.append_target([3.0] * 6, dt_ms=10.0) is True
+    jogger.set_target([3.0] * 6, dt_ms=10.0)
     sessions[mg].update_chunk.assert_called_once_with(
         steps=[[1.0] * 6, [2.0] * 6, [3.0] * 6],
         dt_ms=10.0,
@@ -146,7 +152,7 @@ def test_appending_joint_targets_primes_then_sends_a_rolling_buffer():
         extend_buffer=False,
     )
 
-    assert jogger.append_target([4.0] * 6, dt_ms=10.0) is True
+    jogger.set_target([4.0] * 6, dt_ms=10.0)
     assert sessions[mg].update_chunk.call_args.kwargs["steps"] == [
         [2.0] * 6,
         [3.0] * 6,
@@ -154,23 +160,23 @@ def test_appending_joint_targets_primes_then_sends_a_rolling_buffer():
     ]
 
 
-def test_set_target_clears_append_target_buffer():
-    """Switching to immediate targets must not reuse stale buffered samples."""
-    jogger, (mg,), sessions = _build_joint_jogger("0@ur10e")
+def test_explicit_chunk_clears_buffered_set_target_samples():
+    """An explicit chunk must not reuse stale buffered live-target samples."""
+    jogger, (mg,), sessions = _build_joint_jogger("0@ur10e", buffer_ms=30.0)
 
-    assert jogger.append_target([1.0] * 6, dt_ms=10.0) is False
-    assert jogger.append_target([2.0] * 6, dt_ms=10.0) is False
-    assert jogger.append_target([3.0] * 6, dt_ms=10.0) is True
+    jogger.set_target([1.0] * 6, dt_ms=10.0)
+    jogger.set_target([2.0] * 6, dt_ms=10.0)
+    jogger.set_target([3.0] * 6, dt_ms=10.0)
     assert sessions[mg].update_chunk.call_count == 1
 
-    jogger.set_target([9.0] * 6)
+    jogger.set_target([[9.0] * 6, [9.0] * 6], dt_ms=10.0)
     assert sessions[mg].update_chunk.call_count == 2
 
-    assert jogger.append_target([10.0] * 6, dt_ms=10.0) is False
-    assert jogger.append_target([11.0] * 6, dt_ms=10.0) is False
+    jogger.set_target([10.0] * 6, dt_ms=10.0)
+    jogger.set_target([11.0] * 6, dt_ms=10.0)
     assert sessions[mg].update_chunk.call_count == 2
 
-    assert jogger.append_target([12.0] * 6, dt_ms=10.0) is True
+    jogger.set_target([12.0] * 6, dt_ms=10.0)
     assert sessions[mg].update_chunk.call_args.kwargs["steps"] == [
         [10.0] * 6,
         [11.0] * 6,
@@ -271,17 +277,17 @@ def test_tcp_jogging_streams_a_chunk_of_future_poses():
     sessions[mg].update_chunk.assert_called_once_with(steps=chunk, dt_ms=33.0, anchor_ms=0)
 
 
-def test_appending_tcp_targets_primes_then_sends_a_rolling_buffer():
-    """TCP append_target buffers samples before sending a rolling chunk."""
+def test_buffered_tcp_set_target_primes_then_sends_a_rolling_buffer():
+    """TCP set_target buffers samples before sending a rolling chunk."""
     from nova.types import Pose
 
-    jogger, mg, sessions = _build_tcp_jogger("0@ur10e", tcp="Flange")
+    jogger, mg, sessions = _build_tcp_jogger("0@ur10e", tcp="Flange", buffer_ms=30.0)
 
-    assert jogger.append_target(Pose(500, 200, 300, 0, 3.14, 0), dt_ms=10.0) is False
-    assert jogger.append_target(Pose(510, 200, 300, 0, 3.14, 0), dt_ms=10.0) is False
+    jogger.set_target(Pose(500, 200, 300, 0, 3.14, 0), dt_ms=10.0)
+    jogger.set_target(Pose(510, 200, 300, 0, 3.14, 0), dt_ms=10.0)
     sessions[mg].update_chunk.assert_not_called()
 
-    assert jogger.append_target(Pose(520, 200, 300, 0, 3.14, 0), dt_ms=10.0) is True
+    jogger.set_target(Pose(520, 200, 300, 0, 3.14, 0), dt_ms=10.0)
     sessions[mg].update_chunk.assert_called_once_with(
         steps=[
             [500, 200, 300, 0, 3.14, 0],
@@ -294,22 +300,24 @@ def test_appending_tcp_targets_primes_then_sends_a_rolling_buffer():
     )
 
 
-def test_appending_tcp_targets_uses_wall_time_only_to_prime_before_elapsed_advances(monkeypatch):
+def test_buffered_tcp_set_target_uses_wall_time_only_to_prime_before_elapsed_advances(
+    monkeypatch,
+):
     """Startup cannot wait for elapsed: first chunk is needed before RUNNING."""
     from nova.types import Pose
 
     times = iter([0.00, 0.01, 0.02])
     monkeypatch.setattr("novapolicy.jogging.jogger.time.monotonic", lambda: next(times))
 
-    jogger, mg, sessions = _build_tcp_jogger("0@ur10e", tcp="Flange")
+    jogger, mg, sessions = _build_tcp_jogger("0@ur10e", tcp="Flange", buffer_ms=30.0)
     # elapsed stays at zero before the first chunk makes the robot RUNNING.
     jogger._loop_t0 = 0.0  # type: ignore[attr-defined]
     jogger._ack0_ms = 0.0  # type: ignore[attr-defined]
     sessions[mg].session_elapsed_ms = 0
 
-    assert jogger.append_target(Pose(500, 200, 300, 0, 3.14, 0)) is False
-    assert jogger.append_target(Pose(510, 200, 300, 0, 3.14, 0)) is False
-    assert jogger.append_target(Pose(520, 200, 300, 0, 3.14, 0)) is True
+    jogger.set_target(Pose(500, 200, 300, 0, 3.14, 0))
+    jogger.set_target(Pose(510, 200, 300, 0, 3.14, 0))
+    jogger.set_target(Pose(520, 200, 300, 0, 3.14, 0))
 
     sessions[mg].update_chunk.assert_called_once_with(
         steps=[
@@ -323,63 +331,73 @@ def test_appending_tcp_targets_uses_wall_time_only_to_prime_before_elapsed_advan
     )
 
 
-def test_append_target_does_not_use_wall_time_after_first_buffered_chunk(monkeypatch):
+def test_buffered_set_target_does_not_use_wall_time_after_first_chunk(monkeypatch):
     """After priming, automatic timing waits for acknowledged jogger time."""
     from nova.types import Pose
 
     times = iter([0.00, 0.01, 0.02, 0.03, 0.04, 0.05])
     monkeypatch.setattr("novapolicy.jogging.jogger.time.monotonic", lambda: next(times))
 
-    jogger, mg, sessions = _build_tcp_jogger("0@ur10e", tcp="Flange")
+    jogger, mg, sessions = _build_tcp_jogger("0@ur10e", tcp="Flange", buffer_ms=30.0)
     jogger._loop_t0 = 0.0  # type: ignore[attr-defined]
     jogger._ack0_ms = 0.0  # type: ignore[attr-defined]
     sessions[mg].session_elapsed_ms = 0
 
-    assert jogger.append_target(Pose(500, 200, 300, 0, 3.14, 0)) is False
-    assert jogger.append_target(Pose(510, 200, 300, 0, 3.14, 0)) is False
-    assert jogger.append_target(Pose(520, 200, 300, 0, 3.14, 0)) is True
+    jogger.set_target(Pose(500, 200, 300, 0, 3.14, 0))
+    jogger.set_target(Pose(510, 200, 300, 0, 3.14, 0))
+    jogger.set_target(Pose(520, 200, 300, 0, 3.14, 0))
     sessions[mg].update_chunk.reset_mock()
 
-    assert jogger.append_target(Pose(530, 200, 300, 0, 3.14, 0)) is False
-    assert jogger.append_target(Pose(540, 200, 300, 0, 3.14, 0)) is False
-    assert jogger.append_target(Pose(550, 200, 300, 0, 3.14, 0)) is False
+    jogger.set_target(Pose(530, 200, 300, 0, 3.14, 0))
+    jogger.set_target(Pose(540, 200, 300, 0, 3.14, 0))
+    jogger.set_target(Pose(550, 200, 300, 0, 3.14, 0))
     sessions[mg].update_chunk.assert_not_called()
     assert len(jogger._target_buffers[mg]) == 3  # type: ignore[attr-defined]
 
 
-def test_append_target_uses_each_motion_groups_default_buffer_horizon():
-    """Default append buffering comes from the matching motion group's session."""
-    jogger, (left, right), sessions = _build_joint_jogger("0@ur5e-left", "0@ur5e-right")
-    sessions[left].config = WaypointConfig(min_buffer_ms=10.0)
-    sessions[right].config = WaypointConfig(min_buffer_ms=30.0)
+def test_buffered_set_target_uses_configured_buffer_for_all_motion_groups():
+    """Constructor-level buffering applies equally to every motion group."""
+    jogger, (left, right), sessions = _build_joint_jogger(
+        "0@ur5e-left", "0@ur5e-right", buffer_ms=30.0
+    )
 
-    sent = jogger.append_target(
+    for i in range(2):
+        jogger.set_target(
+            {
+                left: [float(i)] * 6,
+                right: [float(i + 10)] * 6,
+            },
+            dt_ms=10.0,
+        )
+    sessions[left].update_chunk.assert_not_called()
+    sessions[right].update_chunk.assert_not_called()
+
+    jogger.set_target(
         {
-            left: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-            right: [7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
+            left: [2.0] * 6,
+            right: [12.0] * 6,
         },
         dt_ms=10.0,
     )
 
-    assert sent is True
     sessions[left].update_chunk.assert_called_once()
-    sessions[right].update_chunk.assert_not_called()
+    sessions[right].update_chunk.assert_called_once()
 
 
-def test_appending_tcp_targets_can_infer_dt_from_jogger_elapsed():
-    """After startup, append_target uses acknowledged jogger time between samples."""
+def test_buffered_tcp_set_target_can_infer_dt_from_jogger_elapsed():
+    """After startup, buffered set_target uses acknowledged jogger time."""
     from nova.types import Pose
 
-    jogger, mg, sessions = _build_tcp_jogger("0@ur10e", tcp="Flange")
+    jogger, mg, sessions = _build_tcp_jogger("0@ur10e", tcp="Flange", buffer_ms=30.0)
     jogger._loop_t0 = 0.0  # type: ignore[attr-defined]
     jogger._ack0_ms = 0.0  # type: ignore[attr-defined]
 
     sessions[mg].session_elapsed_ms = 0
-    assert jogger.append_target(Pose(500, 200, 300, 0, 3.14, 0)) is False
+    jogger.set_target(Pose(500, 200, 300, 0, 3.14, 0))
     sessions[mg].session_elapsed_ms = 10
-    assert jogger.append_target(Pose(510, 200, 300, 0, 3.14, 0)) is False
+    jogger.set_target(Pose(510, 200, 300, 0, 3.14, 0))
     sessions[mg].session_elapsed_ms = 20
-    assert jogger.append_target(Pose(520, 200, 300, 0, 3.14, 0)) is True
+    jogger.set_target(Pose(520, 200, 300, 0, 3.14, 0))
 
     sessions[mg].update_chunk.assert_called_once_with(
         steps=[

--- a/novapolicy/tests/api/test_waypoint_session.py
+++ b/novapolicy/tests/api/test_waypoint_session.py
@@ -132,6 +132,7 @@ def _build_session(
     states: Sequence[object] = (),
     stop_conditions: list[object] | None = None,
     mode: str = "joint",
+    config: WaypointConfig | None = None,
 ) -> tuple[WaypointJoggingSession, FakeJoggingServer]:
     server = FakeJoggingServer(fault=fault, raise_exc=raise_exc)
 
@@ -154,7 +155,7 @@ def _build_session(
 
     session = WaypointJoggingSession(
         motion_group=mg,
-        config=WaypointConfig(),
+        config=config or WaypointConfig(),
         tcp="Flange",
         mode=mode,
         stop_conditions=stop_conditions,
@@ -219,10 +220,10 @@ async def test_a_queued_joint_chunk_is_sent_as_a_timestamped_waypoint():
         await _wait_until(lambda: len(server.requests) >= 2)
         waypoint_req = _inner(server.requests[1])
         assert isinstance(waypoint_req, api.models.JointWaypointsRequest)
-        assert len(waypoint_req.waypoints) == 1
-        sent = waypoint_req.waypoints[0]
-        assert list(sent.joints.root) == target
-        assert sent.timestamp == 0  # absolute anchor at 0, single step
+        assert len(waypoint_req.waypoints) == 2
+        for sent in waypoint_req.waypoints:
+            assert list(sent.joints.root) == target
+        assert [w.timestamp for w in waypoint_req.waypoints] == [0, 50]
     finally:
         server.stop()
         await session.stop()
@@ -386,9 +387,11 @@ async def test_jog_tcp_chunk_is_sent_as_evenly_spaced_pose_waypoints():
         )
         waypoints = pose_req.waypoints
 
-        # Every chunk step became one pose waypoint, in order.
+        # The requested chunk already covers the default 100ms controller buffer,
+        # so no padding is needed.
         assert len(waypoints) == len(chunk)
-        for sent, expected in zip(waypoints, chunk, strict=True):
+        expected_steps = chunk
+        for sent, expected in zip(waypoints, expected_steps, strict=True):
             assert [sent.pose.position.root[k] for k in range(3)] == expected[:3]
             assert [sent.pose.orientation.root[k] for k in range(3)] == expected[3:6]
 
@@ -418,7 +421,7 @@ async def test_overlapping_tcp_chunks_share_one_absolute_timeline():
     were instead re-sequenced from "now" every tick, the overlap would land on
     different timestamps and the server would keep restarting the trajectory.
     """
-    session, server = _build_session(mode="cartesian")
+    session, server = _build_session(mode="cartesian", config=WaypointConfig(min_buffer_ms=0))
 
     def _pose_requests() -> list[object]:
         return [
@@ -474,7 +477,7 @@ async def test_overlapping_joint_chunks_share_one_absolute_timeline():
     ``JointWaypointsRequest`` messages. The absolute-timeline guarantee is
     mode-independent, so the overlap must coincide here too.
     """
-    session, server = _build_session(mode="joint")
+    session, server = _build_session(mode="joint", config=WaypointConfig(min_buffer_ms=0))
 
     def _joint_requests() -> list[object]:
         return [

--- a/novapolicy/types.py
+++ b/novapolicy/types.py
@@ -100,6 +100,17 @@ class WaypointConfig:
     state_rate_ms: int = 10
     """State stream update rate."""
 
+    min_buffer_ms: float = 100.0
+    """Minimum waypoint horizon sent to the controller.
+
+    Chunks shorter than this are extended so a short packet drop or slow policy
+    tick does not let the controller exhaust its waypoint buffer. Set to ``0``
+    to disable automatic extension.
+    """
+
+    single_step_dt_ms: float = 100.0
+    """Spacing used when a live jog target is sent as a single point."""
+
 
 @dataclass(slots=True)
 class StopContext:


### PR DESCRIPTION
Adds buffered jogging via append_target(...) to avoid one-point stop/start behaviour under packet loss or slow input updates. The jogger now primes a time-based rolling buffer before sending the first chunk, then streams buffered chunks synchronized to acknowledged jogger time. 
Also decouples outgoing waypoint sends from incoming jogging responses, adds Rerun target/actual/error tracking, and documents the buffered teleop flow.