### PR TITLE
feat: wire singularity_handling feature flag through planning API

### DIFF
--- a/nova/cell/motion_group.py
+++ b/nova/cell/motion_group.py
@@ -676,6 +676,7 @@ class MotionGroup(AbstractRobot):
         tcp: str | None,
         motion_group_setup: api.models.MotionGroupSetup,
         start_joint_position: tuple[float, ...],
+        singularity_handling: api.models.SingularityHandling | None = None,
     ) -> api.models.JointTrajectory:
         """
         This method plans a trajectory and checks for collisions.
@@ -729,6 +730,8 @@ class MotionGroup(AbstractRobot):
                 motion_group_setup=motion_group_setup,
                 start_joint_position=api.models.DoubleArray(list(start_joint_position)),
                 motion_commands=motion_commands,
+                singularity_handling=singularity_handling
+                or api.models.SingularityHandling.NONE,
             ),
         )
 
@@ -851,6 +854,7 @@ class MotionGroup(AbstractRobot):
         start_joint_position: tuple[float, ...] | None = None,
         motion_group_setup: api.models.MotionGroupSetup | None = None,
         payload_override: str | api.models.Payload | None = None,
+        singularity_handling: api.models.SingularityHandling | None = None,
     ) -> api.models.JointTrajectory:
         if not actions:
             raise ValueError("No actions provided")
@@ -905,6 +909,7 @@ class MotionGroup(AbstractRobot):
                     tcp=tcp,
                     start_joint_position=current_joints,
                     motion_group_setup=motion_group_setup,
+                    singularity_handling=singularity_handling,
                 )
                 all_trajectories.append(trajectory)
                 # the last joint position of this trajectory is the starting point for the next one

--- a/nova/cell/motion_group.py
+++ b/nova/cell/motion_group.py
@@ -730,8 +730,7 @@ class MotionGroup(AbstractRobot):
                 motion_group_setup=motion_group_setup,
                 start_joint_position=api.models.DoubleArray(list(start_joint_position)),
                 motion_commands=motion_commands,
-                singularity_handling=singularity_handling
-                or api.models.SingularityHandling.NONE,
+                singularity_handling=singularity_handling or api.models.SingularityHandling.NONE,
             ),
         )
 

--- a/nova/cell/robot_cell.py
+++ b/nova/cell/robot_cell.py
@@ -464,6 +464,9 @@ class AbstractRobot(Device):
             pause_on_io (PauseOnIO | None): The pause on IO. If none, does not pause on IO. Defaults to None.
             payload_override (str | api.models.Payload | None): Override for the dynamics payload
                 used by the planner. See :meth:`plan` for resolution rules and caveats.
+            singularity_handling (api.models.SingularityHandling | None): Strategy for handling
+                wrist singularities along a cartesian path. If None, the API default (NONE) is
+                used. Experimental.
         """
         actions_list = _normalize_actions(actions)
 
@@ -512,6 +515,9 @@ class AbstractRobot(Device):
             pause_on_io (PauseOnIO | None): The pause on IO. If none, does not pause on IO. Defaults to None.
             payload_override (str | api.models.Payload | None): Override for the dynamics payload
                 used by the planner. See :meth:`plan` for resolution rules and caveats.
+            singularity_handling (api.models.SingularityHandling | None): Strategy for handling
+                wrist singularities along a cartesian path. If None, the API default (NONE) is
+                used. Experimental.
 
         Raises:
             NoInverseKinematicsSolutionFound: When inverse kinematics cannot find a solution for a target

--- a/nova/cell/robot_cell.py
+++ b/nova/cell/robot_cell.py
@@ -234,6 +234,7 @@ class AbstractRobot(Device):
         start_joint_position: tuple[float, ...] | None = None,
         motion_group_setup: api.models.MotionGroupSetup | None = None,
         payload_override: str | api.models.Payload | None = None,
+        singularity_handling: api.models.SingularityHandling | None = None,
     ) -> api.models.JointTrajectory:
         """Plan a trajectory for the given actions
 
@@ -245,6 +246,8 @@ class AbstractRobot(Device):
                 position of the robot is used.
             payload_override (str | api.models.Payload | None): Override for the dynamics payload used by the planner.
                 Only use this when you are certain the physical controller is configured with the same payload.
+            singularity_handling (api.models.SingularityHandling | None): Strategy for handling wrist singularities
+                along a cartesian path. If None, the API default (NONE) is used. Experimental.
 
         Returns:
             api.models.JointTrajectory: The planned joint trajectory
@@ -257,6 +260,7 @@ class AbstractRobot(Device):
         start_joint_position: tuple[float, ...] | None = None,
         motion_group_setup: api.models.MotionGroupSetup | None = None,
         payload_override: str | api.models.Payload | None = None,
+        singularity_handling: api.models.SingularityHandling | None = None,
     ) -> api.models.JointTrajectory:
         """Plan a trajectory for the given actions.
 
@@ -279,6 +283,10 @@ class AbstractRobot(Device):
                    configured with the same payload. In most cases the automatic resolution
                    is correct and should be preferred.
 
+            singularity_handling (api.models.SingularityHandling | None): Strategy for handling
+                wrist singularities along a cartesian path. If None, the API default (NONE) is
+                used. Experimental.
+
         Returns:
             api.models.JointTrajectory: The planned joint trajectory
 
@@ -298,6 +306,7 @@ class AbstractRobot(Device):
                 start_joint_position=start_joint_position,
                 motion_group_setup=motion_group_setup,
                 payload_override=payload_override,
+                singularity_handling=singularity_handling,
             )
 
             # Automatic viewer integration - log planning results if viewers are active
@@ -442,6 +451,7 @@ class AbstractRobot(Device):
         start_on_io: api.models.StartOnIO | None = None,
         pause_on_io: api.models.PauseOnIO | None = None,
         payload_override: str | api.models.Payload | None = None,
+        singularity_handling: api.models.SingularityHandling | None = None,
     ) -> AsyncIterable[MotionState]:
         """Plan and execute a trajectory for the given actions.
 
@@ -466,6 +476,7 @@ class AbstractRobot(Device):
             tcp,
             start_joint_position=start_joint_position,
             payload_override=payload_override,
+            singularity_handling=singularity_handling,
         )
         motion_state_stream = self.stream_execute(
             joint_trajectory,
@@ -488,6 +499,7 @@ class AbstractRobot(Device):
         start_on_io: api.models.StartOnIO | None = None,
         pause_on_io: api.models.PauseOnIO | None = None,
         payload_override: str | api.models.Payload | None = None,
+        singularity_handling: api.models.SingularityHandling | None = None,
     ) -> None:
         """Plan and execute a trajectory for the given actions.
 
@@ -516,6 +528,7 @@ class AbstractRobot(Device):
             tcp,
             start_joint_position=start_joint_position,
             payload_override=payload_override,
+            singularity_handling=singularity_handling,
         )
         await self.execute(
             joint_trajectory,

--- a/nova/cell/simulation.py
+++ b/nova/cell/simulation.py
@@ -152,6 +152,7 @@ class SimulatedRobot(ConfigurablePeriphery, AbstractRobot):
         start_joint_position: tuple[float, ...] | None = None,
         motion_group_setup: api.models.MotionGroupSetup | None = None,
         payload_override: str | api.models.Payload | None = None,
+        singularity_handling: api.models.SingularityHandling | None = None,
     ) -> api.models.JointTrajectory:
         """
         A simple example planner that:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,26 @@ ws = "wandelscript.cli:app"
 dev-wheel = "nova.helper_scripts.trigger_dev_wheel:main"
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 [dependency-groups]
 dev = [
     "ruff>=0.12.8",
@@ -129,14 +149,7 @@ markers = """
 python-version = "3.11"
 
 [tool.ty.src]
-include = [
-    "nova",
-    "examples",
-    "tests",
-    "wandelscript",
-    "novax",
-    "nova_rerun_bridge",
-]
+include = ["nova", "examples", "tests", "wandelscript", "novax", "nova_rerun_bridge"]
 exclude = [
     "wandelscript/grammar",
     "wandelscript/motions.py",
@@ -190,6 +203,25 @@ missing-argument = "ignore"
 
 [tool.ruff.lint.isort]
 known-first-party = ["nova", "nova_rerun_bridge", "novax"]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.11, <3.13"
 readme = "README.md"
 dependencies = [
     "httpx>=0.28.0,<0.29",
-    "wandelbots_api_client==26.5.0",
+    "wandelbots_api_client==26.5.3",
     "websockets>=14.1.0,<15",
     "loguru>=0.7.2,<0.8",
     "pydantic>=2.11.4,<3",
@@ -74,26 +74,6 @@ ws = "wandelscript.cli:app"
 dev-wheel = "nova.helper_scripts.trigger_dev_wheel:main"
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 [dependency-groups]
 dev = [
     "ruff>=0.12.8",
@@ -149,7 +129,14 @@ markers = """
 python-version = "3.11"
 
 [tool.ty.src]
-include = ["nova", "examples", "tests", "wandelscript", "novax", "nova_rerun_bridge"]
+include = [
+    "nova",
+    "examples",
+    "tests",
+    "wandelscript",
+    "novax",
+    "nova_rerun_bridge",
+]
 exclude = [
     "wandelscript/grammar",
     "wandelscript/motions.py",
@@ -203,25 +190,6 @@ missing-argument = "ignore"
 
 [tool.ruff.lint.isort]
 known-first-party = ["nova", "nova_rerun_bridge", "novax"]
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -1867,7 +1867,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/91/26/430de0d8aaf5aad9f
 
 [[package]]
 name = "wandelbots-api-client"
-version = "26.5.0"
+version = "26.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1882,9 +1882,9 @@ dependencies = [
     { name = "urllib3" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/db/9ee2b8464eea12442121e68920c3f287a401e36f3a8c60fbc5293d1a8c23/wandelbots_api_client-26.5.0.tar.gz", hash = "sha256:84541ef2670d50bc0ff234d61915d5484afdb32bc752b4781e3f516c43336346", size = 648166, upload-time = "2026-06-18T11:36:08.906Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/82/10ff7b05702425f6e64fb2b37aa44cd811c435e6bc9c21810ca2938834b7/wandelbots_api_client-26.5.3.tar.gz", hash = "sha256:87545f99f454589f0b874f02a9e360fbe99aea69597871cded48ed5c0f44e5cf", size = 648848, upload-time = "2026-08-04T13:01:55.256Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/e0/d99c836c94dac05242e8fb5bdf6cecbda04a28de1f8cd828d672b08729e7/wandelbots_api_client-26.5.0-py3-none-any.whl", hash = "sha256:e699e255092402870a7330f2cbd4d28634f6fa930455b761f7f49696598b43ac", size = 1549405, upload-time = "2026-06-18T11:36:16.762Z" },
+    { url = "https://files.pythonhosted.org/packages/02/87/0b8bc2fbac7686892c538bd81433c92d3a0a7e1305e181eff9d123ede1fb/wandelbots_api_client-26.5.3-py3-none-any.whl", hash = "sha256:20715d872ea9ca76bfa4a7b9be3ab3cd0568546740b2067b17b18c0794ac5f3b", size = 1550882, upload-time = "2026-08-04T13:01:51.585Z" },
 ]
 
 [[package]]
@@ -2009,7 +2009,7 @@ requires-dist = [
     { name = "trimesh", marker = "extra == 'nova-rerun-bridge'", specifier = ">=4.5.3" },
     { name = "typer", marker = "extra == 'wandelscript'", specifier = ">=0.12,<0.20" },
     { name = "uvicorn", marker = "extra == 'novax'", specifier = ">=0.34.0" },
-    { name = "wandelbots-api-client", specifier = "==26.5.0" },
+    { name = "wandelbots-api-client", specifier = "==26.5.3" },
     { name = "websockets", specifier = ">=14.1.0,<15" },
 ]
 provides-extras = ["nova-rerun-bridge", "wandelscript", "novax", "novapolicy", "benchmark"]


### PR DESCRIPTION
Add optional `singularity_handling` parameter to `plan()`, `plan_and_execute()`, and `stream_plan_and_execute()` methods.

The parameter accepts a `SingularityHandling` enum (`NONE`, `PALLETIZING_WRIST`, `ADAPTIVE_SAMPLING`) and is forwarded to `PlanTrajectoryRequest`.

### Usage

```python
from nova import api

trajectory = await motion_group.plan(
    actions=[...],
    tcp="tcp",
    singularity_handling=api.models.SingularityHandling.ADAPTIVE_SAMPLING,
)
```

### Changes

- `nova/cell/motion_group.py`: Added `singularity_handling` to `_plan_with_collision_check` and `_plan`, wired to `PlanTrajectoryRequest`
- `nova/cell/robot_cell.py`: Added `singularity_handling` to `_plan`, `plan`, `plan_and_execute`, `stream_plan_and_execute`