### PR TITLE
feat(NDX-810)!: integrate DatasetPose into SDK

### DIFF
--- a/examples/multi_step_movement_with_collision_free.py
+++ b/examples/multi_step_movement_with_collision_free.py
@@ -47,10 +47,10 @@ async def multi_step_movement_with_collision_free(ctx: nova.ProgramContext):
     actions = [
         cartesian_ptp(target_pose),
         # collision_free(home_joints),
-        cartesian_ptp(target_pose @ [50, 0, 0, 0, 0, 0]),
+        cartesian_ptp(target_pose @ Pose([50, 0, 0, 0, 0, 0])),
         io_write(key="digital_out[0]", value=True),
         joint_ptp(home_joints),
-        cartesian_ptp(target_pose @ (50, 100, 0, 0, 0, 0)),
+        cartesian_ptp(target_pose @ Pose((50, 100, 0, 0, 0, 0))),
         # collision_free(home_pose),
         cartesian_ptp(target_pose @ Pose((0, 50, 0, 0, 0, 0))),
         joint_ptp(home_joints),

--- a/examples/start_here.py
+++ b/examples/start_here.py
@@ -70,10 +70,10 @@ async def start(
         joint_ptp(home_joints, settings=normal),  # Move to home position slowly
         cartesian_ptp(target_pose, settings=fast),  # Move to target pose
         cartesian_ptp(
-            target_pose @ [200, 0, 0, 0, 0, 0], settings=fast
+            target_pose @ Pose([200, 0, 0, 0, 0, 0]), settings=fast
         ),  # Move 100mm in target pose's local x-axis
         linear(
-            target_pose @ (200, 200, 0, 0, 0, 0), settings=fast
+            target_pose @ Pose(200, 200, 0, 0, 0, 0), settings=fast
         ),  # Move 100mm in local x and y axes
         joint_ptp(home_joints, settings=normal),
         cartesian_ptp(target_pose @ Pose((0, 200, 0, 0, 0, 0)), settings=fast),

--- a/examples/your-nova-app/app/programs/start_here.py
+++ b/examples/your-nova-app/app/programs/start_here.py
@@ -76,10 +76,10 @@ async def start(ctx: nova.ProgramContext):
         cartesian_ptp(target_pose),  # Move to target pose
         joint_ptp(home_joints),  # Return to home
         cartesian_ptp(
-            target_pose @ [offset, 0, 0, 0, 0, 0]
+            target_pose @ Pose([offset, 0, 0, 0, 0, 0])
         ),  # Move 200mm in target pose's local x-axis
         joint_ptp(home_joints),
-        linear(target_pose @ (offset, offset, 0, 0, 0, 0)),  # Move 200mm in local x and y axes
+        linear(target_pose @ Pose([offset, offset, 0, 0, 0, 0])),  # Move 200mm in local x and y axes
         joint_ptp(home_joints, settings=slow),
         cartesian_ptp(target_pose @ Pose((0, offset, 0, 0, 0, 0))),
         joint_ptp(home_joints),

--- a/nova/actions/motions.py
+++ b/nova/actions/motions.py
@@ -11,17 +11,6 @@ from nova.types.pose import Pose
 PoseOrSequence = Pose | Sequence[float]
 
 
-def _convert_to_pose(target: PoseOrSequence) -> Pose:
-    if not isinstance(target, Pose):
-        t = (*target, 0.0, 0.0, 0.0) if len(target) == 3 else target
-
-        if len(t) != 6:
-            raise ValueError("Target must be a sequence of 6 floats")
-
-        target = Pose(t)
-    return target
-
-
 class Motion(Action, ABC):
     """Base model of a motion
 
@@ -92,8 +81,7 @@ def linear(
 
     """
     if not isinstance(target, Pose):
-        t = (*target, 0.0, 0.0, 0.0) if len(target) == 3 else target
-        target = Pose(t)
+        target = Pose(target)
 
     kwargs.update(utils.get_caller_metas())
 
@@ -163,7 +151,7 @@ def cartesian_ptp(
     CartesianPTP(metas={'line_number': 1}, type='cartesian_ptp', target=Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0), kinematic_configuration=None), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, joint_jerk_limits=None, tcp_velocity_limit=50.0, tcp_acceleration_limit=None, tcp_jerk_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, tcp_orientation_jerk_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None)
 
     """
-    target = _convert_to_pose(target)
+    target = target if isinstance(target, Pose) else Pose(target)
     kwargs.update(utils.get_caller_metas())
     return CartesianPTP(
         target=target, settings=settings, collision_setup=collision_setup, metas=kwargs
@@ -227,8 +215,8 @@ def circular(
     Circular(metas={'line_number': 1}, type='circular', target=Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0), kinematic_configuration=None), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, joint_jerk_limits=None, tcp_velocity_limit=50.0, tcp_acceleration_limit=None, tcp_jerk_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, tcp_orientation_jerk_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None, intermediate=Pose(position=Vector3d(x=7.0, y=8.0, z=9.0), orientation=Vector3d(x=10.0, y=11.0, z=12.0), kinematic_configuration=None))
 
     """
-    target = _convert_to_pose(target)
-    intermediate = _convert_to_pose(intermediate)
+    target = target if isinstance(target, Pose) else Pose(target)
+    intermediate = intermediate if isinstance(intermediate, Pose) else Pose(intermediate)
     kwargs.update(utils.get_caller_metas())
     return Circular(
         target=target,
@@ -342,7 +330,7 @@ def spline(
     Spline(metas={'line_number': 1}, type='spline', target=Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0), kinematic_configuration=None), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, joint_jerk_limits=None, tcp_velocity_limit=50.0, tcp_acceleration_limit=None, tcp_jerk_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, tcp_orientation_jerk_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None, path_parameter=1.0, time=None)
 
     """
-    target = _convert_to_pose(target)
+    target = target if isinstance(target, Pose) else Pose(target)
     kwargs.update(utils.get_caller_metas())
     return Spline(
         target=target,

--- a/nova/actions/motions.py
+++ b/nova/actions/motions.py
@@ -8,7 +8,9 @@ from nova.actions.base import Action
 from nova.types.motion_settings import MotionSettings
 from nova.types.pose import Pose
 
-PoseOrSequence = Pose | Sequence[float]
+PoseCompatible = (
+    api.models.ConfiguredPose | api.models.DatasetPose | api.models.Pose | Pose | Sequence[float]
+)
 
 
 class Motion(Action, ABC):
@@ -58,7 +60,7 @@ class Linear(Motion):
 
 
 def linear(
-    target: PoseOrSequence,
+    target: PoseCompatible,
     settings: MotionSettings = MotionSettings(),
     collision_setup: api.models.CollisionSetup | None = None,
     **kwargs: dict[str, Any],
@@ -80,8 +82,7 @@ def linear(
     Linear(metas={'line_number': 1}, type='linear', target=Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0), kinematic_configuration=None), settings=MotionSettings(blending_auto=None, blending_radius=None, joint_velocity_limits=None, joint_acceleration_limits=None, joint_jerk_limits=None, tcp_velocity_limit=50.0, tcp_acceleration_limit=None, tcp_jerk_limit=None, tcp_orientation_velocity_limit=None, tcp_orientation_acceleration_limit=None, tcp_orientation_jerk_limit=None, position_zone_radius=None, min_blending_velocity=None), collision_setup=None)
 
     """
-    if not isinstance(target, Pose):
-        target = Pose(target)
+    target = target if isinstance(target, Pose) else Pose(target)
 
     kwargs.update(utils.get_caller_metas())
 
@@ -127,7 +128,7 @@ class CartesianPTP(Motion):
 
 
 def cartesian_ptp(
-    target: PoseOrSequence,
+    target: PoseCompatible,
     settings: MotionSettings = MotionSettings(),
     collision_setup: api.models.CollisionSetup | None = None,
     **kwargs: dict[str, Any],
@@ -191,8 +192,8 @@ class Circular(Motion):
 
 
 def circular(
-    target: PoseOrSequence,
-    intermediate: PoseOrSequence,
+    target: PoseCompatible,
+    intermediate: PoseCompatible,
     settings: MotionSettings = MotionSettings(),
     collision_setup: api.models.CollisionSetup | None = None,
     **kwargs: dict[str, Any],
@@ -305,7 +306,7 @@ class Spline(Motion):
 
 
 def spline(
-    target: PoseOrSequence,
+    target: PoseCompatible,
     settings: MotionSettings = MotionSettings(),
     path_parameter: float = 1,
     time=None,

--- a/nova/actions/motions.py
+++ b/nova/actions/motions.py
@@ -6,16 +6,12 @@ import pydantic
 
 from nova import api, utils
 from nova.actions.base import Action
+from nova.types.dataset_pose import DatasetPose
 from nova.types.motion_settings import MotionSettings
 from nova.types.pose import Pose
 
 PoseLike = (
-    api.models.ConfiguredPose
-    | api.models.DatasetPose
-    | api.models.Pose
-    | Pose
-    | Sequence[float]
-    | np.ndarray
+    api.models.ConfiguredPose | DatasetPose | api.models.Pose | Pose | Sequence[float] | np.ndarray
 )
 
 

--- a/nova/actions/motions.py
+++ b/nova/actions/motions.py
@@ -6,13 +6,11 @@ import pydantic
 
 from nova import api, utils
 from nova.actions.base import Action
-from nova.types.dataset_pose import DatasetPose
+from nova.types.dataset_pose import ConfiguredPose, DatasetPose
 from nova.types.motion_settings import MotionSettings
 from nova.types.pose import Pose
 
-PoseLike = (
-    api.models.ConfiguredPose | DatasetPose | api.models.Pose | Pose | Sequence[float] | np.ndarray
-)
+PoseLike = ConfiguredPose | DatasetPose | api.models.Pose | Pose | Sequence[float] | np.ndarray
 
 
 class Motion(Action, ABC):

--- a/nova/actions/motions.py
+++ b/nova/actions/motions.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from typing import Any, Literal, Sequence
 
+import numpy as np
 import pydantic
 
 from nova import api, utils
@@ -8,8 +9,13 @@ from nova.actions.base import Action
 from nova.types.motion_settings import MotionSettings
 from nova.types.pose import Pose
 
-PoseCompatible = (
-    api.models.ConfiguredPose | api.models.DatasetPose | api.models.Pose | Pose | Sequence[float]
+PoseLike = (
+    api.models.ConfiguredPose
+    | api.models.DatasetPose
+    | api.models.Pose
+    | Pose
+    | Sequence[float]
+    | np.ndarray
 )
 
 
@@ -60,7 +66,7 @@ class Linear(Motion):
 
 
 def linear(
-    target: PoseCompatible,
+    target: PoseLike,
     settings: MotionSettings = MotionSettings(),
     collision_setup: api.models.CollisionSetup | None = None,
     **kwargs: dict[str, Any],
@@ -128,7 +134,7 @@ class CartesianPTP(Motion):
 
 
 def cartesian_ptp(
-    target: PoseCompatible,
+    target: PoseLike,
     settings: MotionSettings = MotionSettings(),
     collision_setup: api.models.CollisionSetup | None = None,
     **kwargs: dict[str, Any],
@@ -192,8 +198,8 @@ class Circular(Motion):
 
 
 def circular(
-    target: PoseCompatible,
-    intermediate: PoseCompatible,
+    target: PoseLike,
+    intermediate: PoseLike,
     settings: MotionSettings = MotionSettings(),
     collision_setup: api.models.CollisionSetup | None = None,
     **kwargs: dict[str, Any],
@@ -306,7 +312,7 @@ class Spline(Motion):
 
 
 def spline(
-    target: PoseCompatible,
+    target: PoseLike,
     settings: MotionSettings = MotionSettings(),
     path_parameter: float = 1,
     time=None,

--- a/nova/types/__init__.py
+++ b/nova/types/__init__.py
@@ -1,6 +1,7 @@
 from typing import AsyncIterator, Callable, TypeAlias, Union
 
 import nova.api as api
+from nova.types.dataset_pose import DatasetPose
 from nova.types.motion_settings import MotionSettings
 from nova.types.pose import Pose
 from nova.types.state import MotionState, RobotState
@@ -22,6 +23,7 @@ MovementControllerFunction: TypeAlias = Callable[
 __all__ = [
     "Vector3d",
     "Pose",
+    "DatasetPose",
     "CollisionScene",
     "MotionState",
     "RobotState",

--- a/nova/types/__init__.py
+++ b/nova/types/__init__.py
@@ -1,7 +1,7 @@
 from typing import AsyncIterator, Callable, TypeAlias, Union
 
 import nova.api as api
-from nova.types.dataset_pose import DatasetPose
+from nova.types.dataset_pose import ConfiguredPose, DatasetPose
 from nova.types.motion_settings import MotionSettings
 from nova.types.pose import Pose
 from nova.types.state import MotionState, RobotState
@@ -23,6 +23,7 @@ MovementControllerFunction: TypeAlias = Callable[
 __all__ = [
     "Vector3d",
     "Pose",
+    "ConfiguredPose",
     "DatasetPose",
     "CollisionScene",
     "MotionState",

--- a/nova/types/dataset_pose.py
+++ b/nova/types/dataset_pose.py
@@ -1,0 +1,43 @@
+from pydantic import AwareDatetime
+
+from nova import api
+
+
+# TODO: Remove this compatibility model once `DatasetPose` is available in the minimum
+# supported version of `wandelbots_api_client`. Until then, keep its fields aligned with
+# the API schema so SDK users can adopt dataset poses before the generated model is released.
+class DatasetPose(api.models.ConfiguredPose):
+    """
+    A dataset pose is a taught pose that belongs to a dataset. It extends the
+    shared `ConfiguredPose` with dataset-specific fields such as an identifier, human-readable
+    name, timestamps, and metadata.
+    """
+
+    id: str
+    """
+    Unique identifier of the pose. This identifier is unique across the entire dataset.
+    """
+    dataset_id: str | None = None
+    """
+    Identifier of the dataset that contains this pose.
+    """
+    name: str | None = None
+    """
+    Human-readable name for the pose that is shown in the user interface.
+    """
+    description: str | None = None
+    """
+    Free-form text that describes the purpose of the pose.
+    """
+    created_at: AwareDatetime | None = None
+    """
+    Timestamp when the pose was created, in RFC3339 format.
+    """
+    updated_at: AwareDatetime | None = None
+    """
+    Timestamp when the pose was last updated, in RFC3339 format.
+    """
+    metadata: dict[str, str] | None = None
+    """
+    Additional key-value pairs that can be attached to the pose.
+    """

--- a/nova/types/dataset_pose.py
+++ b/nova/types/dataset_pose.py
@@ -1,12 +1,29 @@
+import pydantic
 from pydantic import AwareDatetime
 
 from nova import api
 
-
-# TODO: Remove this compatibility model once `DatasetPose` is available in the minimum
-# supported version of `wandelbots_api_client`. Until then, keep its fields aligned with
+# TODO: Remove these compatibility models once `DatasetPose` is available in the minimum
+# supported version of `wandelbots_api_client` which will be version 26.6.0. Until then, keep its fields aligned with
 # the API schema so SDK users can adopt dataset poses before the generated model is released.
-class DatasetPose(api.models.ConfiguredPose):
+
+
+class ConfiguredPose(pydantic.BaseModel):
+    """
+    A pose together with an optional kinematic configuration that resolves it to a unique
+    robot posture. Optionally, the pose can be expressed relative to a coordinate system.
+    """
+
+    pose: api.models.Pose
+    kinematic_configuration: api.models.KinematicConfiguration | None = None
+    coordinate_system_id: str | None = None
+    """
+    Optional identifier of the coordinate system the pose is expressed in. If this
+    is null or omitted, the pose is referenced in `world`.
+    """
+
+
+class DatasetPose(ConfiguredPose):
     """
     A dataset pose is a taught pose that belongs to a dataset. It extends the
     shared `ConfiguredPose` with dataset-specific fields such as an identifier, human-readable

--- a/nova/types/pose.py
+++ b/nova/types/pose.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable, Sized
+from typing import Iterable, Sequence, Sized
 
 import numpy as np
 import pydantic
@@ -33,8 +33,13 @@ def _resolve_pose(
         return Pose.from_dataset_pose(dataset_pose)
     if len(args) == 1 and isinstance(args[0], api.models.Pose):
         return Pose.from_api_model(args[0], kinematic_configuration=kinematic_configuration)
-    if len(args) == 1 and isinstance(args[0], tuple):
-        return Pose.from_tuple(args[0], kinematic_configuration=kinematic_configuration)
+    if (
+        len(args) == 1
+        and isinstance(args[0], Sequence)
+        and not isinstance(args[0], str)
+        and len(args[0]) in (3, 6)
+    ):
+        return Pose.from_tuple(tuple(args[0]), kinematic_configuration=kinematic_configuration)
     if len(args) in (3, 6):
         return Pose.from_tuple(args, kinematic_configuration=kinematic_configuration)
     raise ValueError(f"Cannot construct Pose from arguments: {args!r}")
@@ -96,13 +101,12 @@ class Pose(pydantic.BaseModel, Sized):
             super().__init__(**kwargs)
             return
 
-        pose = _resolve_pose(
-            args, kinematic_configuration=kwargs.pop("kinematic_configuration", None)
-        )
+        kinematic_configuration = kwargs.pop("kinematic_configuration", None)
+        pose = _resolve_pose(args, kinematic_configuration)
         super().__init__(
             position=pose.position,
             orientation=pose.orientation,
-            kinematic_configuration=pose.kinematic_configuration,
+            kinematic_configuration=pose.kinematic_configuration or kinematic_configuration,
         )
 
     def __str__(self):

--- a/nova/types/pose.py
+++ b/nova/types/pose.py
@@ -249,11 +249,11 @@ class Pose(pydantic.BaseModel, Sized):
         if isinstance(other, Pose):
             transformed_matrix = np.dot(self.matrix, other.matrix)
             return self._matrix_to_pose(transformed_matrix)
+        if isinstance(other, api.models.ConfiguredPose):
+            return self.__matmul__(Pose.from_dataset_pose(other))
         if isinstance(other, Iterable):
             seq = tuple(other)
             return self.__matmul__(Pose(seq))
-        if isinstance(other, api.models.DatasetPose):
-            return self.__matmul__(Pose.from_dataset_pose(other))
 
         raise ValueError(f"Cannot multiply Pose with {type(other)}")
 

--- a/nova/types/pose.py
+++ b/nova/types/pose.py
@@ -12,33 +12,32 @@ from nova.types.vector3d import Vector3d
 _POSE_EQUALITY_PRECISION = 6
 
 
-def _parse_args(*args):
-    """Parse the arguments and return a dictionary that pydanctic can validate"""
+def _resolve_pose(
+    args: tuple, kinematic_configuration: api.models.KinematicConfiguration | None
+) -> Pose:
+    """Resolve the positional constructor arguments of `Pose` into a `Pose` instance.
+
+    Dispatches to the appropriate factory classmethod based on the shape of `args`.
+    Raises `ValueError` if `args` does not match any supported form, or if `args` carries
+    its own `kinematic_configuration` that conflicts with an explicitly passed one.
+    """
     if args == (None,):
-        return {
-            "position": Vector3d(x=0.0, y=0.0, z=0.0),
-            "orientation": Vector3d(x=0.0, y=0.0, z=0.0),
-        }
+        return Pose.from_tuple((0, 0, 0, 0, 0, 0))
+    if len(args) == 1 and isinstance(args[0], api.models.DatasetPose):
+        dataset_pose = args[0]
+        if dataset_pose.kinematic_configuration is not None and kinematic_configuration is not None:
+            raise ValueError(
+                "Cannot specify kinematic_configuration when passing a PoseLike "
+                "with a kinematic_configuration"
+            )
+        return Pose.from_dataset_pose(dataset_pose)
     if len(args) == 1 and isinstance(args[0], api.models.Pose):
-        pos = args[0].position
-        ori = args[0].orientation
-        if pos is None:
-            pos = [0.0, 0.0, 0.0]
-        if ori is None:
-            ori = [0.0, 0.0, 0.0]
-        return {
-            "position": Vector3d(x=pos[0], y=pos[1], z=pos[2]),
-            "orientation": Vector3d(x=ori[0], y=ori[1], z=ori[2]),
-        }
+        return Pose.from_api_model(args[0], kinematic_configuration=kinematic_configuration)
     if len(args) == 1 and isinstance(args[0], tuple):
-        args = args[0]
-    if len(args) == 6:
-        x1, y1, z1, x2, y2, z2 = args
-        return {"position": Vector3d(x=x1, y=y1, z=z1), "orientation": Vector3d(x=x2, y=y2, z=z2)}
-    if len(args) == 3:
-        x1, y1, z1 = args
-        return {"position": Vector3d(x=x1, y=y1, z=z1), "orientation": Vector3d(x=0, y=0, z=0)}
-    raise ValueError("Invalid number of arguments for Pose")
+        return Pose.from_tuple(args[0], kinematic_configuration=kinematic_configuration)
+    if len(args) in (3, 6):
+        return Pose.from_tuple(args, kinematic_configuration=kinematic_configuration)
+    raise ValueError(f"Cannot construct Pose from arguments: {args!r}")
 
 
 class Pose(pydantic.BaseModel, Sized):
@@ -86,19 +85,25 @@ class Pose(pydantic.BaseModel, Sized):
         >>> kc2 = api.models.KinematicConfiguration(kinematic_branch=kb, axis_ranges=ar)
         >>> Pose((1, 2, 3, 4, 5, 6), kinematic_configuration=kc2).kinematic_configuration == kc2
         True
+        >>> dp = api.models.DatasetPose(id='p1', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6])))
+        >>> Pose(dp)
+        Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0), kinematic_configuration=None)
+        >>> dp2 = api.models.DatasetPose(id='p2', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6])), kinematic_configuration=kc)
+        >>> Pose(dp2).kinematic_configuration == kc
+        True
         """
-        # >>> Pose(api.models.TcpOffset(name='Flange', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.Vector3d([4, 5, 6]))))
-        # Pose(position=Vector3d(x=1, y=2, z=3), orientation=Vector3d(x=4, y=5, z=6))
-        # Preserve kinematic_configuration from kwargs when positional args are parsed by _parse_args.
-        # _parse_args only returns position/orientation, so we inject it back before validation.
-        kinematic_configuration = kwargs.pop("kinematic_configuration", None)
-        if args:
-            values = _parse_args(*args)
-            values["kinematic_configuration"] = kinematic_configuration
-            super().__init__(**values)
-        else:
-            kwargs.setdefault("kinematic_configuration", kinematic_configuration)
+        if not args:
             super().__init__(**kwargs)
+            return
+
+        pose = _resolve_pose(
+            args, kinematic_configuration=kwargs.pop("kinematic_configuration", None)
+        )
+        super().__init__(
+            position=pose.position,
+            orientation=pose.orientation,
+            kinematic_configuration=pose.kinematic_configuration,
+        )
 
     def __str__(self):
         return str(round(self).to_tuple())
@@ -197,7 +202,7 @@ class Pose(pydantic.BaseModel, Sized):
             ),
         )
 
-    def __matmul__(self, other):
+    def __matmul__(self, other) -> Pose:
         """
         Pose concatenation combines two poses into a single pose that represents the cumulative effect of both
         transformations applied sequentially.
@@ -232,6 +237,8 @@ class Pose(pydantic.BaseModel, Sized):
         if isinstance(other, Iterable):
             seq = tuple(other)
             return self.__matmul__(Pose(seq))
+        if isinstance(other, api.models.DatasetPose):
+            return self.__matmul__(Pose.from_dataset_pose(other))
 
         raise ValueError(f"Cannot multiply Pose with {type(other)}")
 
@@ -316,6 +323,67 @@ class Pose(pydantic.BaseModel, Sized):
                 rotation_vec[1],
                 rotation_vec[2],
             )
+        )
+
+    @classmethod
+    def from_tuple(
+        cls, values: tuple, kinematic_configuration: api.models.KinematicConfiguration | None = None
+    ) -> Pose:
+        """Create a Pose from a 3-tuple (position only) or 6-tuple (position + orientation).
+
+        Examples:
+        >>> Pose.from_tuple((1, 2, 3, 4, 5, 6))
+        Pose(position=Vector3d(x=1, y=2, z=3), orientation=Vector3d(x=4, y=5, z=6), kinematic_configuration=None)
+        >>> Pose.from_tuple((1, 2, 3))
+        Pose(position=Vector3d(x=1, y=2, z=3), orientation=Vector3d(x=0, y=0, z=0), kinematic_configuration=None)
+        """
+        if len(values) == 6:
+            x1, y1, z1, x2, y2, z2 = values
+            return cls(
+                position=Vector3d(x=x1, y=y1, z=z1),
+                orientation=Vector3d(x=x2, y=y2, z=z2),
+                kinematic_configuration=kinematic_configuration,
+            )
+        if len(values) == 3:
+            x1, y1, z1 = values
+            return cls(
+                position=Vector3d(x=x1, y=y1, z=z1),
+                orientation=Vector3d(x=0, y=0, z=0),
+                kinematic_configuration=kinematic_configuration,
+            )
+        raise ValueError("Pose.from_tuple expects 3 or 6 values")
+
+    @classmethod
+    def from_api_model(
+        cls,
+        pose: api.models.Pose,
+        kinematic_configuration: api.models.KinematicConfiguration | None = None,
+    ) -> Pose:
+        """Create a Pose from a wandelbots_api_client Pose model.
+
+        Example:
+        >>> Pose.from_api_model(api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6])))
+        Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0), kinematic_configuration=None)
+        """
+        pos = pose.position if pose.position is not None else [0.0, 0.0, 0.0]
+        ori = pose.orientation if pose.orientation is not None else [0.0, 0.0, 0.0]
+        return cls(
+            position=Vector3d(x=pos[0], y=pos[1], z=pos[2]),
+            orientation=Vector3d(x=ori[0], y=ori[1], z=ori[2]),
+            kinematic_configuration=kinematic_configuration,
+        )
+
+    @classmethod
+    def from_dataset_pose(cls, dataset_pose: api.models.DatasetPose) -> Pose:
+        """Create a Pose from a DatasetPose, preserving its kinematic configuration.
+
+        Example:
+        >>> dp = api.models.DatasetPose(id='p1', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6])))
+        >>> Pose.from_dataset_pose(dp)
+        Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0), kinematic_configuration=None)
+        """
+        return cls.from_api_model(
+            dataset_pose.pose, kinematic_configuration=dataset_pose.kinematic_configuration
         )
 
     @classmethod

--- a/nova/types/pose.py
+++ b/nova/types/pose.py
@@ -23,14 +23,25 @@ def _resolve_pose(
     """
     if args == (None,):
         return Pose.from_tuple((0, 0, 0, 0, 0, 0))
-    if len(args) == 1 and isinstance(args[0], api.models.DatasetPose):
-        dataset_pose = args[0]
-        if dataset_pose.kinematic_configuration is not None and kinematic_configuration is not None:
+    if len(args) == 1 and isinstance(args[0], Pose):
+        pose = args[0]
+        if pose.kinematic_configuration is not None and kinematic_configuration is not None:
+            raise ValueError(
+                "Cannot specify kinematic_configuration when passing a Pose with a "
+                "kinematic_configuration"
+            )
+        return pose
+    if len(args) == 1 and isinstance(args[0], api.models.ConfiguredPose):
+        configured_pose = args[0]
+        if (
+            configured_pose.kinematic_configuration is not None
+            and kinematic_configuration is not None
+        ):
             raise ValueError(
                 "Cannot specify kinematic_configuration when passing a PoseLike "
                 "with a kinematic_configuration"
             )
-        return Pose.from_dataset_pose(dataset_pose)
+        return Pose.from_dataset_pose(configured_pose)
     if len(args) == 1 and isinstance(args[0], api.models.Pose):
         return Pose.from_api_model(args[0], kinematic_configuration=kinematic_configuration)
     if (
@@ -378,8 +389,9 @@ class Pose(pydantic.BaseModel, Sized):
         )
 
     @classmethod
-    def from_dataset_pose(cls, dataset_pose: api.models.DatasetPose) -> Pose:
-        """Create a Pose from a DatasetPose, preserving its kinematic configuration.
+    def from_dataset_pose(cls, dataset_pose: api.models.ConfiguredPose) -> Pose:
+        """Create a Pose from a ConfiguredPose (or DatasetPose subtype), preserving its
+        kinematic configuration.
 
         Example:
         >>> dp = api.models.DatasetPose(id='p1', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6])))

--- a/nova/types/pose.py
+++ b/nova/types/pose.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable, Sequence, Sized
+from typing import Sequence, Sized
 
 import numpy as np
 import pydantic
@@ -217,7 +217,7 @@ class Pose(pydantic.BaseModel, Sized):
             ),
         )
 
-    def __matmul__(self, other) -> Pose:
+    def __matmul__(self, other: Pose) -> Pose:
         """
         Pose concatenation combines two poses into a single pose that represents the cumulative effect of both
         transformations applied sequentially.
@@ -225,37 +225,18 @@ class Pose(pydantic.BaseModel, Sized):
         Note: kinematic_configuration is NOT propagated — the result always has
         kinematic_configuration=None.
 
-        Args:
-            other: can be a Pose, or an iterable with 6 elements
-
         Returns:
             Pose: the result of the concatenation
 
         Examples:
         >>> Pose((1, 2, 3, 0, 0, 0)) @ Pose((1, 2, 3, 0, 0, 0))
         Pose(position=Vector3d(x=2.0, y=4.0, z=6.0), orientation=Vector3d(x=0.0, y=0.0, z=0.0), kinematic_configuration=None)
-        >>> Pose((1, 2, 3, 0, 0, 0)) @ [1, 2, 3, 0, 0, 0]
-        Pose(position=Vector3d(x=2.0, y=4.0, z=6.0), orientation=Vector3d(x=0.0, y=0.0, z=0.0), kinematic_configuration=None)
-        >>> Pose((1, 2, 3, 0, 0, 0)) @ (1, 2, 3, 0, 0, 0)
-        Pose(position=Vector3d(x=2.0, y=4.0, z=6.0), orientation=Vector3d(x=0.0, y=0.0, z=0.0), kinematic_configuration=None)
-        >>> def as_iterator(data):
-        ...     for d in data:
-        ...         yield d
-        >>> Pose((1, 2, 3, 0, 0, 0)) @ as_iterator([1, 2, 3, 0, 0, 0])
-        Pose(position=Vector3d(x=2.0, y=4.0, z=6.0), orientation=Vector3d(x=0.0, y=0.0, z=0.0), kinematic_configuration=None)
-        >>> Pose((1, 2, 3, 0, 0, 0)) @ Vector3d.from_tuple((1, 2, 3))
+        >>> Pose((1, 2, 3, 0, 0, 0)) @ Pose(DatasetPose(id='p1', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([0, 0, 0]))))
         Pose(position=Vector3d(x=2.0, y=4.0, z=6.0), orientation=Vector3d(x=0.0, y=0.0, z=0.0), kinematic_configuration=None)
         """
-        if isinstance(other, Pose):
-            transformed_matrix = np.dot(self.matrix, other.matrix)
-            return self._matrix_to_pose(transformed_matrix)
-        if isinstance(other, ConfiguredPose):
-            return self.__matmul__(Pose.from_dataset_pose(other))
-        if isinstance(other, Iterable):
-            seq = tuple(other)
-            return self.__matmul__(Pose(seq))
 
-        raise ValueError(f"Cannot multiply Pose with {type(other)}")
+        transformed_matrix = np.dot(self.matrix, other.matrix)
+        return self._matrix_to_pose(transformed_matrix)
 
     def __array__(self, dtype=None):
         """Convert Pose to a 6-element numpy array: [pos.x, pos.y, pos.z, ori.x, ori.y, ori.z].

--- a/nova/types/pose.py
+++ b/nova/types/pose.py
@@ -23,7 +23,7 @@ def _resolve_pose(
     its own `kinematic_configuration` that conflicts with an explicitly passed one.
     """
     if len(args) == 1 and args[0] is None:
-        return Pose.from_tuple((0, 0, 0, 0, 0, 0))
+        return Pose.from_tuple((0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
     if len(args) == 1 and isinstance(args[0], Pose):
         pose = args[0]
         if pose.kinematic_configuration is not None and kinematic_configuration is not None:
@@ -102,10 +102,10 @@ class Pose(pydantic.BaseModel, Sized):
         >>> kc2 = api.models.KinematicConfiguration(kinematic_branch=kb, axis_ranges=ar)
         >>> Pose((1, 2, 3, 4, 5, 6), kinematic_configuration=kc2).kinematic_configuration == kc2
         True
-        >>> Pose(DatasetPose(id='p1', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6]))))
+        >>> Pose(DatasetPose(id='p1', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6])), kinematic_configuration=None)).
         Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0), kinematic_configuration=None)
-        >>> Pose(DatasetPose(id='p2', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6])), kinematic_configuration=kc))
-        Pose((1,2,3,4,5,6), kinematic_configuration=kc).kinematic_configuration == kc
+        >>> kc = api.models.KinematicConfiguration(kinematic_branch=api.models.KinematicBranch(shoulder_branch='FRONT', elbow_branch='UP', wrist_branch='NO_FLIP'))
+        >>> Pose(DatasetPose(id='p2', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6])), kinematic_configuration=kc)).kinematic_configuration == kc
         True
         """
         if not args:
@@ -394,7 +394,7 @@ class Pose(pydantic.BaseModel, Sized):
         kinematic configuration.
 
         Example:
-        >>> dp = DatasetPose(id='p1', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6])))
+        >>> dp = DatasetPose(id='p1', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6])), kinematic_configuration=None)
         >>> Pose.from_dataset_pose(dp)
         Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0), kinematic_configuration=None)
         """

--- a/nova/types/pose.py
+++ b/nova/types/pose.py
@@ -21,7 +21,7 @@ def _resolve_pose(
     Raises `ValueError` if `args` does not match any supported form, or if `args` carries
     its own `kinematic_configuration` that conflicts with an explicitly passed one.
     """
-    if args == (None,):
+    if len(args) == 1 and args[0] is None:
         return Pose.from_tuple((0, 0, 0, 0, 0, 0))
     if len(args) == 1 and isinstance(args[0], Pose):
         pose = args[0]
@@ -46,7 +46,7 @@ def _resolve_pose(
         return Pose.from_api_model(args[0], kinematic_configuration=kinematic_configuration)
     if (
         len(args) == 1
-        and isinstance(args[0], Sequence)
+        and isinstance(args[0], (Sequence, np.ndarray))
         and not isinstance(args[0], str)
         and len(args[0]) in (3, 6)
     ):

--- a/nova/types/pose.py
+++ b/nova/types/pose.py
@@ -101,11 +101,10 @@ class Pose(pydantic.BaseModel, Sized):
         >>> kc2 = api.models.KinematicConfiguration(kinematic_branch=kb, axis_ranges=ar)
         >>> Pose((1, 2, 3, 4, 5, 6), kinematic_configuration=kc2).kinematic_configuration == kc2
         True
-        >>> dp = api.models.DatasetPose(id='p1', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6])))
-        >>> Pose(dp)
+        >>> Pose(api.models.DatasetPose(id='p1', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6]))))
         Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0), kinematic_configuration=None)
-        >>> dp2 = api.models.DatasetPose(id='p2', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6])), kinematic_configuration=kc)
-        >>> Pose(dp2).kinematic_configuration == kc
+        >>> Pose(api.models.DatasetPose(id='p2', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6])), kinematic_configuration=kc))
+        Pose((1,2,3,4,5,6), kinematic_configuration=kc).kinematic_configuration == kc
         True
         """
         if not args:

--- a/nova/types/pose.py
+++ b/nova/types/pose.py
@@ -7,6 +7,7 @@ import pydantic
 from scipy.spatial.transform import Rotation
 
 from nova import api
+from nova.types.dataset_pose import DatasetPose
 from nova.types.vector3d import Vector3d
 
 _POSE_EQUALITY_PRECISION = 6
@@ -101,9 +102,9 @@ class Pose(pydantic.BaseModel, Sized):
         >>> kc2 = api.models.KinematicConfiguration(kinematic_branch=kb, axis_ranges=ar)
         >>> Pose((1, 2, 3, 4, 5, 6), kinematic_configuration=kc2).kinematic_configuration == kc2
         True
-        >>> Pose(api.models.DatasetPose(id='p1', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6]))))
+        >>> Pose(DatasetPose(id='p1', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6]))))
         Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0), kinematic_configuration=None)
-        >>> Pose(api.models.DatasetPose(id='p2', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6])), kinematic_configuration=kc))
+        >>> Pose(DatasetPose(id='p2', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6])), kinematic_configuration=kc))
         Pose((1,2,3,4,5,6), kinematic_configuration=kc).kinematic_configuration == kc
         True
         """
@@ -388,12 +389,12 @@ class Pose(pydantic.BaseModel, Sized):
         )
 
     @classmethod
-    def from_dataset_pose(cls, dataset_pose: api.models.ConfiguredPose) -> Pose:
+    def from_dataset_pose(cls, dataset_pose: DatasetPose | api.models.ConfiguredPose) -> Pose:
         """Create a Pose from a ConfiguredPose (or DatasetPose subtype), preserving its
         kinematic configuration.
 
         Example:
-        >>> dp = api.models.DatasetPose(id='p1', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6])))
+        >>> dp = DatasetPose(id='p1', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6])))
         >>> Pose.from_dataset_pose(dp)
         Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0), kinematic_configuration=None)
         """

--- a/nova/types/pose.py
+++ b/nova/types/pose.py
@@ -7,7 +7,7 @@ import pydantic
 from scipy.spatial.transform import Rotation
 
 from nova import api
-from nova.types.dataset_pose import DatasetPose
+from nova.types.dataset_pose import ConfiguredPose, DatasetPose
 from nova.types.vector3d import Vector3d
 
 _POSE_EQUALITY_PRECISION = 6
@@ -32,14 +32,14 @@ def _resolve_pose(
                 "kinematic_configuration"
             )
         return pose
-    if len(args) == 1 and isinstance(args[0], api.models.ConfiguredPose):
+    if len(args) == 1 and isinstance(args[0], ConfiguredPose):
         configured_pose = args[0]
         if (
             configured_pose.kinematic_configuration is not None
             and kinematic_configuration is not None
         ):
             raise ValueError(
-                "Cannot specify kinematic_configuration when passing a PoseLike "
+                "Cannot specify kinematic_configuration when passing a ConfiguredPose or DatasetPose "
                 "with a kinematic_configuration"
             )
         return Pose.from_dataset_pose(configured_pose)
@@ -102,7 +102,7 @@ class Pose(pydantic.BaseModel, Sized):
         >>> kc2 = api.models.KinematicConfiguration(kinematic_branch=kb, axis_ranges=ar)
         >>> Pose((1, 2, 3, 4, 5, 6), kinematic_configuration=kc2).kinematic_configuration == kc2
         True
-        >>> Pose(DatasetPose(id='p1', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6])), kinematic_configuration=None)).
+        >>> Pose(DatasetPose(id='p1', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6]))))
         Pose(position=Vector3d(x=1.0, y=2.0, z=3.0), orientation=Vector3d(x=4.0, y=5.0, z=6.0), kinematic_configuration=None)
         >>> kc = api.models.KinematicConfiguration(kinematic_branch=api.models.KinematicBranch(shoulder_branch='FRONT', elbow_branch='UP', wrist_branch='NO_FLIP'))
         >>> Pose(DatasetPose(id='p2', pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=api.models.RotationVector([4, 5, 6])), kinematic_configuration=kc)).kinematic_configuration == kc
@@ -249,7 +249,7 @@ class Pose(pydantic.BaseModel, Sized):
         if isinstance(other, Pose):
             transformed_matrix = np.dot(self.matrix, other.matrix)
             return self._matrix_to_pose(transformed_matrix)
-        if isinstance(other, api.models.ConfiguredPose):
+        if isinstance(other, ConfiguredPose):
             return self.__matmul__(Pose.from_dataset_pose(other))
         if isinstance(other, Iterable):
             seq = tuple(other)
@@ -389,7 +389,7 @@ class Pose(pydantic.BaseModel, Sized):
         )
 
     @classmethod
-    def from_dataset_pose(cls, dataset_pose: DatasetPose | api.models.ConfiguredPose) -> Pose:
+    def from_dataset_pose(cls, dataset_pose: DatasetPose | ConfiguredPose) -> Pose:
         """Create a Pose from a ConfiguredPose (or DatasetPose subtype), preserving its
         kinematic configuration.
 

--- a/tests/actions/test_motions_target_conversion.py
+++ b/tests/actions/test_motions_target_conversion.py
@@ -1,0 +1,86 @@
+import pytest
+
+from nova.actions.motions import cartesian_ptp, circular, linear, spline
+from nova.types import Pose
+
+
+class TestMotionTargetConversion:
+    """Motion factory functions convert PoseOrSequence targets via the Pose constructor."""
+
+    def test_linear_six_tuple(self):
+        assert linear((1, 2, 3, 4, 5, 6)).target == Pose((1, 2, 3, 4, 5, 6))
+
+    def test_linear_three_tuple_defaults_orientation(self):
+        assert linear((1, 2, 3)).target == Pose((1, 2, 3, 0, 0, 0))
+
+    def test_linear_existing_pose_passed_through(self):
+        original = Pose((1, 2, 3, 4, 5, 6))
+        assert linear(original).target is original
+
+    def test_linear_wrong_length_raises(self):
+        with pytest.raises(ValueError):
+            linear((1, 2, 3, 4))
+
+    def test_cartesian_ptp_existing_pose_passed_through(self):
+        original = Pose((1, 2, 3, 4, 5, 6))
+        assert cartesian_ptp(original).target is original
+
+    def test_cartesian_ptp_wrong_length_raises(self):
+        with pytest.raises(ValueError):
+            cartesian_ptp((1, 2, 3, 4))
+
+    def test_circular_existing_poses_passed_through(self):
+        target = Pose((1, 2, 3, 4, 5, 6))
+        intermediate = Pose((7, 8, 9, 10, 11, 12))
+        action = circular(target, intermediate)
+        assert action.target is target
+        assert action.intermediate is intermediate
+
+    def test_circular_wrong_length_raises(self):
+        with pytest.raises(ValueError):
+            circular((1, 2, 3, 4), (7, 8, 9, 10, 11, 12))
+
+    def test_spline_existing_pose_passed_through(self):
+        original = Pose((1, 2, 3, 4, 5, 6))
+        assert spline(original).target is original
+
+    def test_spline_wrong_length_raises(self):
+        with pytest.raises(ValueError):
+            spline((1, 2, 3, 4))
+
+
+class TestMotionFactoriesAcceptLists:
+    """List inputs should behave the same as the equivalent tuple inputs.
+
+    Note: we compare `.target`/`.intermediate` rather than full object equality,
+    since the factory functions attach caller source-location metadata (`metas`)
+    that differs between call sites.
+    """
+
+    def test_linear_six_list(self):
+        assert linear([1, 2, 3, 4, 5, 6]).target == Pose((1, 2, 3, 4, 5, 6))
+
+    def test_linear_three_list_defaults_orientation(self):
+        assert linear([1, 2, 3]).target == Pose((1, 2, 3, 0, 0, 0))
+
+    def test_cartesian_ptp_six_list(self):
+        assert cartesian_ptp([1, 2, 3, 4, 5, 6]).target == Pose((1, 2, 3, 4, 5, 6))
+
+    def test_cartesian_ptp_three_list_defaults_orientation(self):
+        assert cartesian_ptp([1, 2, 3]).target == Pose((1, 2, 3, 0, 0, 0))
+
+    def test_circular_six_lists(self):
+        action = circular([1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12])
+        assert action.target == Pose((1, 2, 3, 4, 5, 6))
+        assert action.intermediate == Pose((7, 8, 9, 10, 11, 12))
+
+    def test_circular_three_lists_default_orientation(self):
+        action = circular([1, 2, 3], [4, 5, 6])
+        assert action.target == Pose((1, 2, 3, 0, 0, 0))
+        assert action.intermediate == Pose((4, 5, 6, 0, 0, 0))
+
+    def test_spline_six_list(self):
+        assert spline([1, 2, 3, 4, 5, 6]).target == Pose((1, 2, 3, 4, 5, 6))
+
+    def test_spline_three_list_defaults_orientation(self):
+        assert spline([1, 2, 3]).target == Pose((1, 2, 3, 0, 0, 0))

--- a/tests/actions/test_motions_target_conversion.py
+++ b/tests/actions/test_motions_target_conversion.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from nova.actions.motions import cartesian_ptp, circular, linear, spline
@@ -84,3 +85,17 @@ class TestMotionFactoriesAcceptLists:
 
     def test_spline_three_list_defaults_orientation(self):
         assert spline([1, 2, 3]).target == Pose((1, 2, 3, 0, 0, 0))
+
+    def test_linear_numpy_array(self):
+        assert linear(np.array([1, 2, 3, 4, 5, 6])).target == Pose((1, 2, 3, 4, 5, 6))
+
+    def test_cartesian_ptp_numpy_array(self):
+        assert cartesian_ptp(np.array([1, 2, 3, 4, 5, 6])).target == Pose((1, 2, 3, 4, 5, 6))
+
+    def test_circular_numpy_arrays(self):
+        action = circular(np.array([1, 2, 3, 4, 5, 6]), np.array([7, 8, 9, 10, 11, 12]))
+        assert action.target == Pose((1, 2, 3, 4, 5, 6))
+        assert action.intermediate == Pose((7, 8, 9, 10, 11, 12))
+
+    def test_spline_numpy_array(self):
+        assert spline(np.array([1, 2, 3, 4, 5, 6])).target == Pose((1, 2, 3, 4, 5, 6))

--- a/tests/nova/types/test_pose_init.py
+++ b/tests/nova/types/test_pose_init.py
@@ -1,0 +1,163 @@
+import pytest
+
+from nova import api
+from nova.types import Pose, Vector3d
+
+
+@pytest.fixture
+def kinematic_config():
+    return api.models.KinematicConfiguration(
+        kinematic_branch=api.models.KinematicBranch(
+            shoulder_branch="FRONT", elbow_branch="UP", wrist_branch="NO_FLIP"
+        )
+    )
+
+
+class TestPoseInitAllowed:
+    """Constructor forms that are currently supported."""
+
+    def test_none_arg_gives_identity(self):
+        p = Pose(None)
+        assert p.to_tuple() == (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        assert p.kinematic_configuration is None
+
+    def test_native_kwargs(self):
+        p = Pose(position=Vector3d(x=10, y=20, z=30), orientation=Vector3d(x=1, y=2, z=3))
+        assert p.to_tuple() == (10, 20, 30, 1, 2, 3)
+        assert p.kinematic_configuration is None
+
+    def test_six_tuple(self):
+        p = Pose((1, 2, 3, 4, 5, 6))
+        assert p.to_tuple() == (1, 2, 3, 4, 5, 6)
+
+    def test_three_tuple_defaults_orientation(self):
+        p = Pose((1, 2, 3))
+        assert p.to_tuple() == (1, 2, 3, 0, 0, 0)
+
+    def test_six_positional_args(self):
+        p = Pose(1, 2, 3, 4, 5, 6)
+        assert p.to_tuple() == (1, 2, 3, 4, 5, 6)
+
+    def test_three_positional_args_defaults_orientation(self):
+        p = Pose(1, 2, 3)
+        assert p.to_tuple() == (1, 2, 3, 0, 0, 0)
+
+    def test_from_api_model(self):
+        api_pose = api.models.Pose(
+            position=api.models.Vector3d([1, 2, 3]),
+            orientation=api.models.RotationVector([4, 5, 6]),
+        )
+        p = Pose(api_pose)
+        assert p.to_tuple() == (1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
+
+    def test_from_api_model_with_none_fields_gives_identity(self):
+        p = Pose(api.models.Pose(position=None, orientation=None))
+        assert p.to_tuple() == (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+    def test_from_api_model_with_none_position_gives_zero_position(self):
+        p = Pose(api.models.Pose(position=None, orientation=api.models.RotationVector([1, 2, 3])))
+        assert p.to_tuple() == (0.0, 0.0, 0.0, 1.0, 2.0, 3.0)
+
+    def test_from_api_model_with_none_orientation_gives_zero_orientation(self):
+        p = Pose(api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=None))
+        assert p.to_tuple() == (1.0, 2.0, 3.0, 0.0, 0.0, 0.0)
+
+    def test_kinematic_configuration_kwarg_preserved(self, kinematic_config):
+        p = Pose((1, 2, 3, 4, 5, 6), kinematic_configuration=kinematic_config)
+        assert p.to_tuple() == (1, 2, 3, 4, 5, 6)
+        assert p.kinematic_configuration == kinematic_config
+
+    def test_from_dataset_pose(self, kinematic_config):
+        dataset_pose = api.models.DatasetPose(
+            id="p1",
+            pose=api.models.Pose(
+                position=api.models.Vector3d([1, 2, 3]),
+                orientation=api.models.RotationVector([4, 5, 6]),
+            ),
+            kinematic_configuration=kinematic_config,
+        )
+        p = Pose(dataset_pose)
+        assert p.to_tuple() == (1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
+        assert p.kinematic_configuration == kinematic_config
+
+    def test_from_dataset_pose_position_none(self, kinematic_config):
+        dataset_pose = api.models.DatasetPose(
+            id="p1",
+            pose=api.models.Pose(position=None, orientation=api.models.RotationVector([4, 5, 6])),
+            kinematic_configuration=kinematic_config,
+        )
+        p = Pose(dataset_pose)
+        assert p.to_tuple() == (0.0, 0.0, 0.0, 4.0, 5.0, 6.0)
+        assert p.kinematic_configuration == kinematic_config
+
+    def test_from_dataset_pose_orientation_none(self, kinematic_config):
+        dataset_pose = api.models.DatasetPose(
+            id="p1",
+            pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=None),
+            kinematic_configuration=kinematic_config,
+        )
+        p = Pose(dataset_pose)
+        assert p.to_tuple() == (1.0, 2.0, 3.0, 0.0, 0.0, 0.0)
+        assert p.kinematic_configuration == kinematic_config
+
+    def test_from_dataset_pose_position_and_orientation_none(self, kinematic_config):
+        dataset_pose = api.models.DatasetPose(
+            id="p1",
+            pose=api.models.Pose(position=None, orientation=None),
+            kinematic_configuration=kinematic_config,
+        )
+        p = Pose(dataset_pose)
+        assert p.to_tuple() == (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        assert p.kinematic_configuration == kinematic_config
+
+    def test_from_dataset_pose_without_kinematic_configuration(self):
+        dataset_pose = api.models.DatasetPose(
+            id="p2",
+            pose=api.models.Pose(
+                position=api.models.Vector3d([1, 2, 3]),
+                orientation=api.models.RotationVector([4, 5, 6]),
+            ),
+        )
+        p = Pose(dataset_pose)
+        assert p.to_tuple() == (1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
+        assert p.kinematic_configuration is None
+
+
+class TestPoseInitForbidden:
+    """Constructor forms that are currently rejected."""
+
+    def test_no_args_raises(self):
+        with pytest.raises(KeyError):
+            Pose()
+
+    def test_none_keyword_args_raises(self):
+        with pytest.raises(TypeError):
+            Pose(position=None, orientation=None)
+
+    def test_from_existing_pose_raises(self):
+        with pytest.raises(ValueError):
+            Pose(Pose((1, 2, 3, 4, 5, 6)))
+
+    def test_single_scalar_arg_raises(self):
+        with pytest.raises(ValueError):
+            Pose(42)
+
+    def test_four_positional_args_raise(self):
+        with pytest.raises(ValueError):
+            Pose(1, 2, 3, 4)
+
+    def test_seven_positional_args_raise(self):
+        with pytest.raises(ValueError):
+            Pose(1, 2, 3, 4, 5, 6, 7)
+
+    def test_dataset_pose_with_double_kinematic_configuration_raises(self, kinematic_config):
+        dataset_pose = api.models.DatasetPose(
+            id="p1",
+            pose=api.models.Pose(
+                position=api.models.Vector3d([1, 2, 3]),
+                orientation=api.models.RotationVector([4, 5, 6]),
+            ),
+            kinematic_configuration=kinematic_config,
+        )
+        with pytest.raises(ValueError):
+            Pose(dataset_pose, kinematic_configuration=kinematic_config)

--- a/tests/nova/types/test_pose_init.py
+++ b/tests/nova/types/test_pose_init.py
@@ -34,6 +34,14 @@ class TestPoseInitAllowed:
         p = Pose((1, 2, 3))
         assert p.to_tuple() == (1, 2, 3, 0, 0, 0)
 
+    def test_six_list(self):
+        p = Pose([1, 2, 3, 4, 5, 6])
+        assert p.to_tuple() == (1, 2, 3, 4, 5, 6)
+
+    def test_three_list_defaults_orientation(self):
+        p = Pose([1, 2, 3])
+        assert p.to_tuple() == (1, 2, 3, 0, 0, 0)
+
     def test_six_positional_args(self):
         p = Pose(1, 2, 3, 4, 5, 6)
         assert p.to_tuple() == (1, 2, 3, 4, 5, 6)
@@ -122,6 +130,26 @@ class TestPoseInitAllowed:
         assert p.to_tuple() == (1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
         assert p.kinematic_configuration is None
 
+    def test_from_existing_pose_copies_values(self):
+        original = Pose((1, 2, 3, 4, 5, 6))
+        p = Pose(original)
+        assert p == original
+        assert p.kinematic_configuration is None
+
+    def test_from_existing_pose_with_kinematic_configuration(self, kinematic_config):
+        original = Pose((1, 2, 3, 4, 5, 6), kinematic_configuration=kinematic_config)
+        p = Pose(original)
+        assert p.to_tuple() == (1, 2, 3, 4, 5, 6)
+        assert p.kinematic_configuration == kinematic_config
+
+    def test_from_existing_pose_without_kinematic_configuration_kwarg_applied(
+        self, kinematic_config
+    ):
+        original = Pose((1, 2, 3, 4, 5, 6))
+        p = Pose(original, kinematic_configuration=kinematic_config)
+        assert p.to_tuple() == (1, 2, 3, 4, 5, 6)
+        assert p.kinematic_configuration == kinematic_config
+
 
 class TestPoseInitForbidden:
     """Constructor forms that are currently rejected."""
@@ -134,10 +162,6 @@ class TestPoseInitForbidden:
         with pytest.raises(TypeError):
             Pose(position=None, orientation=None)
 
-    def test_from_existing_pose_raises(self):
-        with pytest.raises(ValueError):
-            Pose(Pose((1, 2, 3, 4, 5, 6)))
-
     def test_single_scalar_arg_raises(self):
         with pytest.raises(ValueError):
             Pose(42)
@@ -149,6 +173,19 @@ class TestPoseInitForbidden:
     def test_seven_positional_args_raise(self):
         with pytest.raises(ValueError):
             Pose(1, 2, 3, 4, 5, 6, 7)
+
+    def test_four_element_list_raises(self):
+        with pytest.raises(ValueError):
+            Pose([1, 2, 3, 4])
+
+    def test_string_arg_raises(self):
+        with pytest.raises(ValueError):
+            Pose("abcdef")
+
+    def test_existing_pose_with_double_kinematic_configuration_raises(self, kinematic_config):
+        original = Pose((1, 2, 3, 4, 5, 6), kinematic_configuration=kinematic_config)
+        with pytest.raises(ValueError):
+            Pose(original, kinematic_configuration=kinematic_config)
 
     def test_dataset_pose_with_double_kinematic_configuration_raises(self, kinematic_config):
         dataset_pose = api.models.DatasetPose(

--- a/tests/nova/types/test_pose_init.py
+++ b/tests/nova/types/test_pose_init.py
@@ -130,6 +130,38 @@ class TestPoseInitAllowed:
         assert p.to_tuple() == (1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
         assert p.kinematic_configuration is None
 
+    def test_from_configured_pose(self, kinematic_config):
+        configured_pose = api.models.ConfiguredPose(
+            pose=api.models.Pose(
+                position=api.models.Vector3d([1, 2, 3]),
+                orientation=api.models.RotationVector([4, 5, 6]),
+            ),
+            kinematic_configuration=kinematic_config,
+        )
+        p = Pose(configured_pose)
+        assert p.to_tuple() == (1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
+        assert p.kinematic_configuration == kinematic_config
+
+    def test_from_configured_pose_without_kinematic_configuration(self):
+        configured_pose = api.models.ConfiguredPose(
+            pose=api.models.Pose(
+                position=api.models.Vector3d([1, 2, 3]),
+                orientation=api.models.RotationVector([4, 5, 6]),
+            )
+        )
+        p = Pose(configured_pose)
+        assert p.to_tuple() == (1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
+        assert p.kinematic_configuration is None
+
+    def test_from_configured_pose_with_none_position_and_orientation(self, kinematic_config):
+        configured_pose = api.models.ConfiguredPose(
+            pose=api.models.Pose(position=None, orientation=None),
+            kinematic_configuration=kinematic_config,
+        )
+        p = Pose(configured_pose)
+        assert p.to_tuple() == (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        assert p.kinematic_configuration == kinematic_config
+
     def test_from_existing_pose_copies_values(self):
         original = Pose((1, 2, 3, 4, 5, 6))
         p = Pose(original)
@@ -198,3 +230,14 @@ class TestPoseInitForbidden:
         )
         with pytest.raises(ValueError):
             Pose(dataset_pose, kinematic_configuration=kinematic_config)
+
+    def test_configured_pose_with_double_kinematic_configuration_raises(self, kinematic_config):
+        configured_pose = api.models.ConfiguredPose(
+            pose=api.models.Pose(
+                position=api.models.Vector3d([1, 2, 3]),
+                orientation=api.models.RotationVector([4, 5, 6]),
+            ),
+            kinematic_configuration=kinematic_config,
+        )
+        with pytest.raises(ValueError):
+            Pose(configured_pose, kinematic_configuration=kinematic_config)

--- a/tests/nova/types/test_pose_init.py
+++ b/tests/nova/types/test_pose_init.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from nova import api
-from nova.types import Pose, Vector3d
+from nova.types import DatasetPose, Pose, Vector3d
 
 
 @pytest.fixture
@@ -85,7 +85,7 @@ class TestPoseInitAllowed:
         assert p.kinematic_configuration == kinematic_config
 
     def test_from_dataset_pose(self, kinematic_config):
-        dataset_pose = api.models.DatasetPose(
+        dataset_pose = DatasetPose(
             id="p1",
             pose=api.models.Pose(
                 position=api.models.Vector3d([1, 2, 3]),
@@ -98,7 +98,7 @@ class TestPoseInitAllowed:
         assert p.kinematic_configuration == kinematic_config
 
     def test_from_dataset_pose_position_none(self, kinematic_config):
-        dataset_pose = api.models.DatasetPose(
+        dataset_pose = DatasetPose(
             id="p1",
             pose=api.models.Pose(position=None, orientation=api.models.RotationVector([4, 5, 6])),
             kinematic_configuration=kinematic_config,
@@ -108,7 +108,7 @@ class TestPoseInitAllowed:
         assert p.kinematic_configuration == kinematic_config
 
     def test_from_dataset_pose_orientation_none(self, kinematic_config):
-        dataset_pose = api.models.DatasetPose(
+        dataset_pose = DatasetPose(
             id="p1",
             pose=api.models.Pose(position=api.models.Vector3d([1, 2, 3]), orientation=None),
             kinematic_configuration=kinematic_config,
@@ -118,7 +118,7 @@ class TestPoseInitAllowed:
         assert p.kinematic_configuration == kinematic_config
 
     def test_from_dataset_pose_position_and_orientation_none(self, kinematic_config):
-        dataset_pose = api.models.DatasetPose(
+        dataset_pose = DatasetPose(
             id="p1",
             pose=api.models.Pose(position=None, orientation=None),
             kinematic_configuration=kinematic_config,
@@ -128,7 +128,7 @@ class TestPoseInitAllowed:
         assert p.kinematic_configuration == kinematic_config
 
     def test_from_dataset_pose_without_kinematic_configuration(self):
-        dataset_pose = api.models.DatasetPose(
+        dataset_pose = DatasetPose(
             id="p2",
             pose=api.models.Pose(
                 position=api.models.Vector3d([1, 2, 3]),
@@ -229,7 +229,7 @@ class TestPoseInitForbidden:
             Pose(original, kinematic_configuration=kinematic_config)
 
     def test_dataset_pose_with_double_kinematic_configuration_raises(self, kinematic_config):
-        dataset_pose = api.models.DatasetPose(
+        dataset_pose = DatasetPose(
             id="p1",
             pose=api.models.Pose(
                 position=api.models.Vector3d([1, 2, 3]),

--- a/tests/nova/types/test_pose_init.py
+++ b/tests/nova/types/test_pose_init.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from nova import api
-from nova.types import DatasetPose, Pose, Vector3d
+from nova.types import ConfiguredPose, DatasetPose, Pose, Vector3d
 
 
 @pytest.fixture
@@ -140,7 +140,7 @@ class TestPoseInitAllowed:
         assert p.kinematic_configuration is None
 
     def test_from_configured_pose(self, kinematic_config):
-        configured_pose = api.models.ConfiguredPose(
+        configured_pose = ConfiguredPose(
             pose=api.models.Pose(
                 position=api.models.Vector3d([1, 2, 3]),
                 orientation=api.models.RotationVector([4, 5, 6]),
@@ -152,7 +152,7 @@ class TestPoseInitAllowed:
         assert p.kinematic_configuration == kinematic_config
 
     def test_from_configured_pose_without_kinematic_configuration(self):
-        configured_pose = api.models.ConfiguredPose(
+        configured_pose = ConfiguredPose(
             pose=api.models.Pose(
                 position=api.models.Vector3d([1, 2, 3]),
                 orientation=api.models.RotationVector([4, 5, 6]),
@@ -164,7 +164,7 @@ class TestPoseInitAllowed:
         assert p.kinematic_configuration is None
 
     def test_from_configured_pose_with_none_position_and_orientation(self, kinematic_config):
-        configured_pose = api.models.ConfiguredPose(
+        configured_pose = ConfiguredPose(
             pose=api.models.Pose(position=None, orientation=None),
             kinematic_configuration=kinematic_config,
         )
@@ -242,7 +242,7 @@ class TestPoseInitForbidden:
             Pose(dataset_pose, kinematic_configuration=kinematic_config)
 
     def test_configured_pose_with_double_kinematic_configuration_raises(self, kinematic_config):
-        configured_pose = api.models.ConfiguredPose(
+        configured_pose = ConfiguredPose(
             pose=api.models.Pose(
                 position=api.models.Vector3d([1, 2, 3]),
                 orientation=api.models.RotationVector([4, 5, 6]),

--- a/tests/nova/types/test_pose_init.py
+++ b/tests/nova/types/test_pose_init.py
@@ -156,7 +156,8 @@ class TestPoseInitAllowed:
             pose=api.models.Pose(
                 position=api.models.Vector3d([1, 2, 3]),
                 orientation=api.models.RotationVector([4, 5, 6]),
-            )
+            ),
+            kinematic_configuration=None,
         )
         p = Pose(configured_pose)
         assert p.to_tuple() == (1.0, 2.0, 3.0, 4.0, 5.0, 6.0)

--- a/tests/nova/types/test_pose_init.py
+++ b/tests/nova/types/test_pose_init.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from nova import api
@@ -40,6 +41,14 @@ class TestPoseInitAllowed:
 
     def test_three_list_defaults_orientation(self):
         p = Pose([1, 2, 3])
+        assert p.to_tuple() == (1, 2, 3, 0, 0, 0)
+
+    def test_numpy_array(self):
+        p = Pose(np.array([1, 2, 3, 4, 5, 6]))
+        assert p.to_tuple() == (1, 2, 3, 4, 5, 6)
+
+    def test_three_numpy_array_defaults_orientation(self):
+        p = Pose(np.array([1, 2, 3]))
         assert p.to_tuple() == (1, 2, 3, 0, 0, 0)
 
     def test_six_positional_args(self):

--- a/tests/nova/types/test_pose_kinematic_configuration.py
+++ b/tests/nova/types/test_pose_kinematic_configuration.py
@@ -39,7 +39,7 @@ class TestPoseKinematicConfiguration:
         assert pose_with_config != p_no_config
 
     def test_matmul_discards_config(self, pose_with_config):
-        result = pose_with_config @ (0, 0, 0, 0, 0, 0)
+        result = pose_with_config @ Pose((0, 0, 0, 0, 0, 0))
         assert result.kinematic_configuration is None
 
     def test_to_api_model_excludes_config(self, pose_with_config):

--- a/wandelscript/operators.py
+++ b/wandelscript/operators.py
@@ -4,6 +4,8 @@ import operator
 from enum import Enum
 from typing import Any, TypeVar
 
+from nova.types import Pose, Vector3d
+
 T = TypeVar("T")
 
 
@@ -90,6 +92,31 @@ class AdditionOperator(BinaryOperator):
     sub = "-"
 
 
+def _to_pose_operand(value: Any) -> Any:
+    """Coerce a geometric value operand of the `::` operator into a Pose.
+
+    `Pose.__matmul__` only accepts a `Pose`, but Wandelscript's frame algebra also
+    transforms plain positions/poses expressed as a `Vector3d` or a 3-/6-element numeric
+    `tuple`/`list` (e.g. a `[...]` array literal, or a builtin returning a raw tuple).
+    Those are converted to a `Pose` here so they can be chained with `::`.
+
+    Everything else (`Pose`, `Frame`, `Closure`, ...) is returned unchanged so their own
+    `@`/`__rmatmul__` handling still applies.
+    """
+    if isinstance(value, Vector3d):
+        return Pose(value.to_tuple())
+    if (
+        isinstance(value, (tuple, list))
+        and len(value) in (3, 6)
+        and all(
+            isinstance(component, (int, float)) and not isinstance(component, bool)
+            for component in value
+        )
+    ):
+        return Pose(tuple(value))
+    return value
+
+
 class MultiplicationOperator(BinaryOperator):
     """Multiplication, division and transformation chaining operator
 
@@ -104,6 +131,12 @@ class MultiplicationOperator(BinaryOperator):
     mul = "*"
     truediv = "/"
     matmul = "::"
+
+    def __call__(self, a: Any, b: Any) -> Any:
+        if self is MultiplicationOperator.matmul:
+            a = _to_pose_operand(a)
+            b = _to_pose_operand(b)
+        return super().__call__(a, b)
 
 
 class ComparisonOperator(BinaryOperator):


### PR DESCRIPTION
Integrates the new API model type DatasetPose into the SDK. Note: This type is not released yet and thus temporarily duplicated in the SDK type.

This PR extends nova.types.Pose to accept additional API model inputs (notably DatasetPose / ConfiguredPose)

Changes:

- Add Pose constructor dispatch (_resolve_pose) plus new Pose.from_* helpers to support API model inputs and preserve kinematic_configuration.
- Update motion factory functions (linear, cartesian_ptp, circular, spline) to convert targets via Pose(...) directly.
- Add new tests covering allowed/forbidden Pose constructor forms and motion target conversion behavior.
- Temporarily add api models as redundant types into sdk
- restricts pose matrix multiplication to pose operand only as constructor is very convenient and mult type can be more explicit