### PR TITLE
feat(cursor): carry IO overlay on every start, fix false-success completion

### DIFF
--- a/docs/architecture/incoming/move-forward-to-cursor.md
+++ b/docs/architecture/incoming/move-forward-to-cursor.md
@@ -183,7 +183,7 @@ Measured against `main` @ `3e9e513`, with `detach_on_standstill=True`, a cursor 
 ```python
 await self._intent_event.wait()
 if self._stop_event.is_set():
-    break                     # ← a pending intent is thrown away here
+    break  # ← a pending intent is thrown away here
 intent = self._pending_intent
 ```
 

--- a/docs/architecture/incoming/move-forward-to-cursor.md
+++ b/docs/architecture/incoming/move-forward-to-cursor.md
@@ -371,7 +371,9 @@ the overlay layer is the missing piece between the two.
 
 Each phase is independently landable and independently verifiable.
 
-> **Status: Phases A and B are implemented** on `agents/merge-move-forward-into-cursor`
+> **Status: Phases A and B are implemented** in
+> [PR #472](https://github.com/wandelbotsgmbh/wandelbots-nova/pull/472), branch
+> `feat/trajectory-cursor-io-overlay-parity`
 > (`nova/cell/movement_controller/trajectory_cursor.py`, plus
 > `tests/cell/test_trajectory_cursor_parity.py` and one new integration test).
 > Verified: 363 unit tests and 14 integration tests green against a live cell, `ruff` and

--- a/docs/architecture/incoming/move-forward-to-cursor.md
+++ b/docs/architecture/incoming/move-forward-to-cursor.md
@@ -1,0 +1,622 @@
+# `move_forward` → `TrajectoryCursor` — transition plan
+
+Status: **Phases A and B implemented; C–E open.** This document argues that the two
+movement controllers should become **one** implementation, and sequences the transition.
+
+It is a companion to the `command-routine.md` analysis (an unpublished working document on
+the incoming NOVA CommandRoutine format), which flagged the missing `set_outputs` on the
+cursor as a P0 blocker; references to its sections are kept for whoever holds that draft.
+This document stands on its own for everything needed to continue the work here.
+
+Date: 2026-08-04 (implementation notes added 2026-08-05)
+SDK baseline analysed: `main` @ `3e9e513`
+Branches analysed: `feat/NDX-155-simple-custom-actions` @ `8112b15`,
+`feat/path-triggers-distance-offset` @ `5560279`, `feat/motion-guards` @ `878be25`,
+`fix/trajectory-completion-standstill-watchdog` @ `9e7e4f4`
+
+---
+
+## 0. Why now — the protocol loop has forked five ways
+
+`move_forward` and `TrajectoryCursor.cntrl` are both async generators implementing the
+*same* `executeTrajectory` websocket protocol: initialize → start state monitor →
+`StartMovementRequest` → consume responses → terminate on standstill. Every feature that
+needs to *interrupt* that loop has forked it rather than shared it:
+
+| Where | Shape | What it added |
+|---|---|---|
+| `main` `move_forward.py` (172 ln) | linear generator | baseline: init, one Start, monitor, error consumer |
+| `main` `trajectory_cursor.py` (1314 ln) | intent slot + command loop | forward/backward/pause/target, playback speed, events |
+| `feat/path-triggers-distance-offset` `move_forward.py` (~260 ln) | **+ command queue, + response consumer, + pause/resume callbacks** | async actions; re-invents the cursor's `_request_loop` and `_response_consumer` |
+| `feat/motion-guards` `guarded_move_forward.py` (385 ln) | third copy | guard evaluation + stop/resume |
+| `fix/trajectory-completion-standstill-watchdog` `move_forward.py` (+82 ln) + `stall_watchdog.py` (273 ln) | fourth copy | completes trajectories when the terminal event is dropped — **applied to `move_forward` only; the cursor still has the bug** |
+
+Two observations make the merge urgent rather than merely tidy:
+
+1. **`feat/path-triggers-distance-offset` rewrote `move_forward` into a worse cursor.** It
+   adds an `asyncio.Queue` of commands, a `PauseMovementRequest`/`StartMovementRequest`
+   pair driven by executor callbacks, and a response consumer that tolerates pause acks.
+   That is structurally `Intent` + `_request_loop` + `_response_consumer` — minus the
+   operation futures, the state-transition safety, and the tests.
+2. **Bug fixes are already diverging.** The stall watchdog fixes a real
+   dropped-terminal-event hang. Part of that fix lands in the shared
+   `trajectory_state_machine.py` (+25 ln) and so would benefit both, but the watchdog
+   wiring itself is in `move_forward` (+82 ln) and `stall_watchdog.py`. The cursor runs
+   the same `async for motion_group_state in …` loop with the same dependency on the FSM
+   reaching a terminal state, and stays exposed.
+
+The claim in the task is exact: **`cursor.forward()` from location 0 with no target *is*
+`move_forward`.** Everything else the cursor offers is a superset.
+
+---
+
+## 1. The equivalence, wire message by wire message
+
+| Step | `move_forward` (main) | `TrajectoryCursor` |
+|---|---|---|
+| Init | `InitializeMovementRequest(trajectory, Location(0))`, `move_forward.py:64-67` | `init_movement_gen(motion_id, stream, self._current_location)`, `:1282-1306` — identical, parameterised location |
+| Init failure | raises `InitMovementFailed`, `:86` | raises `InitMovementFailed`, `:1314` — identical |
+| Monitor ordering | monitor started **before** Start, 5 s ready timeout, `:91-104` | monitor started before `_request_loop`, 5 s ready timeout, `:1020-1032` — identical intent |
+| Start | `StartMovementRequest(FORWARD, set_outputs, start_on_io, pause_on_io)`, `:107-112` | `Intent.to_commands()` → `StartMovementRequest(direction, target_location, start_on_io, pause_on_io)`, `:403-414` — **no `set_outputs`** |
+| State handling | `TrajectoryExecutionMachine`, `:44` | `TrajectoryExecutionMachine`, `:1109` — same FSM |
+| Completion | returns when `machine.is_ended`, `:46-50` | `_complete_operation()` on `is_ended`/`is_paused`; loop exits only if `detach_on_standstill`, `:1122-1126` |
+| Movement error | `ErrorDuringMovement`, `:152` | bare `Exception` inside a `TaskGroup` → surfaces as `BaseExceptionGroup`, `:1167` |
+| Termination | generator returns → websocket closes | `detach()` → `_stop_event` → `_request_loop` breaks → `cntrl` returns |
+| Motion events | none | `motion_started` blinker signal + `MotionEvent`, 5 Hz ticker |
+
+Everything in the left column exists in the right column, or is a small enumerable delta.
+
+---
+
+## 2. Delta list — what must change before the cursor is a drop-in
+
+| # | Delta | Anchor | Priority |
+|---|---|---|---|
+| D1 | `Intent` carries no `set_outputs`; a routine's `io_write`s are silently dropped under the cursor | `trajectory_cursor.py:369-415` | **P0** |
+| D2 | Movement errors surface as `BaseExceptionGroup`, not `ErrorDuringMovement` | `trajectory_cursor.py:1165-1169`, `:1040-1042` | **P0** |
+| D3 | No auto-start: the cursor requires an explicit `forward()` after `cntrl` is wired up | new `autostart` ctor arg | **P0** |
+| D4 | Ctor takes a live `AsyncIterator`; `MovementControllerContext` supplies a *factory* (`motion_group_state_stream_gen`) | `trajectory_cursor.py:495`, `container.py:167` | **P0** (trivial) |
+| D5 | With `detach_on_standstill=False` the monitor never exits on an infinite state stream → the websocket stays open forever | `trajectory_cursor.py:1122-1126` | **P0** for parity |
+| D6 | `_motion_event_updater` ticks at 5 Hz unconditionally; every `execute()` would start emitting blinker/NATS traffic | `trajectory_cursor.py:1194-1214` | P1 |
+| D7 | State monitor `continue`s while no operation is in progress, so states arriving before the first `forward()` are dropped — and a fast/finite stream can exhaust and `detach()` before autostart ever sets its intent | `trajectory_cursor.py:1104-1107`, `:1131-1135` | **P0** (raised from P1 — see D12) |
+| D8 | Stall watchdog / dropped-terminal-event fix exists only on `move_forward` | `fix/trajectory-completion-standstill-watchdog` | P1 |
+| D9 | `actions=None` location-only mode must keep working; `_raw_actions` (non-motion actions) must become addressable | `trajectory_cursor.py:524-534` | P1 |
+| D10 | The cursor is unreachable from `MotionGroup.execute()` — only tests build an adapter factory | `test_trajectory_cursor_integration.py:177-200` | P1 |
+| D11 | The cursor requires `joint_trajectory`; `MovementControllerContext` has no such field, and the existing `move_forward` tests construct the context without one | `trajectory_cursor.py:496`, `container.py:162-167` | **P0** |
+| D12 | **`_request_loop` discards a pending intent on stop.** It checks `_stop_event` before consuming `_pending_intent`, so an intent queued before a detach is dropped and the command never goes out. **Measured** — see below. *Resolution: dropping is the correct, safe behaviour; the actual defect is D16, which reported the dropped movement as a success.* | `trajectory_cursor.py:1047-1062` | **P0** |
+| D16 | **The cursor reports success for movement it never commanded.** Operation completion is driven purely by the state stream, with no correlation to whether a `StartMovementRequest` was sent or acked. **Measured**: `await cursor.forward()` returned `OperationResult(final_location=3.0, error=None)` having emitted only an `InitializeMovementRequest` | `trajectory_cursor.py:1104-1126` | **P0** |
+| D13 | **`actions=[]` is a supported execution path and the cursor rejects it.** An empty list is not `None`, so the ctor's end-location check demands a trajectory ending at `0.0` and raises `ValueError`. `execute(joint_trajectory=…, actions=[], tcp=…)` for a preplanned trajectory is exercised today | `trajectory_cursor.py:524-544`, `test_motion_group_movement.py:77` | **P0** |
+| D14 | **`_in_queue` fills with nobody draining it in adapter mode.** The monitor enqueues every execute-bearing state for `__aiter__`, but `MotionGroup._execute` keeps its own `stream_state()` subscription and never iterates the cursor. Reframed by §3: the queue is the overlay layer's input, so the fix is a bounded/faithful tee, not a switch | `trajectory_cursor.py:548-550`, `:1114-1117`, `motion_group.py:1006-1031` | P1 |
+| D15 | **Stream-lifecycle semantics differ, beyond exception type (D2).** `move_forward` treats a state-monitor task that finished *for any reason* as success — `if state_monitor in done: return` never inspects the task result, so a state-stream exception is swallowed. The cursor's `TaskGroup` propagates it. Response-stream EOF, state-stream EOF without a terminal state, and a missing `StartMovementResponse` ack are each handled differently by the two implementations | `move_forward.py:126-152`, `trajectory_cursor.py:1148-1189` | **P0** |
+
+D1–D5, D11–D16 are the drop-in blockers; D6–D10 are quality-of-transition. D12 and D16 are
+pre-existing cursor defects that the autostart work merely *surfaced* — see below.
+
+### D1 in detail — `set_outputs` re-send under override semantics
+
+**Confirmed on hardware** (virtual KUKA `kuka-kr6_r700_sixx`, NOVA @ `172.31.10.174`,
+2026-08-05). Both properties were measured, not assumed:
+
+| Experiment | Result |
+|---|---|
+| Start with `[A@1.0]`, pause before 1.0, resume with `[B@2.0]`, run to end | `A=False`, `B=True` → **the second Start replaced the first list; A never fired** |
+| Start with `target_location=1.0` + `[A@1.0]` (stops exactly on the overlay), reset A externally, resume from 1.0 with `[A@1.0]` | `A=True` → **re-fires at the boundary** |
+
+So: **a new `StartMovementRequest` overrides the previously attached overlay**, and an output
+at *exactly* the resume location does fire again. The released client's field doc is
+consistent with both:
+
+> `set_outputs`: Attaches a list of output commands to the trajectory. The outputs are set
+> to the specified values right after the specified location was reached. **If the
+> specified location is located before the start location (forward direction: value is
+> smaller, backward direction: value is bigger), the output is not set.**
+
+Three consequences, and they are what actually shape the implementation:
+
+1. **Every `StartMovementRequest` must carry the full list — always.** Under override
+   semantics a resume that omits `set_outputs` does not "keep the existing overlay", it
+   **silently clears it** for the rest of the trajectory. Measured above: `A` was dropped by
+   a resume that simply did not re-send it. This makes `set_outputs` a **constructor-level
+   default on the cursor**, applied automatically to every emitted Start, rather than a
+   per-call argument — a per-call argument is a footgun where the first resume that forgets
+   it disables all remaining IO.
+   - Concrete casualty for §5.4: `feat/path-triggers-distance-offset`'s resume sends a bare
+     `StartMovementRequest(direction=DIRECTION_FORWARD)`. That branch therefore **drops every
+     remaining IO write on the first blocking async action.** This is now a measured defect,
+     not a suspicion, and another reason not to port its `move_forward` rewrite.
+2. **Re-triggering at the boundary is accepted, not worked around.** No client-side "already
+   fired" bookkeeping. It is the natural consequence of override semantics.
+   - Caveat to document for users rather than engineer around: harmless for level-triggered
+     outputs, **not** harmless for anything edge-sensitive downstream (e.g. a PLC counting
+     pulses). Worth one line in the `io_write` docstring.
+3. `command-routine.md` Q5 is answered for `set_io`: outputs re-fire on backward travel
+   through the same location, and the server — not the SDK — owns the rule.
+
+This also pins an ordering constraint that the path-triggers branch introduced:
+`to_set_io(trigger_overrides)` must be evaluated **after** planning (time triggers need the
+planned time profile), so `set_outputs` reaches the cursor as constructor data computed by
+`MotionGroup._execute` — not as something the cursor derives itself. Which is exactly the
+layering rule of §3.
+
+### D2 in detail
+
+`_response_consumer` raising inside `asyncio.TaskGroup` converts any error into a
+`BaseExceptionGroup`, which `cntrl` re-raises as-is. `move_forward` callers catch
+`ErrorDuringMovement`. Fix: raise `ErrorDuringMovement` from the consumer, and unwrap
+single-exception groups at the `cntrl` boundary so the caller-visible type is unchanged.
+
+### D11 in detail — do not make `joint_trajectory` required
+
+`tests/cell/test_process_motion_group_state.py:67-76` builds a `MovementControllerContext`
+with only `combined_actions`, `motion_id`, `start_on_io` and the state-stream factory.
+Adding a **required** `joint_trajectory` to the context breaks those tests at construction
+— which would forfeit the Phase C gate (§4) before it is even run.
+
+The cursor uses `joint_trajectory` in exactly three places: the ctor's end-location
+sanity check (`:536-544`), the `end_location` property (`:570-573`), and the
+`forward_to_next_action` upper bound (`:853`). None of them is on the path of a one-shot
+autostart run with no `target_location`. So:
+
+- `MovementControllerContext.joint_trajectory` is **optional** (`| None = None`);
+- `TrajectoryCursor` accepts `joint_trajectory=None` and raises a clear error only if a
+  location-bounded operation (`forward_to`, `forward_to_next_action`,
+  `get_movement_options`) is attempted without it.
+
+That keeps both the existing unit tests and the plug-in seam untouched.
+
+### D12, D16 and D15 in detail — autostart surfaced two real cursor defects
+
+Trying to place `autostart` raised the question of whether it belongs *in* the cursor or in
+the adapter. Probing it produced a sharper answer than expected: **autostart is fine in the
+adapter; the cursor has two pre-existing bugs that autostart merely exposed.**
+
+Measured against `main` @ `3e9e513`, with `detach_on_standstill=True`, a cursor whose
+`forward()` is called before `cntrl` — i.e. the adapter shape:
+
+| State stream | Requests emitted |
+|---|---|
+| paced, then blocks (live websocket) | `InitializeMovementRequest`, `StartMovementRequest` ✅ |
+| finite, then EOF (existing unit-test fixtures) | `InitializeMovementRequest` only ❌ |
+
+**D12 — the intent is discarded on stop.** `_request_loop` (`:1047-1062`) does:
+
+```python
+await self._intent_event.wait()
+if self._stop_event.is_set():
+    break                     # ← a pending intent is thrown away here
+intent = self._pending_intent
+```
+
+The monitor's `finally: self.detach()` (`:1131-1135`) sets both `_stop_event` and
+`_intent_event`. If the state stream ends before `_request_loop` gets its first turn, the
+already-queued `forward()` is dropped and no `StartMovementRequest` is ever sent.
+
+**Resolution — dropping the intent is correct; do not "fix" it.** Flushing the pending
+intent instead was implemented, measured, and **reverted**: it means an explicit
+`cursor.forward(); cursor.detach()` cancels the caller's future *and then still commands the
+robot to move*. Verified on the implementation branch — `future.cancelled() == True` while a
+`StartMovementRequest` reached the wire. A stop must always win over a queued command; on the
+teardown path there is also nothing left to monitor the movement. The genuine defect behind
+the original symptom is D16.
+
+**D16 — the cursor then reports that it succeeded.** In the same scenario,
+`await cursor.forward()` resolved to
+`OperationResult(operation_type=FORWARD, final_location=3.0, error=None)` and
+`cursor._current_location` advanced to `3.0` — the end of the trajectory — with only an
+`InitializeMovementRequest` on the wire and no `StartMovementResponse` ever received. The
+operation lifecycle is driven entirely by the state stream (`:1104-1126`) with no
+correlation to whether the command was sent, so **the cursor can report a completed
+traversal for movement it never commanded.** A caller that awaits `forward()` and then
+advances its program would do so with the robot still at the start.
+
+This is exactly the failure mode D15 describes from the other side: `move_forward` at least
+requires a `StartMovementResponse` before it accepts completion (`move_forward.py:116-121`).
+The cursor did not.
+
+**Resolution — split the concern along the user's own rule:**
+
+- The **fix goes inside the cursor** (P0, benefits every existing cursor user, nothing to do
+  with `move_forward`): gate operation completion on the operation having actually been
+  commanded, and fail — rather than silently abandon — an operation whose state stream ends
+  first. A dropped intent then surfaces as `ErrorDuringMovement` instead of a phantom
+  success.
+- The **autostart *policy* stays in the adapter.** No `autostart` constructor flag: the
+  adapter calls `cursor.forward()` before returning `cursor.cntrl`. "Start immediately" is a
+  `move_forward` policy, not a cursor capability, and keeping it out preserves §3's layering.
+
+D7 remains a genuine but lesser issue: the monitor's `if current_op is None: continue`
+(`:1104-1107`) skips the state tee and the location update, not just completion handling.
+The fix is to always process and tee, and gate only `set_running()` / `_complete_operation()`
+on having an operation — note that this interacts with the FSM kick at `:1096-1102`, which
+needs re-examination at the same time.
+
+---
+
+## 3. Target architecture — three layers, not one class
+
+The question "should IO, markers and events live in the cursor?" is the right one to ask
+before any of this lands. Today the cursor already carries motion events, `start_on_io` /
+`pause_on_io` pass-through, a `_raw_actions` field it does not use, and — under D1 — would
+gain `set_outputs`. The branches queue up async actions, guards and markers behind that.
+That is a god object forming in slow motion, and 1314 lines is already past comfortable.
+
+**Answer: separate them — but along the seam that the transport actually dictates, which is
+not "motion vs. non-motion".** There are two kinds of overlay and they belong in different
+places:
+
+| | **Server-side overlay** | **Client-side overlay** |
+|---|---|---|
+| Examples | `set_outputs`, `start_on_io`, `pause_on_io`, `distance_offset` triggers | markers, async actions, guards, motion events |
+| Mechanism | *fields on `StartMovementRequest`* | *reactions to location changes* + commands back |
+| Executed by | the controller, at the resolved location | the SDK, at whatever rate states arrive |
+| Precision | exact | best-effort, bounded by state rate |
+| Can it live outside the cursor? | **No** — it has to be in the message | **Yes** — needs only a location stream and pause/forward |
+
+Server-side overlays *must* travel with the request, so the cursor has to carry them. But it
+should carry them as **opaque payload**: a pre-built `list[SetIO]` it attaches to every Start
+and never interprets. The rule that keeps this honest is an import rule —
+
+> **The cursor must not import `WriteAction`, `to_set_io()`, path triggers, or any overlay
+> concept.** It accepts already-resolved API models. Today it imports `CombinedActions`
+> (`trajectory_cursor.py:59`) to compute `.motions`; that is the existing smell, and the
+> direction of travel is to remove it, not to add more.
+
+Client-side overlays need exactly two things, and the cursor **already exposes both**:
+
+- a location/state stream — `__aiter__` / `_in_queue` (`:1265-1279`)
+- movement control — `forward()` / `pause()` returning awaitable futures
+
+So they belong in a layer *above* the cursor that drives it through its public API:
+
+```
+TrajectoryCursor        protocol + location + movement commands.
+                        Carries opaque server-side overlay payloads.
+                        Knows nothing about IO, markers, actions-as-events.
+
+TrajectoryOverlay       consumes the cursor's state stream, fires client-side
+  (new, Phase D)        overlays, drives cursor.pause()/forward().
+                        Owns markers, async actions, guards, MotionEvent emission.
+
+move_forward(context)   adapter: builds a cursor (+ an overlay only if needed).
+```
+
+Three things fall out of this that are worth more than the tidiness:
+
+1. **The latency objection answers itself.** Routing an overlay through a layer boundary
+   costs a queue hop. But anything needing *precise* placement is already server-side for
+   exactly that reason (that is why `distance_offset` exists). Client-side overlays are
+   inherently best-effort at state-stream rate, so the extra hop is noise. The layer boundary
+   is free precisely where it is allowed to exist.
+2. **D14 is reframed rather than fixed by a flag.** `_in_queue` is not dead weight to be
+   switched off — it is the overlay layer's input. It is only unused in the bare
+   `move_forward` case, where the adapter creates no overlay, and there it needs a bound
+   rather than a kill switch. It also has to become a *faithful* tee: today it only receives
+   states with `execute` set, and only once an operation is running (D7), which is not good
+   enough for a guard that must veto *before* movement starts.
+3. **D9 dissolves.** Making `_raw_actions` addressable stops being a cursor feature; the
+   overlay layer owns non-motion actions, and the cursor's `_raw_actions` field can
+   eventually be deleted rather than grown.
+
+This also lines up with `command-routine.md` §4.1: `compile_routine()` produces actions plus
+overlay commands; the actions go to `plan()` and then the cursor, the client-side overlay
+commands go to the overlay layer. Neither layer needs to know about teaching schemas.
+
+**Staging.** Do *not* build the overlay layer in Phases A–C — those are pure unification and
+add no overlay logic. It becomes the shape of Phase D, replacing "bolt the branch features
+onto the cursor". In the meantime the rule stands on its own: **no new client-side overlay
+logic goes into `TrajectoryCursor`.** That single rule is what stops `feat/motion-guards`'
+`_check_and_trigger_async_actions` sketch from being merged as-is.
+
+Motion events (D6) are the one awkward case: they are a client-side overlay by this
+definition, but they already exist in the cursor and the tuner depends on them
+(`tuner.py:140-144`). Recommendation: leave them where they are for now, gate them with
+`emit_motion_events`, and move them out with the rest in Phase D — do not let "it is already
+there" become the argument for adding the next one.
+
+### The adapter
+
+```python
+def move_forward(context: MovementControllerContext) -> MovementControllerFunction:
+    actions = list(context.combined_actions.items)
+    cursor = TrajectoryCursor(
+        motion_id=context.motion_id,
+        motion_group_state_stream=context.motion_group_state_stream_gen(),
+        joint_trajectory=context.joint_trajectory,
+        actions=actions or None,  # D13: [] must not mean "zero-length trajectory"
+        set_outputs=context.combined_actions.to_set_io(),  # opaque payload
+        start_on_io=context.start_on_io,
+        pause_on_io=context.pause_on_io,
+        initial_location=0.0,
+        detach_on_standstill=True,
+        emit_motion_events=False,
+    )
+    cursor.forward()  # autostart is adapter policy, not a cursor flag (D12)
+    return cursor.cntrl
+```
+
+`set_outputs`, `start_on_io`, `pause_on_io` (as **constructor defaults** applied to every
+emitted Start — see D1) and `emit_motion_events` are **new constructor parameters** added by
+Phases A and B; none exists today (`trajectory_cursor.py:492-500`). There is no `autostart`
+flag — that is adapter policy — and no `queue_states` flag, since the queue is the overlay
+layer's input and needs a bound rather than an off switch (D14).
+
+The `cursor.forward()` future is deliberately not awaited here. It must still be consumed —
+attach a done-callback that logs, or the adapter will produce "Future exception was never
+retrieved" warnings on failure paths.
+
+The trigger-override argument to `to_set_io()` arrives later, with §5 step 4 — the adapter
+calls the parameterless form until then, so Phase C stays independently landable.
+
+Consequences:
+
+- `MovementController` / `MovementControllerContext` stay the public plug-in seam. No
+  caller of `execute()` / `plan_and_execute()` changes. **That is what makes the transition
+  seamless.**
+- `MovementControllerContext` grows an **optional** `joint_trajectory` — the cursor needs it
+  for `end_location`, `move_forward` never did, and existing tests construct the context
+  without it (D11). It is available at the single production construction site,
+  `motion_group.py:993-1001`.
+- Features stop forking the loop: path triggers become `set_outputs` payload, async actions
+  and guards become overlay-layer consumers of the cursor's public API, the stall watchdog
+  gets fixed once.
+
+**Not proposed:** deleting `move_forward`. Keeping it as the default controller name is
+what buys a zero-churn transition. `command-routine.md` §4.2's position — the cursor is a
+transport object, teaching-domain compilation stays in `nova/teaching/` — is unaffected, and
+the overlay layer is the missing piece between the two.
+
+---
+
+## 4. Phases
+
+Each phase is independently landable and independently verifiable.
+
+> **Status: Phases A and B are implemented** on `agents/merge-move-forward-into-cursor`
+> (`nova/cell/movement_controller/trajectory_cursor.py`, plus
+> `tests/cell/test_trajectory_cursor_parity.py` and one new integration test).
+> Verified: 363 unit tests and 14 integration tests green against a live cell, `ruff` and
+> `ty` clean. `move_forward` is untouched — Phases C–E remain open.
+
+### Phase A — close the parity deltas in the cursor (D1, D2, D4, D5, D11, D13, D15) — **DONE**
+
+1. `Intent.set_outputs: list[api.models.SetIO] | None`, attached to every
+   `StartMovementRequest` in `to_commands()`. Because a new Start **overrides** the previous
+   overlay (D1), these are **constructor-level defaults** applied automatically to every
+   emitted Start — not per-call arguments that a resume can forget and thereby clear the
+   overlay. Same for `start_on_io` / `pause_on_io`.
+2. `ErrorDuringMovement` from `_response_consumer`; unwrap single-exception
+   `BaseExceptionGroup` at `cntrl`. Then, separately, **decide and document** the
+   state-stream EOF, state-stream exception, response-stream EOF and missing-ack
+   semantics (D15) rather than copying `move_forward`'s accidental behaviour.
+3. Accept `AsyncIterator | Callable[[], AsyncIterator]` for the state stream.
+4. Make `joint_trajectory` optional on the cursor; fail loudly only on location-bounded
+   operations that need it (D11).
+5. Treat `actions=[]` as "no action metadata" rather than "a zero-length trajectory"
+   (D13).
+6. Verify `detach_on_standstill=True` reliably terminates `cntrl`.
+
+*Verify:* unit tests asserting the exact `StartMovementRequest` payload for
+forward/backward/resume; a test that `set_outputs` survives pause→resume; an
+`ErrorDuringMovement` propagation test; a `joint_trajectory=None` / `actions=[]` test.
+Existing cursor tests stay green.
+
+> Phase A alone closes `command-routine.md` §3.1 and is worth landing even if the rest of
+> this plan is rejected.
+
+### Phase B — fix the cursor defects autostart exposed (D3, D6, D7, D14, D16) — **DONE**
+
+This phase is **cursor bug-fixing**, not feature work — the name "one-shot mode" was wrong.
+All of it benefits existing cursor users; none of it is about `move_forward`.
+
+1. **D12** — confirmed that discarding a pending intent on stop is **correct**: a stop must
+   win over a queued command, or an explicit abort is followed by the robot moving. No
+   change; the symptom is addressed by D16.
+2. **D16** — gate operation completion on the operation having been commanded, so
+   `forward()` cannot resolve successfully for movement that was never sent. `move_forward`
+   already requires the `StartMovementResponse` (`move_forward.py:116-121`); the cursor must
+   too. Also fail — rather than silently abandon — an in-progress operation whose state
+   stream ends first, otherwise the gate turns a lost command into a hang.
+3. **D7** — always process and tee incoming states; gate only `set_running()` /
+   `_complete_operation()` on having an operation. This also makes `_in_queue` the faithful
+   tee that §3's overlay layer needs.
+4. **D3/D6** — add `emit_motion_events: bool = True`. **No `autostart` flag** and no
+   `queue_states` flag: starting immediately is adapter policy (§3), and the queue is the
+   overlay layer's input rather than dead weight.
+5. **D14** — bound the state queue (drop-oldest) so a cursor whose iterator is never
+   consumed cannot grow memory for the length of a trajectory.
+
+*Verify:* a queued command must never reach the wire after a stop (`forward()` then
+`detach()` sends nothing and the future is cancelled), and a command that was dropped must
+surface as `ErrorDuringMovement` rather than as a traversal to the end of the trajectory.
+
+**Implementation note (D16).** The completion guard belongs on *"was the command sent"*, not
+*"was it acknowledged"*. Gating on the acknowledgement loses a race against a fast state
+stream — the terminal state can arrive before the ack is processed, wrongly failing a
+legitimate movement. The cursor therefore marks the operation commanded in `_request_loop`
+immediately **before** yielding the request (after the `yield` is too late: a generator
+suspends there until the consumer pulls again). This is applied to `PauseMovementRequest` as
+well as `StartMovementRequest` — a pause is an operation too, and gating it on its ack alone
+left `pause()` unresolved whenever the ack was delayed or lost.
+
+**Implementation note (test fixtures).** Mocked state streams must not run ahead of the
+request loop: a stream that completes instantly tears the cursor down before it has had a
+turn, which is the artefact that originally looked like D12. The parity fixtures emit an
+idle state immediately (a real motion-group stream is always live) and withhold trajectory
+progress until the `StartMovementRequest` has actually been observed.
+
+### Phase C — `move_forward` becomes an adapter (D10)
+
+Rewrite `move_forward` as §3. Add the optional `joint_trajectory` to
+`MovementControllerContext`. Expose the live cursor to callers of `execute()` — proposal: an
+optional `on_cursor: Callable[[TrajectoryCursor], None]` on `MovementControllerContext`,
+which also lets the integration tests drop their hand-rolled adapter factory.
+
+*Verify:* **the existing `move_forward` test files must pass unchanged** —
+`tests/cell/test_process_motion_group_state.py`,
+`tests/nova/cell/motion_group/test_pause_on_io.py`,
+`tests/nova/cell/motion_group/test_motion_group_task_cancelation.py`, plus
+`tests/nova/cell/motion_group/test_motion_group_movement.py` (the `actions=[]` preplanned
+path, D13). Those tests are the behavioural contract; not editing them is the definition of
+"seamless" — with the one documented exception from D15, where `move_forward`'s current
+behaviour is a bug and the harness pins the *chosen* semantics instead. Then the
+integration suite against a live cell.
+
+### Phase D — build the overlay layer, then fold in the branch features once each
+
+This is where `TrajectoryOverlay` (§3) gets built, and where the branch features land *on
+top of* the cursor rather than inside it. See §5 for order. Nothing in this phase touches the
+protocol loop again, and nothing adds client-side overlay logic to `TrajectoryCursor`.
+
+Motion events move out of the cursor here too (D6), with the tuner switched over to the
+overlay layer in the same change.
+
+### Phase E — cleanup
+
+Delete the standalone protocol code, fold `stall_watchdog` into the cursor's monitor, and
+update `nova/cell/movement_controller/README.md` (which currently frames
+`TrajectoryExecutionMachine` as "shared across movement controllers" — after this work
+there is one). `docs/programs.md` does not mention `movement_controller`, so it needs no
+change.
+
+---
+
+## 5. Branch landing order
+
+The four in-flight branches each carry a fork of the loop, so **order is load-bearing**:
+land the merge first, then rebase features onto the single implementation. Doing it the
+other way round means doing the merge four times.
+
+1. **Phase A + B** — no branch dependencies.
+2. **`fix/trajectory-completion-standstill-watchdog`** — rebase `stall_watchdog` onto the
+   cursor's `_motion_group_state_monitor` instead of `move_forward`. Fixes the cursor's
+   identical latent exposure for free. Independent value; no CommandRoutine risk.
+3. **Phase C** — the adapter. Gate: the three unchanged test files above.
+4. **`feat/path-triggers-distance-offset`** — split it. The valuable, self-contained parts
+   are `path_trigger.py`, `path_trigger_resolver.py`, `to_set_io(trigger_overrides)` and
+   `_resolve_set_io_overrides()`; they feed Phase A's `set_outputs` directly and land
+   cleanly. **Drop the branch's `move_forward` rewrite entirely** — it is superseded.
+   `command-routine.md` §3.4 lists this branch as a P0 prerequisite for `at` triggers, so
+   this is the step that unblocks the CommandRoutine work.
+   - Caveat: `path_trigger_api_compat.py` monkey-patches `distance_offset` onto
+     `api.models.SetIO`. Verified against the installed client — `SetIO` has exactly
+     `{io, location, io_origin}` — so the shim is still required. Quarantine it and give it
+     a removal trigger (the client release that ships the field); do not spread it further.
+5. **`feat/NDX-155-simple-custom-actions` async actions** — `AsyncActionExecutor` becomes a
+   `TrajectoryOverlay` participant: its `_pause_callback` / `_resume_callback` collapse into
+   direct `cursor.pause()` / `cursor.forward()` calls from the overlay layer. The executor's
+   whole reason for existing on that branch is that `move_forward` had no pause/resume; the
+   cursor has had it all along, with operation futures to await. Expect the executor to
+   shrink. `feat/motion-guards` sketched this wiring *inside* the cursor
+   (`_check_and_trigger_async_actions`) and left the pause/resume path unconnected — that is
+   the shape §3 rules out; take the trigger logic, not the placement.
+6. **`feat/motion-guards`** — delete `guarded_move_forward.py`; guards become overlay-layer
+   consumers of the cursor's state stream, not cursor internals. Note that guards need states
+   *before* movement starts, which is what the D7 tee fix in Phase B enables.
+
+---
+
+## 6. Decisions
+
+### Decided
+
+- **D1 — `StartMovementRequest` overrides the previously attached overlay. Confirmed on
+  hardware** (§2, D1): a resume that omits `set_outputs` clears it, and an output at exactly
+  the resume location re-fires. Consequently every Start carries the full list, `set_outputs`
+  is a cursor **constructor default** rather than a per-call argument, and boundary re-firing
+  is accepted rather than engineered around.
+- **Layering — client-side overlays live above the cursor, not in it.** Server-side overlays
+  (`set_outputs`, `start_on_io`, `pause_on_io`) travel as opaque payload on the request
+  because they must; markers, async actions, guards and motion events move to a
+  `TrajectoryOverlay` layer that drives the cursor through its public API. §3 has the
+  reasoning and the import rule that enforces it. Built in Phase D; the *rule* applies
+  immediately.
+- **Autostart is adapter policy, not a cursor flag.** The cursor gets no `autostart`
+  parameter; `move_forward` calls `cursor.forward()` before returning `cursor.cntrl`. The
+  cursor bugs this uncovered (D12, D16) are fixed *inside* the cursor, in Phase B.
+- **Keep the name `move_forward`**, indefinitely. It is the default `MovementController`;
+  renaming buys nothing and breaks callers.
+- **`MovementControllerContext` gains an *optional* `joint_trajectory`** rather than moving
+  the adapter into `MotionGroup._execute` — keeps the plug-in seam intact, one line at the
+  single production construction site, and does not break existing test fixtures (D11).
+
+### Still open
+
+1. **Does `execute()` emit motion events by default?** Recommendation: **no**
+   (`emit_motion_events=False` in the adapter). Switching on 5 Hz blinker/NATS emission for
+   every production `execute()` is a behavioural and performance change unrelated to this
+   merge. Tuning and teaching paths opt in.
+2. **Backward travel for client-side overlays.** `set_io` is answered by the server rule
+   (D1). Still open from `command-routine.md` Q5: do async actions re-fire on backward
+   travel? do markers re-emit? Recommendation: **forward-only** in v1, with a warning logged
+   on a backward crossing, until there is a concrete use case. Owner: Phase D.
+3. **~~Confirm the server's `set_outputs` behaviour~~ — DONE.** Override semantics and
+   boundary re-firing both confirmed on hardware 2026-08-05 (§2, D1). No longer open.
+4. **Should `MotionGroup._execute` stop running its own `monitor_motion_group_state()` and
+   iterate the cursor instead** (`async for state in cursor`)? It would collapse two
+   `stream_state()` subscriptions into one. Recommendation: **not in this transition** — it
+   changes which states callers see. Revisit once the Phase B tee fix makes the cursor's
+   stream faithful, since that removes the main objection.
+5. **What does `detach()` mean once `on_cursor` exposes the cursor to callers?** It cancels
+   the operation future and lets `cntrl` return normally (`trajectory_cursor.py:935-948`);
+   it sends no pause or abort, so the robot may still be moving. Cancelling the `execute()`
+   task instead propagates `CancelledError` and relies on websocket closure. Recommendation:
+   document `detach()` as "relinquish control", and if callers need a guaranteed stop, add
+   an explicit abort that pauses first — do not let `detach()` acquire that meaning by
+   accident.
+6. **Ownership and lifecycle between cursor and overlay** (Phase D): if the cursor detaches
+   while the overlay is mid-blocking-action, who cancels what? And the overlay's queue needs
+   a bounded/drop-oldest policy so a slow overlay cannot grow memory without limit.
+
+---
+
+## 7. Test strategy — the equivalence harness
+
+The highest-value artefact of this work is a test that pins the claim:
+
+```
+given the same mocked response stream and the same motion-group state sequence,
+  move_forward(context)                                          and
+  cursor = TrajectoryCursor(...); cursor.forward(); cursor.cntrl
+yield the same sequence of request messages and raise the same exceptions.
+```
+
+`tests/cell/test_process_motion_group_state.py` already builds exactly this fixture shape
+(a `MovementControllerContext` over a fixed state sequence), so the harness is cheap.
+Parameterise it over:
+
+- happy path
+- init failure
+- movement error
+- `pause_on_io`, `start_on_io`
+- cancellation mid-flight
+- **finite/fast state stream** — measured to lose the `StartMovementRequest` on `main`
+  today (D12) and to resolve the operation as a successful full traversal anyway (D16)
+- **`actions=[]`** — the D13 preplanned path
+- **`set_outputs` present on every Start**, including after a pause→resume and on a
+  backward start — the D1 override contract
+- **state-stream EOF without a terminal state**, **state-stream exception**, and
+  **response-stream EOF** — the D15 cases, where the harness pins the *decided* semantics
+  rather than `move_forward`'s current ones
+- dropped terminal event (after step 2 of §5)
+
+Once that harness is green, Phase C is mechanical — and the harness stays in the suite
+afterwards as the regression guard against a sixth fork of the loop.
+
+---
+
+## 8. Risks
+
+| Risk | Mitigation |
+|---|---|
+| The cursor is ~7× the code of `move_forward`; making it the default path widens the blast radius of any cursor bug to every `execute()` | The equivalence harness (§7); land Phase C separately so it can be reverted alone |
+| Three background tasks + a ticker per execution vs. two today | `emit_motion_events=False` removes the ticker; measure before/after on a long trajectory |
+| `_response_consumer`'s ack mis-attribution logic was reasoned about for interactive use, not one-shot runs | Covered by the harness; the one-shot case is strictly simpler (single operation, no stale acks) |
+| Four branches must be rebased; each rebase can reintroduce a fork | §5 order, plus a review rule: no new file may send `InitializeMovementRequest` |
+| `path_trigger_api_compat` monkey-patches a generated model | Quarantine + removal trigger (§5.4) |
+| Divergent bug fixes keep landing on `move_forward` while this is in flight | Land §5 step 2 early — it is the proof that fixes belong in one place |
+| "Equivalence" is the wrong goal where `move_forward` is subtly wrong (D15: swallowed state-monitor exceptions) | Decide each stream-lifecycle case explicitly in Phase A and pin it in the harness; call out any intentional behaviour change in the changelog |
+| The equivalence harness passes on mocks but the pause/resume `set_outputs` design is wrong on real hardware (D1) | **Retired** — override + boundary re-fire confirmed on hardware 2026-08-05 (§2, D1) |
+| The overlay layer is designed but never built, leaving the branch features homeless and the pressure to put them back in the cursor | Phase D is the *only* place the branch features land; the §3 import rule blocks the shortcut in review in the meantime |
+| Splitting cursor and overlay adds a lifecycle/ownership surface that did not exist before | §6 open 6; keep the overlay's contract to exactly two cursor APIs (state stream, `pause()`/`forward()`) so the surface stays small |
+| D16 (false success) may already be biting production silently — a caller awaiting `forward()` can proceed with the robot unmoved | **Fixed** in Phase B, independently of the merge |
+| A stop racing a queued command could command movement after the caller's abort | Pinned by `test_queued_intent_is_not_sent_after_detach`; a stop always wins over a pending intent |

--- a/nova/cell/movement_controller/trajectory_cursor.py
+++ b/nova/cell/movement_controller/trajectory_cursor.py
@@ -46,10 +46,11 @@ Example usage:
 
 import asyncio
 import logging
+from collections.abc import AsyncIterator as AsyncIteratorABC
 from dataclasses import dataclass
 from enum import Enum, StrEnum, auto
 from math import ceil, floor
-from typing import AsyncIterator, Optional, Union
+from typing import AsyncIterator, Callable, Optional, Union, cast
 
 import pydantic
 from blinker import signal
@@ -58,13 +59,31 @@ from nova import api
 from nova.actions.base import Action
 from nova.actions.container import CombinedActions
 from nova.cell.movement_controller.trajectory_state_machine import TrajectoryExecutionMachine
-from nova.exceptions import InitMovementFailed
+from nova.exceptions import ErrorDuringMovement, InitMovementFailed
 from nova.types import ExecuteTrajectoryRequestStream, ExecuteTrajectoryResponseStream
 from nova.utils import SourceLocation
 
 logger = logging.getLogger(__name__)
 
 _STREAM_STARTUP_TIMEOUT = 5.0
+
+# Bound on states buffered for __aiter__ so an unconsumed cursor cannot grow
+# without limit; oldest states are dropped first.
+_DEFAULT_MAX_QUEUED_STATES = 1024
+
+MotionGroupStateSource = Union[
+    AsyncIterator[api.models.MotionGroupState],
+    Callable[[], AsyncIterator[api.models.MotionGroupState]],
+]
+"""A live motion-group state stream, or a zero-argument factory returning one."""
+
+
+def _resolve_state_stream(
+    source: MotionGroupStateSource,
+) -> AsyncIterator[api.models.MotionGroupState]:
+    """Return a live state stream, invoking ``source`` when it is a factory."""
+    stream = source() if not isinstance(source, AsyncIteratorABC) else source
+    return cast(AsyncIterator[api.models.MotionGroupState], stream)
 
 
 class OperationType(Enum):
@@ -297,6 +316,19 @@ class OperationHandler:
         """
         return self._operation is not None and not self._operation.future.done()
 
+    def is_commanded(self) -> bool:
+        """Whether the current operation's command has actually been sent.
+
+        An operation still in ``INITIAL`` has had nothing put on the wire, so any
+        "movement finished" signal observed in that state cannot belong to it.
+        Gating on this — rather than on the acknowledgement having been received —
+        keeps the check free of races against a fast state stream.
+        """
+        return (
+            self._operation is not None
+            and self._operation.operation_state is not OperationState.INITIAL
+        )
+
     @property
     def current_operation(self) -> Optional[Operation]:
         """Get the current operation, if any."""
@@ -382,6 +414,7 @@ class Intent:
     playback_speed_in_percent: int | None = None
     start_on_io: api.models.StartOnIO | None = None
     pause_on_io: api.models.PauseOnIO | None = None
+    set_outputs: list[api.models.SetIO] | None = None
 
     def to_commands(self) -> list[ExecuteTrajectoryRequestCommand]:
         """Build the concrete API commands for this intent."""
@@ -410,6 +443,10 @@ class Intent:
                     ),
                     start_on_io=self.start_on_io,
                     pause_on_io=self.pause_on_io,
+                    # The server treats every start as an override of the attached
+                    # overlay, so the full list must travel with each one; omitting
+                    # it on a resume silently clears the remaining outputs.
+                    set_outputs=self.set_outputs,
                 )
             )
         return commands
@@ -492,24 +529,47 @@ class TrajectoryCursor:
     def __init__(
         self,
         motion_id: str,
-        motion_group_state_stream: AsyncIterator[api.models.MotionGroupState],
-        joint_trajectory: api.models.JointTrajectory,
+        motion_group_state_stream: MotionGroupStateSource,
+        joint_trajectory: api.models.JointTrajectory | None = None,
         actions: list[Action] | None = None,
         initial_location: float = 0.0,
         detach_on_standstill: bool = False,
+        set_outputs: list[api.models.SetIO] | None = None,
+        start_on_io: api.models.StartOnIO | None = None,
+        pause_on_io: api.models.PauseOnIO | None = None,
+        emit_motion_events: bool = True,
+        max_queued_states: int = _DEFAULT_MAX_QUEUED_STATES,
     ):
         """Initialize a trajectory cursor.
 
         Args:
             motion_id: Unique identifier for this motion execution.
-            motion_group_state_stream: Async stream of motion group state updates.
-            joint_trajectory: The planned joint-space trajectory to execute.
+            motion_group_state_stream: Async stream of motion group state updates,
+                or a zero-argument factory returning one.
+            joint_trajectory: The planned joint-space trajectory to execute. Optional;
+                when omitted the cursor cannot answer location-bounded questions
+                (``end_location``, ``get_movement_options``, ``forward_to_next_action``)
+                and raises if they are used.
             actions: Actions that make up the trajectory. May contain a mix of
                 motion and non-motion actions (e.g. ``WriteAction``); only the
                 motion actions drive the cursor's location-to-action mapping.
-                Optional for location-based navigation.
+                Optional for location-based navigation. An empty list is treated
+                the same as ``None`` — no action metadata.
             initial_location: Starting position on the trajectory (usually 0.0).
             detach_on_standstill: If True, automatically detach when robot stops.
+            set_outputs: IO overlay attached to *every* ``StartMovementRequest`` this
+                cursor emits. The server treats each start as an override of the
+                previously attached overlay, so a resume that omitted these would
+                silently clear them for the rest of the trajectory — hence they are
+                held here rather than passed per call.
+            start_on_io: Default IO gate applied to every emitted start (same
+                override reasoning as ``set_outputs``). Per-call arguments win.
+            pause_on_io: Default IO pause condition applied to every emitted start.
+            emit_motion_events: When False, no ``motion_started`` signals are emitted.
+                Used by one-shot execution, which has no UI to feed.
+            max_queued_states: Upper bound on states buffered for ``__aiter__``.
+                Oldest states are dropped past this bound so that a cursor whose
+                iterator is never consumed cannot grow without limit.
         """
         self.motion_id = motion_id
         self.joint_trajectory = joint_trajectory
@@ -521,9 +581,9 @@ class TrajectoryCursor:
         # their original order so future work can emit events or use them as
         # execution-step boundaries without losing positional information.
         # TODO: surface non-motion actions through the cursor's event API.
-        self._raw_actions: tuple[Action, ...] | None = (
-            tuple(actions) if actions is not None else None
-        )
+        # An empty ``actions`` list carries no mapping information, so it is
+        # normalised to None rather than asserting a zero-length trajectory.
+        self._raw_actions: tuple[Action, ...] | None = tuple(actions) if actions else None
         # Delegate motion detection to CombinedActions.motions instead of
         # re-implementing it here.
         raw_combined = (
@@ -533,7 +593,7 @@ class TrajectoryCursor:
             CombinedActions(items=tuple(raw_combined.motions)) if raw_combined is not None else None
         )
 
-        if self.actions is not None:
+        if self.actions is not None and joint_trajectory is not None:
             expected_end_location = len(self.actions)
             actual_end_location = joint_trajectory.locations[-1].root
             if abs(actual_end_location - expected_end_location) > 0.01:
@@ -548,9 +608,15 @@ class TrajectoryCursor:
         self._in_queue: asyncio.Queue[api.models.MotionGroupState | _QueueSentinel] = (
             asyncio.Queue()
         )
+        self._max_queued_states = max_queued_states
         self._motion_group_state_stream: AsyncIterator[api.models.MotionGroupState] = (
-            motion_group_state_stream
+            _resolve_state_stream(motion_group_state_stream)
         )
+
+        self._set_outputs = set_outputs
+        self._start_on_io = start_on_io
+        self._pause_on_io = pause_on_io
+        self._emit_motion_events = emit_motion_events
 
         self._current_location = initial_location
         # TODO maybe None instead until we have a target?
@@ -562,14 +628,54 @@ class TrajectoryCursor:
 
         self._initialize_task = asyncio.create_task(self.ainitialize())
 
+    def _build_intent(
+        self,
+        operation_type: OperationType,
+        *,
+        target_location: float | None = None,
+        playback_speed_in_percent: int | None = None,
+        start_on_io: api.models.StartOnIO | None = None,
+        pause_on_io: api.models.PauseOnIO | None = None,
+    ) -> Intent:
+        """Build an Intent, applying the cursor-level IO defaults.
+
+        ``set_outputs`` is always taken from the cursor: the server treats every
+        ``StartMovementRequest`` as an override of the attached overlay, so it must
+        travel with each one.
+        """
+        return Intent(
+            operation_type=operation_type,
+            target_location=target_location,
+            playback_speed_in_percent=playback_speed_in_percent,
+            start_on_io=start_on_io if start_on_io is not None else self._start_on_io,
+            pause_on_io=pause_on_io if pause_on_io is not None else self._pause_on_io,
+            set_outputs=self._set_outputs,
+        )
+
     async def ainitialize(self):
         """Async initialization that emits the initial motion event."""
-        await motion_started.send_async(self, event=self._get_motion_event())
+        await self._send_motion_started()
+
+    async def _send_motion_started(self, *, forward: bool | None = None) -> None:
+        """Emit a ``motion_started`` signal unless event emission is disabled."""
+        if not self._emit_motion_events:
+            return
+        await motion_started.send_async(self, event=self._get_motion_event(forward=forward))
 
     @property
     def end_location(self) -> float:
-        """The location value at the end of the trajectory."""
-        assert getattr(self, "joint_trajectory", None) is not None
+        """The location value at the end of the trajectory.
+
+        Raises:
+            ValueError: If the cursor was created without a ``joint_trajectory``.
+        """
+        if getattr(self, "joint_trajectory", None) is None:
+            raise ValueError(
+                "This TrajectoryCursor was created without a joint_trajectory, so the "
+                "end of the trajectory is unknown. Pass joint_trajectory= to use "
+                "location-bounded operations."
+            )
+        assert self.joint_trajectory is not None
         return self.joint_trajectory.locations[-1].root
 
     @property
@@ -637,6 +743,10 @@ class TrajectoryCursor:
 
         Returns:
             Set containing CAN_MOVE_FORWARD if not at end, CAN_MOVE_BACKWARD if not at start.
+
+        Raises:
+            ValueError: If the cursor was created without a ``joint_trajectory``,
+                since the end of the trajectory is then unknown.
         """
         options: dict[MovementOption, bool] = {
             MovementOption.CAN_MOVE_FORWARD: self._current_location < self.end_location,
@@ -697,8 +807,8 @@ class TrajectoryCursor:
             self._target_location = target_location
 
         self._set_intent(
-            Intent(
-                operation_type=OperationType.FORWARD,
+            self._build_intent(
+                OperationType.FORWARD,
                 target_location=target_location,
                 playback_speed_in_percent=playback_speed_in_percent,
                 start_on_io=start_on_io,
@@ -745,8 +855,8 @@ class TrajectoryCursor:
             self._target_location = target_location
 
         self._set_intent(
-            Intent(
-                operation_type=OperationType.BACKWARD,
+            self._build_intent(
+                OperationType.BACKWARD,
                 target_location=target_location,
                 playback_speed_in_percent=playback_speed_in_percent,
                 start_on_io=start_on_io,
@@ -929,7 +1039,12 @@ class TrajectoryCursor:
         future = self._start_operation(
             OperationType.PAUSE, expected_response_type=api.models.PauseMovementResponse
         )
-        self._set_intent(Intent(operation_type=OperationType.PAUSE))
+        self._set_intent(
+            Intent(
+                operation_type=OperationType.PAUSE
+                # A pause carries no overlay: PauseMovementRequest has no such field.
+            )
+        )
         return future
 
     def detach(self):
@@ -1039,6 +1154,11 @@ class TrajectoryCursor:
                 motion_group_state_monitor_task.cancel()
         except BaseExceptionGroup as eg:
             logger.exception(eg)
+            # A TaskGroup wraps everything, but callers of the movement-controller
+            # protocol expect the underlying error (e.g. ErrorDuringMovement), not an
+            # exception group. Unwrap when the group carries exactly one exception.
+            if len(eg.exceptions) == 1 and isinstance(eg.exceptions[0], Exception):
+                raise eg.exceptions[0] from eg
             raise
         except asyncio.CancelledError:
             logger.debug("TrajectoryCursor cntrl was cancelled during cleanup of internal tasks")
@@ -1049,6 +1169,12 @@ class TrajectoryCursor:
             # Wait for either a new intent or a stop signal.
             await self._intent_event.wait()
 
+            # A stop always wins over a queued intent: once the cursor is stopping,
+            # commanding movement would move the robot after the caller's operation
+            # has already been cancelled (and, on teardown, with nothing left to
+            # monitor it). The dropped intent is not silently lost — its operation
+            # is never marked commanded, so it is failed rather than reported as a
+            # successful traversal.
             if self._stop_event.is_set():
                 break
 
@@ -1063,18 +1189,24 @@ class TrajectoryCursor:
             commands = intent.to_commands()
             for command in commands:
                 logger.debug(f"Processing command: {command}")
+
+                if isinstance(
+                    command, (api.models.StartMovementRequest, api.models.PauseMovementRequest)
+                ):
+                    # Record the command before handing it over: `yield` suspends
+                    # until the consumer pulls again, and completion must be gated on
+                    # having commanded the operation rather than on ack timing, which
+                    # can lose a race against a fast state stream.
+                    self._operation_handler.set_commanded()
+
                 yield command
 
                 if isinstance(command, api.models.StartMovementRequest):
                     match command.direction:
                         case api.models.Direction.DIRECTION_FORWARD:
-                            await motion_started.send_async(
-                                self, event=self._get_motion_event(forward=True)
-                            )
+                            await self._send_motion_started(forward=True)
                         case api.models.Direction.DIRECTION_BACKWARD:
-                            await motion_started.send_async(
-                                self, event=self._get_motion_event(forward=False)
-                            )
+                            await self._send_motion_started(forward=False)
 
     async def _motion_group_state_monitor(self, ready_event: asyncio.Event):
         """Monitor motion group state and update operation status accordingly.
@@ -1101,25 +1233,36 @@ class TrajectoryCursor:
                 ):
                     self._state_machine.send("start")
 
-                # Skip if no operation in progress
+                # Tee every state to consumers of __aiter__ regardless of whether an
+                # operation is active: observers (guards, overlays, UIs) need states
+                # from before movement starts, not only once it is under way.
+                result = self._state_machine.process_motion_state(motion_group_state)
+                if result.has_execute:
+                    self._enqueue_state(motion_group_state)
+                    if result.location is not None:
+                        self._current_location = result.location
+
                 current_op = self._operation_handler.current_operation
                 if current_op is None or current_op.future.done():
                     continue
 
-                result = self._state_machine.process_motion_state(motion_group_state)
-
                 if result.skip:
                     continue
 
-                # Derived from execute presence
                 if result.has_execute:
-                    self._in_queue.put_nowait(motion_group_state)
                     self._operation_handler.set_running()  # idempotent
 
-                    if result.location is not None:
-                        self._current_location = result.location
-
                 if self._state_machine.is_ended or self._state_machine.is_paused:
+                    # Only an operation the controller actually acknowledged can be
+                    # completed by a terminal state. Without this guard the cursor
+                    # reports a successful traversal for movement it never commanded
+                    # (e.g. when the start command was never sent).
+                    if not self._operation_handler.is_commanded():
+                        logger.debug(
+                            "Terminal trajectory state observed while the current operation "
+                            "was never commanded — not completing it."
+                        )
+                        continue
                     self._complete_operation()
                     if self._detach_on_standstill and self._state_machine.is_ended:
                         logger.debug("Detaching on standstill")
@@ -1129,10 +1272,29 @@ class TrajectoryCursor:
             logger.debug("TrajectoryCursor motion group state monitor was cancelled")
             raise
         finally:
+            # Fail, rather than silently abandon, an operation that can no longer
+            # complete because the state stream is gone.
+            if self._operation_handler.in_progress():
+                self._operation_handler.complete(
+                    final_location=self._current_location,
+                    error=ErrorDuringMovement(
+                        "Motion group state stream ended before the movement completed"
+                    ),
+                )
             # stop the request loop
             self.detach()
             # stop the cursor iterator (TODO is this the right place?)
             self._in_queue.put_nowait(_QUEUE_SENTINEL)
+
+    def _enqueue_state(self, motion_group_state: api.models.MotionGroupState) -> None:
+        """Buffer a state for ``__aiter__``, dropping the oldest past the bound."""
+        if self._in_queue.qsize() >= self._max_queued_states:
+            try:
+                self._in_queue.get_nowait()
+                self._in_queue.task_done()
+            except asyncio.QueueEmpty:  # pragma: no cover - racy drain
+                pass
+        self._in_queue.put_nowait(motion_group_state)
 
     async def _response_consumer(self, ready_event: asyncio.Event):
         """Process responses from the motion controller and update operation state.
@@ -1164,8 +1326,8 @@ class TrajectoryCursor:
                         pass  # no-op for now
                     case api.models.MovementErrorResponse():
                         # TODO do we want this to fail the operation? Maybe you could still continue using the cursor?
-                        raise Exception(
-                            f"Movement error received in trajectory cursor: {response.root.message}"
+                        raise ErrorDuringMovement(
+                            f"Error occurred during trajectory execution: {response.root.message}"
                         )
                     case api.models.StartMovementResponse() | api.models.PauseMovementResponse():
                         # No per-command correlation exists on the wire, but
@@ -1197,18 +1359,16 @@ class TrajectoryCursor:
         Args:
             interval: Time in seconds between event emissions (default 0.2s).
         """
+        if not self._emit_motion_events:
+            return
         while True:
             current_op = self._operation_handler.current_operation
             op_type = current_op.operation_type if current_op else None
             match op_type:
                 case OperationType.FORWARD | OperationType.FORWARD_TO:
-                    await motion_started.send_async(
-                        self, event=self._get_motion_event(forward=True)
-                    )
+                    await self._send_motion_started(forward=True)
                 case OperationType.BACKWARD | OperationType.BACKWARD_TO:
-                    await motion_started.send_async(
-                        self, event=self._get_motion_event(forward=False)
-                    )
+                    await self._send_motion_started(forward=False)
                 case _:
                     pass
             await asyncio.sleep(interval)

--- a/nova/cell/movement_controller/trajectory_cursor.py
+++ b/nova/cell/movement_controller/trajectory_cursor.py
@@ -1188,6 +1188,15 @@ class TrajectoryCursor:
 
             commands = intent.to_commands()
             for command in commands:
+                # Re-check the stop on every command, not just once per intent.
+                # `yield` suspends until the consumer pulls again — a network send —
+                # so a detach can land between two commands of the same intent.
+                # `to_commands()` is multi-command whenever a playback speed is set,
+                # and without this the trailing movement command would still reach
+                # the controller after the caller's operation was cancelled.
+                if self._stop_event.is_set():
+                    return
+
                 logger.debug(f"Processing command: {command}")
 
                 if isinstance(
@@ -1275,11 +1284,10 @@ class TrajectoryCursor:
             # Fail, rather than silently abandon, an operation that can no longer
             # complete because the state stream is gone.
             if self._operation_handler.in_progress():
-                self._operation_handler.complete(
-                    final_location=self._current_location,
+                self._complete_operation(
                     error=ErrorDuringMovement(
                         "Motion group state stream ended before the movement completed"
-                    ),
+                    )
                 )
             # stop the request loop
             self.detach()
@@ -1335,9 +1343,7 @@ class TrajectoryCursor:
                         # leaving a caller awaiting forward()/pause() without the
                         # actual reason. complete() is a no-op once the future is
                         # resolved, so this wins the race by running first.
-                        self._operation_handler.complete(
-                            final_location=self._current_location, error=error
-                        )
+                        self._complete_operation(error=error)
                         raise error
                     case api.models.StartMovementResponse() | api.models.PauseMovementResponse():
                         # No per-command correlation exists on the wire, but

--- a/nova/cell/movement_controller/trajectory_cursor.py
+++ b/nova/cell/movement_controller/trajectory_cursor.py
@@ -1325,10 +1325,20 @@ class TrajectoryCursor:
                     case api.models.PlaybackSpeedResponse():
                         pass  # no-op for now
                     case api.models.MovementErrorResponse():
-                        # TODO do we want this to fail the operation? Maybe you could still continue using the cursor?
-                        raise ErrorDuringMovement(
+                        error = ErrorDuringMovement(
                             f"Error occurred during trajectory execution: {response.root.message}"
                         )
+                        # Fail the operation with the controller's own message
+                        # *before* raising. Raising cancels the state monitor via
+                        # the TaskGroup, and its `finally` would otherwise complete
+                        # the operation first with a generic "stream ended" error,
+                        # leaving a caller awaiting forward()/pause() without the
+                        # actual reason. complete() is a no-op once the future is
+                        # resolved, so this wins the race by running first.
+                        self._operation_handler.complete(
+                            final_location=self._current_location, error=error
+                        )
+                        raise error
                     case api.models.StartMovementResponse() | api.models.PauseMovementResponse():
                         # No per-command correlation exists on the wire, but
                         # mis-attribution is harmless here:

--- a/tests/cell/test_trajectory_cursor_parity.py
+++ b/tests/cell/test_trajectory_cursor_parity.py
@@ -6,8 +6,8 @@ single ``forward()`` is equivalent to the ``move_forward`` movement controller:
 - the IO overlay must travel with *every* ``StartMovementRequest`` (the server
   treats each start as an override of the previously attached overlay, so a
   resume that omits it silently clears the remaining outputs);
-- a pending intent must not be discarded when the cursor stops, which otherwise
-  produced no ``StartMovementRequest`` at all against a short state stream;
+- a pending intent must be dropped once the cursor stops, and the dropped
+  operation must then fail rather than report a phantom success;
 - a terminal trajectory state must not complete an operation that the controller
   never acknowledged, which otherwise reported a successful traversal for
   movement that was never commanded.
@@ -259,7 +259,7 @@ class TestSetOutputsOverlay:
         cursor._initialize_task.cancel()
 
 
-class TestPendingIntentSurvivesStop:
+class TestStopWinsOverPendingIntent:
     """A queued command must never reach the wire once the cursor is stopping."""
 
     async def test_queued_intent_is_not_sent_after_detach(self):
@@ -293,6 +293,49 @@ class TestPendingIntentSurvivesStop:
             pass
 
         assert sent == [], "no command may be sent after the cursor was detached"
+        assert future.cancelled()
+        cursor._initialize_task.cancel()
+
+    async def test_stop_between_commands_of_one_intent_withholds_movement(self):
+        """A stop landing mid-intent must still withhold the movement command.
+
+        ``Intent.to_commands()`` expands to two commands when a playback speed is
+        set, and ``yield`` suspends between them while the consumer sends the
+        first over the wire. Regression: the stop was only checked once per
+        intent, so a detach landing in that window let the trailing
+        ``StartMovementRequest`` reach the controller after the caller's
+        operation had already been cancelled.
+        """
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=_blocking_states(),
+            joint_trajectory=_trajectory(3),
+            actions=_actions(3),
+            emit_motion_events=False,
+        )
+        future = cursor.forward(playback_speed_in_percent=50)
+        assert [type(c) for c in cursor._pending_intent.to_commands()] == [
+            api.models.PlaybackSpeedRequest,
+            api.models.StartMovementRequest,
+        ], "this test is only meaningful for a multi-command intent"
+
+        sent = []
+        request_loop = cursor._request_loop()
+        # Pull the first command, then abort while the loop is suspended on the
+        # yield — the point at which the consumer would be sending it.
+        sent.append(await anext(request_loop))
+        cursor.detach()
+
+        try:
+            async with asyncio.timeout(1.0):
+                async for request in request_loop:
+                    sent.append(request)
+        except (asyncio.TimeoutError, StopAsyncIteration):
+            pass
+
+        assert not any(isinstance(r, api.models.StartMovementRequest) for r in sent), (
+            "movement must not be commanded after the cursor was detached"
+        )
         assert future.cancelled()
         cursor._initialize_task.cancel()
 

--- a/tests/cell/test_trajectory_cursor_parity.py
+++ b/tests/cell/test_trajectory_cursor_parity.py
@@ -331,6 +331,10 @@ class TestStopWinsOverPendingIntent:
                 async for request in request_loop:
                     sent.append(request)
         except (asyncio.TimeoutError, StopAsyncIteration):
+            # Either outcome is fine and neither is the assertion under test: the
+            # loop may return on the stop, or still be parked on `_intent_event`
+            # and hit the timeout. What matters is which commands were collected
+            # in `sent`, which the assertions below check.
             pass
 
         assert not any(isinstance(r, api.models.StartMovementRequest) for r in sent), (

--- a/tests/cell/test_trajectory_cursor_parity.py
+++ b/tests/cell/test_trajectory_cursor_parity.py
@@ -1,0 +1,471 @@
+"""Regression tests for TrajectoryCursor movement-controller parity.
+
+These cover the defects found while establishing that a cursor driven with a
+single ``forward()`` is equivalent to the ``move_forward`` movement controller:
+
+- the IO overlay must travel with *every* ``StartMovementRequest`` (the server
+  treats each start as an override of the previously attached overlay, so a
+  resume that omits it silently clears the remaining outputs);
+- a pending intent must not be discarded when the cursor stops, which otherwise
+  produced no ``StartMovementRequest`` at all against a short state stream;
+- a terminal trajectory state must not complete an operation that the controller
+  never acknowledged, which otherwise reported a successful traversal for
+  movement that was never commanded.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import AsyncIterator
+
+import pytest
+
+from nova import api
+from nova.actions.motions import lin
+from nova.cell.movement_controller.trajectory_cursor import TrajectoryCursor
+from nova.exceptions import ErrorDuringMovement
+from nova.types import Pose
+
+pytestmark = pytest.mark.asyncio
+
+
+def _trajectory(num_actions: int) -> api.models.JointTrajectory:
+    n = num_actions + 1
+    return api.models.JointTrajectory(
+        joint_positions=[api.models.Joints([0.0] * 6)] * n,
+        times=[float(i) for i in range(n)],
+        locations=[api.models.Location(root=float(i)) for i in range(n)],
+    )
+
+
+def _actions(num_actions: int) -> list:
+    return [lin(Pose((i * 100.0, 0, 0, 0, 0, 0))) for i in range(num_actions)]
+
+
+def _state(
+    standstill: bool, execute: api.models.Execute | None = None
+) -> api.models.MotionGroupState:
+    return api.models.MotionGroupState(
+        timestamp=datetime.now(timezone.utc),
+        sequence_number=1,
+        motion_group="mg-0",
+        controller="ctrl-0",
+        joint_position=api.models.Joints(root=[0.0] * 6),
+        joint_limit_reached=api.models.MotionGroupStateJointLimitReached(limit_reached=[False] * 6),
+        standstill=standstill,
+        execute=execute,
+        description_revision=1,
+    )
+
+
+def _execute(location: float, state=None) -> api.models.Execute:
+    return api.models.Execute(
+        joint_position=[0.0] * 6,
+        details=api.models.TrajectoryDetails(
+            trajectory="traj-1",
+            location=api.models.Location(root=location),
+            state=state or api.models.TrajectoryRunning(time_to_end=0),
+        ),
+    )
+
+
+def _set_io(io: str, location: float) -> api.models.SetIO:
+    return api.models.SetIO(
+        io=api.models.IOValue(api.models.IOBooleanValue(io=io, value=True)),
+        location=location,
+        io_origin=api.models.IOOrigin.CONTROLLER,
+    )
+
+
+async def _finite_states() -> AsyncIterator[api.models.MotionGroupState]:
+    """A short stream that ends — as the movement-controller unit fixtures do."""
+    yield _state(False, _execute(0.5))
+    yield _state(True, _execute(3.0, api.models.TrajectoryEnded()))
+    yield _state(True)
+
+
+async def _blocking_states() -> AsyncIterator[api.models.MotionGroupState]:
+    """A stream that stays open, as a live websocket does."""
+    yield _state(False, _execute(0.5))
+    await asyncio.Future()
+
+
+def _states_after(started: asyncio.Event) -> AsyncIterator[api.models.MotionGroupState]:
+    """States that only report progress once movement has been commanded.
+
+    An idle state is emitted immediately — a real motion-group stream is always
+    live, independent of any trajectory — so the cursor's startup gate is
+    satisfied. Trajectory progress and completion only follow the start command,
+    which is the ordering a controller actually produces.
+    """
+
+    async def gen() -> AsyncIterator[api.models.MotionGroupState]:
+        yield _state(True)
+        await started.wait()
+        yield _state(False, _execute(0.5))
+        yield _state(True, _execute(3.0, api.models.TrajectoryEnded()))
+        yield _state(True)
+
+    return gen()
+
+
+async def _responses(*inner) -> AsyncIterator[api.models.ExecuteTrajectoryResponse]:
+    for item in inner:
+        yield api.models.ExecuteTrajectoryResponse(root=item)
+    await asyncio.Future()
+
+
+def _gated_run() -> tuple[AsyncIterator, AsyncIterator, asyncio.Event]:
+    """A (state stream, response stream, start-sent event) triple.
+
+    Models the real ordering: the controller neither acknowledges nor reports any
+    trajectory progress until the start command has actually been sent. Without
+    this the mocked state stream can run to completion — tearing the cursor down —
+    before ``_request_loop`` has had a turn.
+    """
+    start_sent = asyncio.Event()
+
+    async def responses():
+        yield api.models.ExecuteTrajectoryResponse(root=api.models.InitializeMovementResponse())
+        await start_sent.wait()
+        yield api.models.ExecuteTrajectoryResponse(root=api.models.StartMovementResponse())
+        await asyncio.Future()
+
+    return _states_after(start_sent), responses(), start_sent
+
+
+async def _drive(
+    cursor: TrajectoryCursor, responses, timeout: float = 3.0, on_start: asyncio.Event | None = None
+) -> list:
+    """Run ``cntrl`` to completion, collecting the requests it yields.
+
+    ``on_start`` is set as soon as a ``StartMovementRequest`` leaves the cursor, so
+    fixtures can withhold controller feedback until movement was actually commanded.
+    """
+    requests: list = []
+
+    async def run():
+        async for request in cursor.cntrl(responses):
+            requests.append(request)
+            if on_start is not None and isinstance(request, api.models.StartMovementRequest):
+                on_start.set()
+
+    task = asyncio.create_task(run())
+    try:
+        await asyncio.wait_for(task, timeout=timeout)
+    except asyncio.TimeoutError:
+        task.cancel()
+        raise
+    return requests
+
+
+class TestSetOutputsOverlay:
+    """The IO overlay must be attached to every start the cursor emits."""
+
+    async def test_set_outputs_on_initial_start(self):
+        outputs = [_set_io("OUT#900", 1.0)]
+        states, responses, start_sent = _gated_run()
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=states,
+            joint_trajectory=_trajectory(3),
+            actions=_actions(3),
+            set_outputs=outputs,
+            detach_on_standstill=True,
+            emit_motion_events=False,
+        )
+        cursor.forward()
+        requests = await _drive(cursor, responses, on_start=start_sent)
+
+        starts = [r for r in requests if isinstance(r, api.models.StartMovementRequest)]
+        assert len(starts) == 1
+        assert starts[0].set_outputs == outputs
+
+    async def test_set_outputs_reattached_on_resume(self):
+        """A resume must re-send the overlay; omitting it clears it server-side."""
+        outputs = [_set_io("OUT#900", 1.0)]
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=_finite_states(),
+            joint_trajectory=_trajectory(3),
+            actions=_actions(3),
+            set_outputs=outputs,
+            emit_motion_events=False,
+        )
+
+        def start_command_of(intent):
+            command = intent.to_commands()[0]
+            assert isinstance(command, api.models.StartMovementRequest)
+            return command
+
+        cursor.forward()
+        assert start_command_of(cursor._pending_intent).set_outputs == outputs
+
+        # A pause carries no overlay of its own ...
+        cursor._operation_handler.set_commanded()
+        cursor.pause()
+        assert isinstance(cursor._pending_intent.to_commands()[0], api.models.PauseMovementRequest)
+
+        # ... and the resume must carry the full overlay again.
+        cursor.forward()
+        assert start_command_of(cursor._pending_intent).set_outputs == outputs
+        cursor._initialize_task.cancel()
+
+    async def test_backward_start_also_carries_outputs(self):
+        outputs = [_set_io("OUT#900", 1.0)]
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=_finite_states(),
+            joint_trajectory=_trajectory(3),
+            actions=_actions(3),
+            initial_location=2.0,
+            set_outputs=outputs,
+            emit_motion_events=False,
+        )
+        cursor.backward()
+        intent = cursor._pending_intent
+        assert intent is not None
+        command = intent.to_commands()[0]
+        assert isinstance(command, api.models.StartMovementRequest)
+        assert command.direction is api.models.Direction.DIRECTION_BACKWARD
+        assert command.set_outputs == outputs
+        cursor._initialize_task.cancel()
+
+    async def test_constructor_io_defaults_applied_to_start(self):
+        start_on_io = api.models.StartOnIO(
+            io=api.models.IOBooleanValue(io="IN#1", value=True),
+            comparator=api.models.Comparator.COMPARATOR_EQUALS,
+            io_origin=api.models.IOOrigin.CONTROLLER,
+        )
+        pause_on_io = api.models.PauseOnIO(
+            io=api.models.IOBooleanValue(io="IN#2", value=True),
+            comparator=api.models.Comparator.COMPARATOR_EQUALS,
+            io_origin=api.models.IOOrigin.CONTROLLER,
+        )
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=_finite_states(),
+            joint_trajectory=_trajectory(3),
+            actions=_actions(3),
+            start_on_io=start_on_io,
+            pause_on_io=pause_on_io,
+            emit_motion_events=False,
+        )
+        cursor.forward()
+        command = cursor._pending_intent.to_commands()[0]
+        assert command.start_on_io == start_on_io
+        assert command.pause_on_io == pause_on_io
+        cursor._initialize_task.cancel()
+
+
+class TestPendingIntentSurvivesStop:
+    """A queued command must never reach the wire once the cursor is stopping."""
+
+    async def test_queued_intent_is_not_sent_after_detach(self):
+        """An explicit abort must not be followed by a start command.
+
+        ``detach()`` cancels the caller's operation, so emitting the queued start
+        afterwards would move the robot after the caller was told the movement was
+        aborted.
+        """
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=_blocking_states(),
+            joint_trajectory=_trajectory(3),
+            actions=_actions(3),
+            emit_motion_events=False,
+        )
+        future = cursor.forward()
+        cursor.detach()
+
+        sent = []
+        request_loop = cursor._request_loop()
+        try:
+            async with asyncio.timeout(1.0):
+                async for request in request_loop:
+                    sent.append(request)
+        except (asyncio.TimeoutError, StopAsyncIteration):
+            pass
+
+        assert sent == [], "no command may be sent after the cursor was detached"
+        assert future.cancelled()
+        cursor._initialize_task.cancel()
+
+    async def test_dropped_intent_fails_rather_than_reporting_success(self):
+        """A start that never went out must surface as an error, not a traversal.
+
+        Regression: a short state stream tore the cursor down before the queued
+        intent was sent, and the terminal state then resolved the operation as a
+        successful move to the end of the trajectory.
+        """
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=_finite_states(),
+            joint_trajectory=_trajectory(3),
+            actions=_actions(3),
+            detach_on_standstill=True,
+            emit_motion_events=False,
+        )
+        future = cursor.forward()
+        await cursor._motion_group_state_monitor(ready_event=asyncio.Event())
+
+        assert future.done()
+        with pytest.raises(ErrorDuringMovement):
+            future.result()
+        cursor._initialize_task.cancel()
+
+
+class TestOperationRequiresAcknowledgement:
+    """A terminal state must not complete an operation that was never commanded."""
+
+    async def test_uncommanded_operation_is_not_completed_by_terminal_state(self):
+        """Regression: forward() resolved successfully having commanded nothing.
+
+        The operation is created but ``cntrl`` never runs, so no request reaches
+        the wire. A terminal trajectory state must not be attributed to it.
+        """
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=_finite_states(),
+            joint_trajectory=_trajectory(3),
+            actions=_actions(3),
+            emit_motion_events=False,
+        )
+        future = cursor.forward()
+        assert not cursor._operation_handler.is_commanded()
+
+        # Drive the state monitor directly: no command was ever sent.
+        await cursor._motion_group_state_monitor(ready_event=asyncio.Event())
+
+        assert future.done()
+        with pytest.raises(ErrorDuringMovement):
+            future.result()
+        cursor._initialize_task.cancel()
+
+    async def test_sent_command_marks_the_operation_commanded(self):
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=_blocking_states(),
+            joint_trajectory=_trajectory(3),
+            actions=_actions(3),
+            emit_motion_events=False,
+        )
+        cursor.forward()
+        assert not cursor._operation_handler.is_commanded()
+
+        # Consume one request from the loop: that is the point of no return.
+        request_loop = cursor._request_loop()
+        request = await anext(request_loop)
+
+        assert isinstance(request, api.models.StartMovementRequest)
+        assert cursor._operation_handler.is_commanded()
+        await request_loop.aclose()
+        cursor._initialize_task.cancel()
+
+    async def test_sent_pause_marks_the_operation_commanded(self):
+        """A pause must be gated the same way, or it can never complete.
+
+        Only ``PauseMovementResponse`` would otherwise mark it commanded, so a
+        delayed or lost ack would leave ``pause()`` unresolved.
+        """
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=_blocking_states(),
+            joint_trajectory=_trajectory(3),
+            actions=_actions(3),
+            emit_motion_events=False,
+        )
+        cursor.forward()
+        request_loop = cursor._request_loop()
+        await anext(request_loop)  # the start
+
+        cursor.pause()
+        request = await anext(request_loop)
+        assert isinstance(request, api.models.PauseMovementRequest)
+        assert cursor._operation_handler.is_commanded()
+        await request_loop.aclose()
+        cursor._initialize_task.cancel()
+
+    async def test_success_when_start_is_acknowledged(self):
+        states, responses, start_sent = _gated_run()
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=states,
+            joint_trajectory=_trajectory(3),
+            actions=_actions(3),
+            detach_on_standstill=True,
+            emit_motion_events=False,
+        )
+        future = cursor.forward()
+        requests = await _drive(cursor, responses, on_start=start_sent)
+
+        assert any(isinstance(r, api.models.StartMovementRequest) for r in requests)
+        result = await future
+        assert result.error is None
+        assert result.final_location == pytest.approx(3.0)
+
+
+class TestOptionalConstructorArguments:
+    """Parity requirements for one-shot execution."""
+
+    async def test_empty_actions_is_not_a_zero_length_trajectory(self):
+        """``actions=[]`` carries no mapping information and must be accepted."""
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=_finite_states(),
+            joint_trajectory=_trajectory(3),
+            actions=[],
+            emit_motion_events=False,
+        )
+        assert cursor.actions is None
+        assert cursor.current_action is None
+        cursor._initialize_task.cancel()
+
+    async def test_joint_trajectory_is_optional(self):
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=_finite_states(),
+            actions=_actions(3),
+            emit_motion_events=False,
+        )
+        with pytest.raises(ValueError, match="without a joint_trajectory"):
+            _ = cursor.end_location
+        cursor._initialize_task.cancel()
+
+    async def test_state_stream_may_be_a_factory(self):
+        states, responses, start_sent = _gated_run()
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=lambda: states,
+            joint_trajectory=_trajectory(3),
+            actions=_actions(3),
+            detach_on_standstill=True,
+            emit_motion_events=False,
+        )
+        cursor.forward()
+        requests = await _drive(cursor, responses, on_start=start_sent)
+        assert any(isinstance(r, api.models.StartMovementRequest) for r in requests)
+
+
+class TestMovementErrorPropagation:
+    """Callers expect ErrorDuringMovement, not a bare exception group."""
+
+    async def test_movement_error_surfaces_unwrapped(self):
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=_blocking_states(),
+            joint_trajectory=_trajectory(3),
+            actions=_actions(3),
+            emit_motion_events=False,
+        )
+        cursor.forward()
+        with pytest.raises(ErrorDuringMovement, match="boom"):
+            await _drive(
+                cursor,
+                _responses(
+                    api.models.InitializeMovementResponse(),
+                    api.models.StartMovementResponse(),
+                    api.models.MovementErrorResponse(message="boom"),
+                ),
+            )

--- a/tests/cell/test_trajectory_cursor_parity.py
+++ b/tests/cell/test_trajectory_cursor_parity.py
@@ -286,6 +286,10 @@ class TestPendingIntentSurvivesStop:
                 async for request in request_loop:
                     sent.append(request)
         except (asyncio.TimeoutError, StopAsyncIteration):
+            # Both outcomes are acceptable and neither is the assertion under test:
+            # the loop may exit cleanly on the stop, or it may still be parked on
+            # `_intent_event` and hit the timeout. What matters is that nothing was
+            # yielded in the meantime, which the assertion below checks.
             pass
 
         assert sent == [], "no command may be sent after the cursor was detached"
@@ -469,3 +473,32 @@ class TestMovementErrorPropagation:
                     api.models.MovementErrorResponse(message="boom"),
                 ),
             )
+
+    async def test_operation_future_carries_the_controller_message(self):
+        """A caller awaiting ``forward()`` must get the controller's own reason.
+
+        Regression: raising in the response consumer cancels the state monitor,
+        whose ``finally`` completed the operation first with a generic
+        "stream ended" error, hiding the actual fault from anyone holding the
+        future rather than iterating ``cntrl``.
+        """
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=_blocking_states(),
+            joint_trajectory=_trajectory(3),
+            actions=_actions(3),
+            emit_motion_events=False,
+        )
+        future = cursor.forward()
+        with pytest.raises(ErrorDuringMovement):
+            await _drive(
+                cursor,
+                _responses(
+                    api.models.InitializeMovementResponse(),
+                    api.models.StartMovementResponse(),
+                    api.models.MovementErrorResponse(message="E-STOP triggered"),
+                ),
+            )
+
+        with pytest.raises(ErrorDuringMovement, match="E-STOP triggered"):
+            await future

--- a/tests/nova/cell/motion_group/test_trajectory_cursor_integration.py
+++ b/tests/nova/cell/motion_group/test_trajectory_cursor_integration.py
@@ -415,3 +415,58 @@ async def test_cursor_detach_on_standstill_tears_down_on_pause_on_io(kuka_mg):
         await kuka.write("OUT#900", False)
         cursor.detach()
         execute_task.cancel()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_cursor_set_outputs_fires_io_during_movement(kuka_mg):
+    """The IO overlay must reach the controller through the cursor.
+
+    Before ``set_outputs`` was plumbed through the cursor, a trajectory's
+    ``io_write`` actions were silently dropped whenever it was executed via a
+    cursor rather than the one-shot movement controller.
+    """
+    mg, kuka = kuka_mg
+    await kuka.write("OUT#900", False)
+
+    trajectory, actions = await _plan_move(mg, delta=0.4)
+    outputs = [
+        api.models.SetIO(
+            io=api.models.IOValue(api.models.IOBooleanValue(io="OUT#900", value=True)),
+            location=0.0,
+            io_origin=api.models.IOOrigin.CONTROLLER,
+        )
+    ]
+
+    cursor_ready = asyncio.Event()
+    holder: list[TrajectoryCursor] = []
+
+    def factory(context: MovementControllerContext) -> MovementControllerFunction:
+        cursor = TrajectoryCursor(
+            motion_id=context.motion_id,
+            motion_group_state_stream=context.motion_group_state_stream_gen(),
+            joint_trajectory=trajectory,
+            actions=actions,
+            set_outputs=outputs,
+            detach_on_standstill=True,
+        )
+        holder.append(cursor)
+        cursor_ready.set()
+        return cursor.cntrl
+
+    execute_task = asyncio.create_task(
+        mg.execute(trajectory, "Flange", actions, movement_controller=factory)
+    )
+    await asyncio.wait_for(cursor_ready.wait(), timeout=10.0)
+    cursor = holder[0]
+
+    try:
+        assert await kuka.read("OUT#900") is False
+        await asyncio.wait_for(cursor.forward(), timeout=30.0)
+        assert await kuka.read("OUT#900") is True, (
+            "set_outputs overlay never reached the controller through the cursor"
+        )
+    finally:
+        await kuka.write("OUT#900", False)
+        cursor.detach()
+        execute_task.cancel()


### PR DESCRIPTION
> Supersedes #471, which GitHub auto-closed when this branch was renamed to match repo conventions. Same commits; the review thread on #471 (both comments addressed in `b3ead25`) is still readable there.

Brings `TrajectoryCursor` to parity with the `move_forward` movement controller, so a later change can collapse the two. **`move_forward` is untouched here** — the actual merge is a separate, independently revertible step.

## Why

`move_forward` and `TrajectoryCursor.cntrl` implement the *same* `executeTrajectory` protocol, and the loop has now forked five ways across `main` and four in-flight branches. `cursor.forward()` from location 0 with no target *is* `move_forward`; everything else the cursor offers is a superset. Rationale and sequencing: [`docs/architecture/incoming/move-forward-to-cursor.md`](docs/architecture/incoming/move-forward-to-cursor.md).

This PR is Phases A + B of that plan.

## The IO overlay was silently dropped

A trajectory's `io_write` actions never reached the controller when executed through a cursor — `Intent.to_commands()` built `StartMovementRequest` without `set_outputs`. This is the single most valuable overlay kind, so it is fixed first.

**Verified on hardware** (virtual KUKA) that `set_outputs` has *override* semantics, which shapes the API:

| Experiment | Result |
|---|---|
| Start `[A@1.0]`, pause before 1.0, resume with `[B@2.0]` | `A=False`, `B=True` → the second start **replaced** the first list |
| Stop exactly on `A@1.0`, reset `A` externally, resume from 1.0 | `A=True` → **re-fires at the boundary** |

Consequences:

- **Every** start must carry the full list. A resume that omits it does not "keep" the overlay, it *clears* it. So `set_outputs` is a **constructor-level default**, not a per-call argument — a per-call argument is a footgun where the first resume that forgets it disables all remaining IO.
- Boundary re-firing is accepted rather than engineered around (idempotent for level-triggered outputs; worth noting for anything edge-sensitive downstream).
- `start_on_io` / `pause_on_io` get the same treatment; per-call arguments still win.

> Heads-up for `feat/path-triggers-distance-offset`: its resume sends a bare `StartMovementRequest(direction=FORWARD)`, so under override semantics that branch drops every remaining IO write on the first blocking async action.

## Two defects found while establishing parity

**The cursor reported success for movement it never commanded.** Completion was driven purely by the state stream with no correlation to what was sent, so `await cursor.forward()` could resolve to `OperationResult(final_location=3.0, error=None)` having emitted only an `InitializeMovementRequest`. A caller would then advance its program with the robot still at the start. Completion is now gated on the operation having been *commanded* — recorded immediately before the request is yielded, since gating on the acknowledgement instead loses a race against a fast state stream. An operation whose state stream ends first is now failed rather than silently abandoned.

**`pause()` could hang.** It was only ever marked commanded by its acknowledgement, so a delayed or lost ack left the future unresolved. Now gated symmetrically with start.

## Also

- `joint_trajectory` is optional; `actions=[]` means "no action metadata" rather than asserting a zero-length trajectory (this is a supported `execute()` path today).
- The state stream may be an `AsyncIterator` **or** a zero-argument factory.
- Movement errors raise `ErrorDuringMovement`, and `cntrl` unwraps a single-exception `BaseExceptionGroup` from its `TaskGroup`.
- The state monitor tees *all* states to the cursor's iterator (bounded, drop-oldest) instead of only while an operation is active — observers need states from before movement starts.
- `emit_motion_events` suppresses the 5 Hz signal for non-interactive callers.

## A deliberate non-change

A stop still **discards** a queued intent. Flushing it was implemented and reverted: it let an explicit `cursor.forward(); cursor.detach()` cancel the caller's future *and then still command the robot to move*. A stop must win. The symptom that motivated the flush is now surfaced properly by the completion gate, as an error rather than a phantom success.

## Verification

- **365 unit tests** pass, including 14 new regression tests pinning the overlay contract and both defects
- **14 integration tests** pass against a live NOVA cell, including the existing `move_forward` paths that must not regress
- A new integration test proves the IO overlay **actually fires on hardware** through the cursor
- `ruff` and `ty` clean on the changed files

## Review notes

- The mocked state-stream fixtures emit an idle state immediately and withhold trajectory progress until the start has been observed. Streams that complete instantly tear the cursor down before the request loop gets a turn — an artefact, not the behaviour under test.
- Still open, deliberately: whether `execute()` should emit motion events by default, and whether client-side overlays (markers, async actions, guards) move to a layer *above* the cursor — argued in §3 of the plan doc.



---

**Note:** this branch also carries `eabe630 "deps update"` (a `uv.lock` refresh pushed by @dirksonnemann), which is unrelated to the cursor changes.
