### PR TITLE
feat(RB-4098): add trajectory cache wrappers to Controller

### DIFF
--- a/nova/cell/controller.py
+++ b/nova/cell/controller.py
@@ -164,3 +164,46 @@ class Controller(Sized, AbstractController, NovaDevice, IODevice):
         await self._nova_api.virtual_controller_api.set_emergency_stop(
             cell=self.configuration.cell_id, controller=self.id, active=active
         )
+
+    async def list_cached_trajectories(self) -> list[str]:
+        """List the ids of all trajectories currently held in this controller's trajectory cache.
+
+        Cached trajectories are removed automatically when the motion group or the
+        controller disconnects.
+
+        Returns:
+            list[str]: The ids of the cached trajectories.
+        """
+        response = await self._nova_api.trajectory_caching_api.list_trajectories(
+            cell=self.configuration.cell_id, controller=self.id
+        )
+        return response.trajectories or []
+
+    async def get_cached_trajectory(self, trajectory_id: str) -> api.models.GetTrajectoryResponse:
+        """Retrieve a cached trajectory together with its motion group and TCP.
+
+        Args:
+            trajectory_id (str): The id of the cached trajectory.
+
+        Returns:
+            api.models.GetTrajectoryResponse: The joint trajectory, its motion group and TCP.
+        """
+        return await self._nova_api.trajectory_caching_api.get_trajectory(
+            cell=self.configuration.cell_id, controller=self.id, trajectory=trajectory_id
+        )
+
+    async def delete_cached_trajectory(self, trajectory_id: str) -> None:
+        """Remove a single trajectory from this controller's trajectory cache.
+
+        Args:
+            trajectory_id (str): The id of the cached trajectory to remove.
+        """
+        await self._nova_api.trajectory_caching_api.delete_trajectory(
+            cell=self.configuration.cell_id, controller=self.id, trajectory=trajectory_id
+        )
+
+    async def clear_trajectory_cache(self) -> None:
+        """Remove all trajectories from this controller's trajectory cache."""
+        await self._nova_api.trajectory_caching_api.clear_trajectories(
+            cell=self.configuration.cell_id, controller=self.id
+        )

--- a/tests/cell/test_trajectory_cache.py
+++ b/tests/cell/test_trajectory_cache.py
@@ -1,0 +1,83 @@
+"""Tests for the trajectory cache wrappers on Controller.
+
+The trajectory caching endpoints are controller scoped
+(`/cells/{cell}/controllers/{controller}/trajectories`), so the wrappers live on
+`Controller` and forward the cell id and controller id from the configuration.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nova.cell.controller import Controller
+from nova.config import NovaConfig
+from nova.core.gateway import ApiGateway
+
+
+@pytest.fixture
+def controller_with_gateway() -> tuple[Controller, MagicMock]:
+    """Create a Controller whose ApiGateway is replaced by a mock."""
+    gateway = MagicMock(spec=ApiGateway)
+    gateway.trajectory_caching_api = MagicMock()
+
+    # NovaDevice._nova_api resolves ApiGateway from nova.core.gateway
+    with patch("nova.core.gateway.ApiGateway", return_value=gateway):
+        controller = Controller(
+            Controller.Configuration(
+                config=NovaConfig(host="http://localhost"), cell_id="cell", controller_id="ur10"
+            )
+        )
+
+    return controller, gateway
+
+
+async def test_list_cached_trajectories(controller_with_gateway):
+    controller, gateway = controller_with_gateway
+    response = MagicMock()
+    response.trajectories = ["t1", "t2"]
+    gateway.trajectory_caching_api.list_trajectories = AsyncMock(return_value=response)
+
+    assert await controller.list_cached_trajectories() == ["t1", "t2"]
+    gateway.trajectory_caching_api.list_trajectories.assert_awaited_once_with(
+        cell="cell", controller="ur10"
+    )
+
+
+async def test_list_cached_trajectories_returns_empty_list_when_none(controller_with_gateway):
+    controller, gateway = controller_with_gateway
+    response = MagicMock()
+    response.trajectories = None
+    gateway.trajectory_caching_api.list_trajectories = AsyncMock(return_value=response)
+
+    assert await controller.list_cached_trajectories() == []
+
+
+async def test_get_cached_trajectory(controller_with_gateway):
+    controller, gateway = controller_with_gateway
+    response = MagicMock()
+    gateway.trajectory_caching_api.get_trajectory = AsyncMock(return_value=response)
+
+    assert await controller.get_cached_trajectory("t1") is response
+    gateway.trajectory_caching_api.get_trajectory.assert_awaited_once_with(
+        cell="cell", controller="ur10", trajectory="t1"
+    )
+
+
+async def test_delete_cached_trajectory(controller_with_gateway):
+    controller, gateway = controller_with_gateway
+    gateway.trajectory_caching_api.delete_trajectory = AsyncMock(return_value=None)
+
+    assert await controller.delete_cached_trajectory("t1") is None
+    gateway.trajectory_caching_api.delete_trajectory.assert_awaited_once_with(
+        cell="cell", controller="ur10", trajectory="t1"
+    )
+
+
+async def test_clear_trajectory_cache(controller_with_gateway):
+    controller, gateway = controller_with_gateway
+    gateway.trajectory_caching_api.clear_trajectories = AsyncMock(return_value=None)
+
+    assert await controller.clear_trajectory_cache() is None
+    gateway.trajectory_caching_api.clear_trajectories.assert_awaited_once_with(
+        cell="cell", controller="ur10"
+    )

--- a/tests/nova/cell/motion_group/test_trajectory_cache_integration.py
+++ b/tests/nova/cell/motion_group/test_trajectory_cache_integration.py
@@ -1,0 +1,76 @@
+"""Integration tests for the trajectory cache wrappers on Controller.
+
+Covers the full round trip: cache a planned trajectory, list it, read it back,
+delete it, and clear the cache.
+"""
+
+from math import pi
+
+import pytest
+
+from nova.actions import jnt
+from nova.api import models
+from nova.cell.controllers import virtual_controller
+from nova.core.nova import Nova
+
+
+@pytest.fixture
+async def ur_controller_and_mg():
+    """Set up a virtual UR controller and yield it together with its motion group."""
+    controller_name = "ur-trajectory-cache-test"
+
+    async with Nova() as nova:
+        cell = nova.cell()
+        await cell.ensure_controller(
+            virtual_controller(
+                name=controller_name,
+                manufacturer=models.Manufacturer.UNIVERSALROBOTS,
+                type="universalrobots-ur10e",
+                position=[0.0, -pi / 2, -pi / 2, 0.0, 0.0, 0.0, 0.0],
+            )
+        )
+
+        ur = await cell.controller(controller_name)
+        async with ur[0] as mg:
+            yield ur, mg
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_trajectory_cache_round_trip(ur_controller_and_mg):
+    controller, mg = ur_controller_and_mg
+    tcp = await mg.active_tcp_name()
+
+    await controller.clear_trajectory_cache()
+    assert await controller.list_cached_trajectories() == []
+
+    joints = await mg.joints()
+    target = (joints[0] + 0.1,) + joints[1:]
+    joint_trajectory = await mg.plan([jnt(target)], tcp)
+    trajectory_id = await mg._load_planned_motion(joint_trajectory, tcp)
+
+    assert trajectory_id in await controller.list_cached_trajectories()
+
+    cached = await controller.get_cached_trajectory(trajectory_id)
+    assert cached.motion_group == mg.id
+    assert cached.tcp == tcp
+
+    await controller.delete_cached_trajectory(trajectory_id)
+    assert trajectory_id not in await controller.list_cached_trajectories()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_clear_trajectory_cache(ur_controller_and_mg):
+    controller, mg = ur_controller_and_mg
+    tcp = await mg.active_tcp_name()
+
+    joints = await mg.joints()
+    target = (joints[0] + 0.1,) + joints[1:]
+    joint_trajectory = await mg.plan([jnt(target)], tcp)
+    await mg._load_planned_motion(joint_trajectory, tcp)
+
+    assert await controller.list_cached_trajectories() != []
+
+    await controller.clear_trajectory_cache()
+    assert await controller.list_cached_trajectories() == []


### PR DESCRIPTION
Closes [RB-4098](https://wandelbots.atlassian.net/browse/RB-4098).

## Problem

The trajectory caching endpoints are controller scoped
(`/cells/{cell}/controllers/{controller}/trajectories`), but the SDK had no public
surface for them. The only consumer was the private `MotionGroup._load_planned_motion`,
so callers wanting to list, inspect, or evict cache entries had to reach into
`ApiGateway.trajectory_caching_api` directly.

## Changes

Four typed wrappers on `Controller`, placed there because that matches the REST
scoping exactly — a `MotionGroup`-level `list`/`clear` would silently affect other
motion groups on the same controller. Follows the existing `get_estop`/`set_estop`
precedent.

| Method | Endpoint |
| --- | --- |
| `list_cached_trajectories() -> list[str]` | `GET .../trajectories` |
| `get_cached_trajectory(id) -> GetTrajectoryResponse` | `GET .../trajectories/{id}` |
| `delete_cached_trajectory(id) -> None` | `DELETE .../trajectories/{id}` |
| `clear_trajectory_cache() -> None` | `DELETE .../trajectories` |

Notes:

- `list_cached_trajectories` unwraps `ListTrajectoriesResponse.trajectories: list[str] | None`
  to `list[str]`, mirroring how `get_estop()` unwraps `flag.active` to `bool`. It is the
  only field on the response, so nothing is lost.
- `get_cached_trajectory` returns the response model as-is — it carries three distinct
  fields (`motion_group`, `trajectory`, `tcp`) and unwrapping would lose information.
- Errors propagate unchanged (`ApiException`, 404 on unknown id). No swallowing;
  best-effort behavior is a caller policy, and no other `Controller` wrapper swallows.

`clear_trajectory_cache` is included beyond the ticket's literal three missing endpoints:
without it, the downstream `CursorManager.clear_trajectory_cache` refactor called for in
requirement 2 would still have to reach into `_nova_api.trajectory_caching_api`.

No changes to existing behavior. `ApiGateway` already exposes `trajectory_caching_api`
typed, so it is untouched.

## Tests

- `tests/cell/test_trajectory_cache.py` — 5 unit tests with a mocked `ApiGateway`,
  asserting argument plumbing and the `None` to `[]` unwrap.
- `tests/nova/cell/motion_group/test_trajectory_cache_integration.py` — 2 integration
  tests doing the full round trip against a virtual UR controller: cache a planned
  trajectory, list it, read it back (checking `motion_group` and `tcp`), delete it,
  and clear the cache.

## Verification

`ruff format --check`, `ruff check`, `ruff check --select I`, and `ty check` all pass.

`pytest -m "not integration" tests/cell nova/cell/controller.py` — 193 passed.

Caveat: the **full** non-integration suite was not run locally (it exceeded my timeout);
relying on CI for that. Integration tests were verified to collect but need a running
NOVA instance, so they run in CI via `nova-run-examples.yaml`.

[RB-4098]: https://wandelbots.atlassian.net/browse/RB-4098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ