### PR TITLE
allow tcp_id being None for forward_kinematics calculation of motion group

### DIFF
--- a/nova/cell/motion_group.py
+++ b/nova/cell/motion_group.py
@@ -443,7 +443,7 @@ class MotionGroup(AbstractRobot):
 
         joint_positions = [api.models.DoubleArray(list(joint_config)) for joint_config in joints]
 
-        tcp_offset = await self.tcp_offset(tcp) if tcp is not None else None
+        tcp_offset = (await self.tcp_offset(tcp)).to_api_model() if tcp is not None else None
         motion_group_model = await self.get_model()
         mounting = await self.get_mounting()
 
@@ -452,7 +452,7 @@ class MotionGroup(AbstractRobot):
             forward_kinematics_request=api.models.ForwardKinematicsRequest(
                 motion_group_model=api.models.MotionGroupModel(motion_group_model),
                 joint_positions=joint_positions,
-                tcp_offset=tcp_offset.to_api_model() if tcp_offset is not None else None,
+                tcp_offset=tcp_offset,
                 mounting=mounting.to_api_model() if mounting is not None else None,
             ),
         )

--- a/nova/cell/motion_group.py
+++ b/nova/cell/motion_group.py
@@ -425,8 +425,15 @@ class MotionGroup(AbstractRobot):
         )
         return response.joints  # ty: ignore[invalid-return-type]
 
-    async def forward_kinematics(self, joints: list[tuple[float, ...]], tcp: str) -> list[Pose]:
+    async def forward_kinematics(
+        self, joints: list[tuple[float, ...]], tcp: str | None
+    ) -> list[Pose]:
         """Get the forward kinematics of the motion group.
+
+        Args:
+            joints: The joint configurations to compute poses for.
+            tcp: The TCP to apply. If None, no TCP offset is applied and the returned
+                poses are the flange poses.
 
         Returns:
             list[Pose]: The forward kinematics of the motion group. Empty list if not available.
@@ -436,7 +443,7 @@ class MotionGroup(AbstractRobot):
 
         joint_positions = [api.models.DoubleArray(list(joint_config)) for joint_config in joints]
 
-        tcp_offset = await self.tcp_offset(tcp)
+        tcp_offset = await self.tcp_offset(tcp) if tcp is not None else None
         motion_group_model = await self.get_model()
         mounting = await self.get_mounting()
 
@@ -445,7 +452,7 @@ class MotionGroup(AbstractRobot):
             forward_kinematics_request=api.models.ForwardKinematicsRequest(
                 motion_group_model=api.models.MotionGroupModel(motion_group_model),
                 joint_positions=joint_positions,
-                tcp_offset=tcp_offset.to_api_model(),
+                tcp_offset=tcp_offset.to_api_model() if tcp_offset is not None else None,
                 mounting=mounting.to_api_model() if mounting is not None else None,
             ),
         )

--- a/tests/cell/test_motion_group.py
+++ b/tests/cell/test_motion_group.py
@@ -246,6 +246,10 @@ def mock_motion_group():
     mock_api_client.trajectory_planning_api.plan_trajectory = AsyncMock()
     mock_api_client.virtual_controller_api = MagicMock()
     mock_api_client.virtual_controller_api.add_virtual_controller_tcp = AsyncMock()
+    mock_api_client.motion_group_api = MagicMock()
+    mock_api_client.motion_group_api.get_motion_group_description = AsyncMock()
+    mock_api_client.kinematics_api = MagicMock()
+    mock_api_client.kinematics_api.forward_kinematics = AsyncMock()
     return MotionGroup(
         api_client=mock_api_client,
         cell="test_cell",
@@ -528,3 +532,63 @@ async def test_ensure_virtual_tcp_different_rotation_types_not_equal(mock_motion
             orientation_type=tcp.orientation_type,
         ),
     )
+
+
+@pytest.mark.asyncio
+async def test_forward_kinematics_without_tcp_skips_tcp_offset(mock_motion_group):
+    """tcp=None must compute the flange pose and must not resolve any TCP offset."""
+    gripper_pose = api.models.Pose(
+        position=api.models.Vector3d([10, 20, 30]), orientation=api.models.RotationVector([0, 0, 0])
+    )
+    mock_motion_group._api_client.motion_group_api.get_motion_group_description.return_value = (
+        api.models.MotionGroupDescription(
+            motion_group_model=api.models.MotionGroupModel("test-model"),
+            operation_limits=api.models.OperationLimits(),
+            mounting=None,
+            tcps={"gripper": api.models.TcpOffset(name="gripper", pose=gripper_pose)}
+        )
+    )
+    flange_pose = api.models.Pose(
+        position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([0, 0, 0])
+    )
+    mock_motion_group._api_client.kinematics_api.forward_kinematics.return_value = MagicMock(
+        tcp_poses=[flange_pose]
+    )
+
+    result = await mock_motion_group.forward_kinematics(joints=[(0, 0, 0, 0, 0, 0)], tcp=None)
+
+    assert result == [Pose(flange_pose)]
+    request = mock_motion_group._api_client.kinematics_api.forward_kinematics.call_args.kwargs[
+        "forward_kinematics_request"
+    ]
+    assert request.tcp_offset is None
+
+
+@pytest.mark.asyncio
+async def test_forward_kinematics_with_tcp_applies_tcp_offset(mock_motion_group):
+    """tcp=<name> must resolve and forward that TCP's offset to the API request."""
+    gripper_pose = api.models.Pose(
+        position=api.models.Vector3d([10, 20, 30]), orientation=api.models.RotationVector([0, 0, 0])
+    )
+    mock_motion_group._api_client.motion_group_api.get_motion_group_description.return_value = (
+        api.models.MotionGroupDescription(
+            motion_group_model=api.models.MotionGroupModel("test-model"),
+            operation_limits=api.models.OperationLimits(),
+            mounting=None,
+            tcps={"gripper": api.models.TcpOffset(name="gripper", pose=gripper_pose)}
+        )
+    )
+    tcp_pose = api.models.Pose(
+        position=api.models.Vector3d([11, 22, 33]), orientation=api.models.RotationVector([0, 0, 0])
+    )
+    mock_motion_group._api_client.kinematics_api.forward_kinematics.return_value = MagicMock(
+        tcp_poses=[tcp_pose]
+    )
+
+    result = await mock_motion_group.forward_kinematics(joints=[(0, 0, 0, 0, 0, 0)], tcp="gripper")
+
+    assert result == [Pose(tcp_pose)]
+    request = mock_motion_group._api_client.kinematics_api.forward_kinematics.call_args.kwargs[
+        "forward_kinematics_request"
+    ]
+    assert request.tcp_offset == Pose(gripper_pose).to_api_model()

--- a/tests/cell/test_motion_group.py
+++ b/tests/cell/test_motion_group.py
@@ -545,7 +545,7 @@ async def test_forward_kinematics_without_tcp_skips_tcp_offset(mock_motion_group
             motion_group_model=api.models.MotionGroupModel("test-model"),
             operation_limits=api.models.OperationLimits(),
             mounting=None,
-            tcps={"gripper": api.models.TcpOffset(name="gripper", pose=gripper_pose)}
+            tcps={"gripper": api.models.TcpOffset(name="gripper", pose=gripper_pose)},
         )
     )
     flange_pose = api.models.Pose(
@@ -575,7 +575,7 @@ async def test_forward_kinematics_with_tcp_applies_tcp_offset(mock_motion_group)
             motion_group_model=api.models.MotionGroupModel("test-model"),
             operation_limits=api.models.OperationLimits(),
             mounting=None,
-            tcps={"gripper": api.models.TcpOffset(name="gripper", pose=gripper_pose)}
+            tcps={"gripper": api.models.TcpOffset(name="gripper", pose=gripper_pose)},
         )
     )
     tcp_pose = api.models.Pose(


### PR DESCRIPTION
To calculate the forward kinematics of positioners, we need to allow passing None for tcp_id since not all positioners (e.g. yaskawa) have tcps.