### PR TITLE
feat(cursor): make move_forward a TrajectoryCursor adapter

### DIFF
--- a/docs/architecture/incoming/move-forward-to-cursor.md
+++ b/docs/architecture/incoming/move-forward-to-cursor.md
@@ -1,6 +1,6 @@
 # `move_forward` → `TrajectoryCursor` — transition plan
 
-Status: **Phases A and B implemented; C–E open.** This document argues that the two
+Status: **Phases A–C implemented; D–E open.** This document argues that the two
 movement controllers should become **one** implementation, and sequences the transition.
 
 It is a companion to the `command-routine.md` analysis (an unpublished working document on
@@ -446,12 +446,32 @@ turn, which is the artefact that originally looked like D12. The parity fixtures
 idle state immediately (a real motion-group stream is always live) and withhold trajectory
 progress until the `StartMovementRequest` has actually been observed.
 
-### Phase C — `move_forward` becomes an adapter (D10)
+### Phase C — `move_forward` becomes an adapter (D10) — **DONE**
 
 Rewrite `move_forward` as §3. Add the optional `joint_trajectory` to
 `MovementControllerContext`. Expose the live cursor to callers of `execute()` — proposal: an
 optional `on_cursor: Callable[[TrajectoryCursor], None]` on `MovementControllerContext`,
 which also lets the integration tests drop their hand-rolled adapter factory.
+
+> Implemented on `feat/move-forward-cursor-adapter` (stacked on the Phase A+B branch,
+> landed before the watchdog rebase of §5 step 2 — the adapter is the smaller, better-tested
+> change, and the watchdog has never run in production). Two deviations from the sketch
+> above:
+>
+> - **`on_cursor` is deferred.** It only becomes reachable with `execute()`-level plumbing,
+>   and open question 5 (§6, what `detach()` means for an exposed cursor) should be settled
+>   in the same change. D10 is P1 quality-of-transition; the adapter does not need it.
+> - **The cursor gained a first-dispatch gate.** The gate-test fixtures surfaced a real
+>   scheduling hazard: a state stream that is consumed to its end in a single scheduling
+>   slice (a mock — or a fast real stream, depending on Python-version `wait_for`
+>   internals) tears the cursor down before `_request_loop` has its first turn, dropping
+>   the adapter's queued start. `cntrl` now creates a gate when an intent is already queued
+>   at protocol start; the state monitor may process its first state (the liveness
+>   handshake) but holds before pulling further states until the queued command has been
+>   dispatched. An explicit `detach()` still wins over the queued intent — every
+>   `_request_loop` exit path and `detach()` itself open the gate, so nothing deadlocks.
+>   This is what lets the Phase C gate below pass **with zero edits**, rather than
+>   reclassifying those fixtures as D15 artefacts.
 
 *Verify:* **the existing `move_forward` test files must pass unchanged** —
 `tests/cell/test_process_motion_group_state.py`,

--- a/nova/actions/container.py
+++ b/nova/actions/container.py
@@ -165,6 +165,9 @@ class MovementControllerContext(pydantic.BaseModel):
     start_on_io: api.models.StartOnIO | None = None
     pause_on_io: api.models.PauseOnIO | None = None
     motion_group_state_stream_gen: Callable[[], AsyncIterator[api.models.MotionGroupState]]
+    # The planned trajectory being executed. Optional: only location-bounded
+    # cursor operations need it, one-shot execution does not.
+    joint_trajectory: api.models.JointTrajectory | None = None
 
 
 MovementController = Callable[[MovementControllerContext], MovementControllerFunction]

--- a/nova/cell/motion_group.py
+++ b/nova/cell/motion_group.py
@@ -1001,6 +1001,7 @@ class MotionGroup(AbstractRobot):
                 start_on_io=start_on_io,
                 pause_on_io=pause_on_io,
                 motion_group_state_stream_gen=self.stream_state,
+                joint_trajectory=joint_trajectory,
             )
         )
 

--- a/nova/cell/movement_controller/move_forward.py
+++ b/nova/cell/movement_controller/move_forward.py
@@ -1,172 +1,57 @@
 import asyncio
 import logging
 
-from nova import api
 from nova.actions import MovementControllerContext
-from nova.cell.movement_controller.trajectory_state_machine import TrajectoryExecutionMachine
-from nova.exceptions import ErrorDuringMovement, InitMovementFailed
-from nova.types import (
-    ExecuteTrajectoryRequestStream,
-    ExecuteTrajectoryResponseStream,
-    MovementControllerFunction,
-)
+from nova.cell.movement_controller.trajectory_cursor import TrajectoryCursor
+from nova.types import MovementControllerFunction
 
 logger = logging.getLogger(__name__)
 
-_START_STATE_MONITOR_TIMEOUT = 5.0
 
-
-# TODO: when the message exchange is not working as expected we should gracefully close
 def move_forward(context: MovementControllerContext) -> MovementControllerFunction:
+    """Default movement controller: run the trajectory forward from start to end.
+
+    This is a thin adapter over :class:`TrajectoryCursor`, which owns the
+    ``executeTrajectory`` protocol; ``move_forward`` only configures a cursor for
+    one-shot execution and starts it. The name and the plug-in seam
+    (``MovementController`` / ``MovementControllerContext``) are kept for
+    backwards compatibility.
+
+    Must be called with a running event loop: the cursor schedules its
+    background initialization at construction time.
     """
-    movement_controller is an async function that yields requests to the server.
-    If a movement_consumer is provided, we'll asend() each wb.models.MovementMovement to it,
-    letting it produce MotionState objects.
+    cursor = TrajectoryCursor(
+        motion_id=context.motion_id,
+        motion_group_state_stream=context.motion_group_state_stream_gen,
+        joint_trajectory=context.joint_trajectory,
+        # An empty list carries no action metadata; it must not be mistaken
+        # for a zero-length trajectory.
+        actions=list(context.combined_actions.items) or None,
+        # Server-side IO overlay, attached by the cursor to every start it
+        # emits (each start overrides the previously attached overlay).
+        set_outputs=context.combined_actions.to_set_io(),
+        start_on_io=context.start_on_io,
+        pause_on_io=context.pause_on_io,
+        initial_location=0.0,
+        detach_on_standstill=True,
+        emit_motion_events=False,
+    )
+    # Starting immediately is move_forward policy, not a cursor capability.
+    operation = cursor.forward()
+    operation.add_done_callback(_consume_operation_outcome)
+    return cursor.cntrl
+
+
+def _consume_operation_outcome(operation: asyncio.Future) -> None:
+    """Retrieve the one-shot operation's result so asyncio never warns about it.
+
+    Nobody awaits this future in one-shot execution: movement errors reach the
+    protocol caller through ``cntrl`` itself. A state stream that ends before
+    the trajectory completes only resolves the future, matching the previous
+    ``move_forward`` behaviour of returning once the state monitor is gone.
     """
-
-    async def movement_controller(
-        response_stream: ExecuteTrajectoryResponseStream,
-    ) -> ExecuteTrajectoryRequestStream:
-        async def motion_group_state_monitor(stream_started_event: asyncio.Event):
-            try:
-                logger.info("Starting state monitor for trajectory")
-                machine = TrajectoryExecutionMachine()
-                machine.send("start")
-
-                async for motion_group_state in context.motion_group_state_stream_gen():
-                    if not stream_started_event.is_set():
-                        stream_started_event.set()
-
-                    logger.debug(
-                        f"Trajectory: {context.motion_id} state monitor received state: {motion_group_state}"
-                    )
-
-                    machine.process_motion_state(motion_group_state)
-
-                    if machine.is_ended:
-                        logger.info(
-                            f"Trajectory: {context.motion_id} state monitor ended at standstill."
-                        )
-                        return
-
-                    if machine.is_waiting_for_standstill:
-                        logger.debug(f"Trajectory: {context.motion_id} waiting for standstill")
-
-                logger.info(
-                    f"Trajectory: {context.motion_id} state monitor ended without TrajectoryEnded"
-                )
-            except BaseException as e:
-                logger.error(
-                    f"Trajectory: {context.motion_id} state monitor ended with exception: {type(e).__name__}: {e}"
-                )
-                raise
-
-        trajectory_id = api.models.TrajectoryId(id=context.motion_id)
-        initialize_movement_request = api.models.InitializeMovementRequest(
-            trajectory=trajectory_id, initial_location=api.models.Location(0)
-        )
-
-        logger.info(f"Trajectory: {context.motion_id} Initializing movement with request")
-        yield initialize_movement_request
-        initialize_movement_response = await anext(response_stream)
-
-        logger.info(f"Trajectory: {context.motion_id} received initialize movement response.")
-        if not isinstance(initialize_movement_response.root, api.models.InitializeMovementResponse):
-            raise Exception(
-                f"Expected InitializeMovementResponse but got: {initialize_movement_response.root}"
-            )
-
-        if (
-            initialize_movement_response.root.message
-            or initialize_movement_response.root.add_trajectory_error
-        ):
-            logger.error(
-                f"Trajectory: {context.motion_id} initialization failed: {initialize_movement_response.root}"
-            )
-            raise InitMovementFailed(initialize_movement_response.root)
-
-        # before sending start movement start state monitoring to not loose any data
-        # at this point we have exclusive right to do movement on the robot, any movement should be
-        # what is coming from our trajectory
-        try:
-            stream_started_event = asyncio.Event()
-            state_monitor = asyncio.create_task(
-                motion_group_state_monitor(stream_started_event),
-                name=f"motion-group-state-monitor-{context.motion_id}",
-            )
-            logger.info(f"Trajectory: {context.motion_id} waiting for state monitor to start")
-            await asyncio.wait_for(
-                stream_started_event.wait(), timeout=_START_STATE_MONITOR_TIMEOUT
-            )
-        except asyncio.TimeoutError:
-            logger.error(f"Trajectory: {context.motion_id} state monitor failed to start in time")
-            state_monitor.cancel()
-            raise Exception("State monitor failed to start in time")
-
-        set_io_list = context.combined_actions.to_set_io()
-        start_movement_request = api.models.StartMovementRequest(
-            direction=api.models.Direction.DIRECTION_FORWARD,
-            set_outputs=set_io_list,
-            start_on_io=context.start_on_io,
-            pause_on_io=context.pause_on_io,
-        )
-        logger.info(f"Trajectory: {context.motion_id} sending StartMovementRequest")
-        yield start_movement_request
-
-        start_movement_response = await anext(response_stream)
-        logger.info(f"Trajectory: {context.motion_id} received start movement response.")
-        if not isinstance(start_movement_response.root, api.models.StartMovementResponse):
-            raise Exception(
-                f"Expected StartMovementResponse but got: {start_movement_response.root}"
-            )
-
-        # the only possible response we can get from web socket at this point is a movement failure
-        error_message = ""
-
-        async def error_response_consumer(response_stream: ExecuteTrajectoryResponseStream):
-            response = await anext(response_stream)
-            if not isinstance(response.root, api.models.MovementErrorResponse):
-                logger.error(
-                    f"Trajectory: {context.motion_id} received unexpected response: {response}"
-                )
-                return
-
-            nonlocal error_message
-            error_message = response.root.message
-
-        error_consumer = asyncio.create_task(
-            error_response_consumer(response_stream),
-            name=f"execute-trajectory-error-consumer-{context.motion_id}",
-        )
-        tasks = {error_consumer, state_monitor}
-
-        try:
-            logger.info(f"Trajectory: {context.motion_id} waiting for completion or error")
-            done, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-            if state_monitor in done:
-                logger.info(f"Trajectory: {context.motion_id} completed via state monitor")
-                return
-
-            if error_consumer in done:
-                logger.info(f"Trajectory: {context.motion_id} error consumer completed")
-                raise ErrorDuringMovement(
-                    f"Error occurred during trajectory execution: {error_message}"
-                )
-        except BaseException as e:
-            logger.error(
-                f"Trajectory: {context.motion_id} encountered exception: {type(e).__name__}: {e}"
-            )
-            raise
-        finally:
-            for task in tasks:
-                if not task.done():
-                    logger.info(
-                        f"Trajectory: {context.motion_id} cancelling task: {task.get_name()}"
-                    )
-                    task.cancel()
-
-            logger.info(f"Trajectory: {context.motion_id} waiting for tasks to finish")
-            await asyncio.gather(*tasks, return_exceptions=True)
-            logger.info(f"Trajectory: {context.motion_id} all tasks finished")
-
-    return movement_controller
+    if operation.cancelled():
+        return
+    error = operation.exception()
+    if error is not None:
+        logger.debug(f"move_forward operation ended with an error: {error!r}")

--- a/nova/cell/movement_controller/trajectory_cursor.py
+++ b/nova/cell/movement_controller/trajectory_cursor.py
@@ -589,9 +589,12 @@ class TrajectoryCursor:
         raw_combined = (
             CombinedActions(items=self._raw_actions) if self._raw_actions is not None else None  # ty: ignore[invalid-argument-type]
         )
-        self.actions = (
-            CombinedActions(items=tuple(raw_combined.motions)) if raw_combined is not None else None
-        )
+        # A list with no motion actions (e.g. only io_write) carries no
+        # location-to-action mapping either, so it is normalised to None just
+        # like an empty list — otherwise the end-location check below would
+        # demand a zero-length trajectory.
+        motions = tuple(raw_combined.motions) if raw_combined is not None else ()
+        self.actions = CombinedActions(items=motions) if motions else None
 
         if self.actions is not None and joint_trajectory is not None:
             expected_end_location = len(self.actions)
@@ -1210,11 +1213,6 @@ class TrajectoryCursor:
                 continue
 
             commands = intent.to_commands()
-            # Release the state monitor before the first yield: setting the event
-            # only schedules its waiter, and this task keeps running until the
-            # yield below has handed the command to the consumer — so the monitor
-            # can only resume once the command is actually on its way out.
-            self._signal_first_dispatch()
             for command in commands:
                 # Re-check the stop on every command, not just once per intent.
                 # `yield` suspends until the consumer pulls again — a network send —
@@ -1227,6 +1225,16 @@ class TrajectoryCursor:
 
                 logger.debug(f"Processing command: {command}")
 
+                # A stop that lands while this intent is mid-dispatch (e.g. between
+                # a PlaybackSpeedRequest and its StartMovementRequest) must suppress
+                # the remaining commands for the same reason a queued intent is
+                # dropped above: nothing is left to monitor the movement. A speed
+                # setting without its movement command is harmless; the reverse is
+                # not.
+                if self._stop_event.is_set():
+                    self._signal_first_dispatch()
+                    return
+
                 if isinstance(
                     command, (api.models.StartMovementRequest, api.models.PauseMovementRequest)
                 ):
@@ -1235,6 +1243,13 @@ class TrajectoryCursor:
                     # having commanded the operation rather than on ack timing, which
                     # can lose a race against a fast state stream.
                     self._operation_handler.set_commanded()
+                    # Release the state monitor only for the movement command itself,
+                    # not for a leading PlaybackSpeedRequest: setting the event only
+                    # schedules its waiter, and this task keeps running until the
+                    # yield below has handed the command to the consumer — so the
+                    # monitor can only resume once the movement command is actually
+                    # on its way out.
+                    self._signal_first_dispatch()
 
                 yield command
 

--- a/nova/cell/movement_controller/trajectory_cursor.py
+++ b/nova/cell/movement_controller/trajectory_cursor.py
@@ -605,6 +605,12 @@ class TrajectoryCursor:
         self._pending_intent: Intent | None = None
         self._intent_event = asyncio.Event()
         self._stop_event = asyncio.Event()
+        # Created by cntrl() when an intent is already queued at protocol start
+        # (the one-shot adapter shape). While present and unset, the state
+        # monitor holds after its first state so a fast state stream cannot be
+        # interpreted — or torn down on EOF — before the queued command was
+        # dispatched. See _request_loop/_motion_group_state_monitor.
+        self._first_dispatch_gate: asyncio.Event | None = None
         self._in_queue: asyncio.Queue[api.models.MotionGroupState | _QueueSentinel] = (
             asyncio.Queue()
         )
@@ -1061,6 +1067,12 @@ class TrajectoryCursor:
                 op.future.cancel()
         self._stop_event.set()
         self._intent_event.set()  # wake _request_loop so it sees the stop
+        self._signal_first_dispatch()  # a parked state monitor must not outlive a stop
+
+    def _signal_first_dispatch(self) -> None:
+        """Release a state monitor parked on the first-dispatch gate, if any."""
+        if self._first_dispatch_gate is not None:
+            self._first_dispatch_gate.set()
 
     def _start_operation(
         self,
@@ -1111,6 +1123,15 @@ class TrajectoryCursor:
             self.motion_id, response_stream, self._current_location
         ):
             yield request
+
+        # An intent queued before the protocol started (a cursor commanded ahead
+        # of cntrl, e.g. by the move_forward adapter) must reach the wire before
+        # trajectory progress is interpreted: scheduling could otherwise let the
+        # state monitor consume a fast stream — and tear the cursor down on its
+        # end — before _request_loop has had its first turn, failing the
+        # operation without ever sending the command.
+        if self._pending_intent is not None:
+            self._first_dispatch_gate = asyncio.Event()
 
         motion_group_state_monitor_ready_event = asyncio.Event()
         response_consumer_ready_event = asyncio.Event()
@@ -1176,6 +1197,7 @@ class TrajectoryCursor:
             # is never marked commanded, so it is failed rather than reported as a
             # successful traversal.
             if self._stop_event.is_set():
+                self._signal_first_dispatch()
                 break
 
             # Consume the pending intent atomically.
@@ -1184,9 +1206,15 @@ class TrajectoryCursor:
             self._intent_event.clear()
 
             if intent is None:
+                self._signal_first_dispatch()
                 continue
 
             commands = intent.to_commands()
+            # Release the state monitor before the first yield: setting the event
+            # only schedules its waiter, and this task keeps running until the
+            # yield below has handed the command to the consumer — so the monitor
+            # can only resume once the command is actually on its way out.
+            self._signal_first_dispatch()
             for command in commands:
                 # Re-check the stop on every command, not just once per intent.
                 # `yield` suspends until the consumer pulls again — a network send —
@@ -1228,7 +1256,9 @@ class TrajectoryCursor:
         """
         logger.debug("Starting state monitor for trajectory cursor")
         try:
-            async for motion_group_state in self._motion_group_state_stream:
+            async for motion_group_state in self._held_at_first_dispatch(
+                self._motion_group_state_stream
+            ):
                 ready_event.set()
 
                 # Ensure the state machine is in executing state when an operation
@@ -1293,6 +1323,25 @@ class TrajectoryCursor:
             self.detach()
             # stop the cursor iterator (TODO is this the right place?)
             self._in_queue.put_nowait(_QUEUE_SENTINEL)
+
+    async def _held_at_first_dispatch(
+        self, stream: AsyncIterator[api.models.MotionGroupState]
+    ) -> AsyncIterator[api.models.MotionGroupState]:
+        """Pass states through, holding between states until the first dispatch.
+
+        With an intent queued before ``cntrl`` started (``_first_dispatch_gate``
+        set up by ``cntrl``), the monitor may process the first state — that is
+        the liveness handshake ``ready_event`` needs — but must not pull further
+        states, or reach the stream's end, before ``_request_loop`` has sent the
+        queued command: trajectory progress would be attributed to (or teardown
+        would fail) an operation that never went out. Once the gate opens the
+        wrapper is transparent. Without a gate (interactive use) it passes
+        everything straight through.
+        """
+        async for motion_group_state in stream:
+            yield motion_group_state
+            if self._first_dispatch_gate is not None:
+                await self._first_dispatch_gate.wait()
 
     def _enqueue_state(self, motion_group_state: api.models.MotionGroupState) -> None:
         """Buffer a state for ``__aiter__``, dropping the oldest past the bound."""

--- a/tests/cell/test_move_forward_adapter.py
+++ b/tests/cell/test_move_forward_adapter.py
@@ -1,0 +1,135 @@
+"""Regression tests for move_forward as a TrajectoryCursor adapter.
+
+Since the Phase C merge (docs/architecture/incoming/move-forward-to-cursor.md),
+``move_forward`` no longer implements the ``executeTrajectory`` protocol itself:
+it configures a :class:`TrajectoryCursor` for one-shot execution and starts it.
+The behavioural contract of the old implementation is pinned by the untouched
+``move_forward`` test files; these tests pin what is new at the adapter seam:
+
+- the start command must reach the wire even against a state stream that runs
+  to its end in a single scheduling slice (the first-dispatch gate);
+- the context's IO overlay and IO gates must arrive on the emitted start.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+from nova import api
+from nova.actions.container import CombinedActions, MovementControllerContext
+from nova.actions.io import io_write
+from nova.actions.motions import lin
+from nova.cell.movement_controller.move_forward import move_forward
+from nova.types import Pose
+
+pytestmark = pytest.mark.asyncio
+
+
+def _state(
+    standstill: bool, execute: api.models.Execute | None = None
+) -> api.models.MotionGroupState:
+    return api.models.MotionGroupState(
+        timestamp=datetime.now(timezone.utc),
+        sequence_number=1,
+        motion_group="mg-0",
+        controller="ctrl-0",
+        joint_position=api.models.Joints(root=[0.0] * 6),
+        joint_limit_reached=api.models.MotionGroupStateJointLimitReached(limit_reached=[False] * 6),
+        standstill=standstill,
+        execute=execute,
+        description_revision=1,
+    )
+
+
+def _execute(location: float, state=None) -> api.models.Execute:
+    return api.models.Execute(
+        joint_position=[0.0] * 6,
+        details=api.models.TrajectoryDetails(
+            trajectory="traj-1",
+            location=api.models.Location(root=location),
+            state=state or api.models.TrajectoryRunning(time_to_end=0),
+        ),
+    )
+
+
+def _finite_states():
+    """A state stream that ends, as the movement-controller unit fixtures do.
+
+    Without the cursor's first-dispatch gate this stream is consumed to its end
+    in one scheduling slice, tearing the cursor down before the adapter's queued
+    start had a turn — the measured D12/D16 artefact from the transition plan.
+    """
+
+    async def gen():
+        yield _state(False, _execute(0.5))
+        yield _state(True, _execute(1.0, api.models.TrajectoryEnded()))
+        yield _state(True)
+
+    return gen
+
+
+async def _responses():
+    yield api.models.ExecuteTrajectoryResponse(root=api.models.InitializeMovementResponse())
+    yield api.models.ExecuteTrajectoryResponse(root=api.models.StartMovementResponse())
+    await asyncio.Future()
+
+
+def _context(**overrides) -> MovementControllerContext:
+    defaults = dict(
+        combined_actions=CombinedActions(items=()),
+        motion_id="test-motion",
+        motion_group_state_stream_gen=_finite_states(),
+    )
+    defaults.update(overrides)
+    return MovementControllerContext(**defaults)
+
+
+async def _run(context: MovementControllerContext) -> list:
+    controller_fn = move_forward(context)
+    requests = []
+    async with asyncio.timeout(5):
+        async for request in controller_fn(_responses()):
+            requests.append(request)
+    return requests
+
+
+async def test_start_reaches_the_wire_against_a_fast_finite_stream():
+    """An empty-actions context (the preplanned path) runs to completion and
+    the start command is sent even though the mocked state stream can be
+    consumed to its end before the request loop's first turn."""
+    requests = await _run(_context())
+
+    assert any(isinstance(r, api.models.InitializeMovementRequest) for r in requests)
+    assert any(isinstance(r, api.models.StartMovementRequest) for r in requests)
+
+
+async def test_start_carries_the_io_overlay_and_io_gates():
+    """set_outputs derived from the actions, and the context's start/pause IO
+    conditions, must all travel on the emitted StartMovementRequest."""
+    combined_actions = CombinedActions(
+        items=(lin(Pose((100.0, 0, 0, 0, 0, 0))), io_write(key="OUT#900", value=True))
+    )
+    start_on_io = api.models.StartOnIO(
+        io=api.models.IOBooleanValue(io="IN#1", value=True),
+        comparator=api.models.Comparator.COMPARATOR_EQUALS,
+        io_origin=api.models.IOOrigin.CONTROLLER,
+    )
+    pause_on_io = api.models.PauseOnIO(
+        io=api.models.IOBooleanValue(io="IN#2", value=True),
+        comparator=api.models.Comparator.COMPARATOR_EQUALS,
+        io_origin=api.models.IOOrigin.CONTROLLER,
+    )
+    context = _context(
+        combined_actions=combined_actions, start_on_io=start_on_io, pause_on_io=pause_on_io
+    )
+
+    requests = await _run(context)
+
+    starts = [r for r in requests if isinstance(r, api.models.StartMovementRequest)]
+    assert len(starts) == 1
+    expected_outputs = combined_actions.to_set_io()
+    assert expected_outputs, "fixture must produce a non-empty IO overlay"
+    assert starts[0].set_outputs == expected_outputs
+    assert starts[0].start_on_io == start_on_io
+    assert starts[0].pause_on_io == pause_on_io

--- a/tests/cell/test_move_forward_adapter.py
+++ b/tests/cell/test_move_forward_adapter.py
@@ -104,6 +104,30 @@ async def test_start_reaches_the_wire_against_a_fast_finite_stream():
     assert any(isinstance(r, api.models.StartMovementRequest) for r in requests)
 
 
+async def test_io_only_actions_with_a_preplanned_trajectory():
+    """Attaching an IO-only overlay to a preplanned trajectory must keep working.
+
+    Regression (PR #475 review): the cursor normalised ``actions=[]`` to "no
+    action metadata" but not a non-empty list without motion actions, so this
+    previously-supported ``execute()`` shape raised ``ValueError`` against the
+    trajectory's real end location.
+    """
+    combined_actions = CombinedActions(items=(io_write(key="OUT#900", value=True),))
+    joint_trajectory = api.models.JointTrajectory(
+        joint_positions=[api.models.Joints([0.0] * 6), api.models.Joints([0.1] * 6)],
+        times=[0.0, 1.0],
+        locations=[api.models.Location(root=0.0), api.models.Location(root=1.0)],
+    )
+    context = _context(combined_actions=combined_actions, joint_trajectory=joint_trajectory)
+
+    requests = await _run(context)
+
+    starts = [r for r in requests if isinstance(r, api.models.StartMovementRequest)]
+    assert len(starts) == 1
+    assert starts[0].set_outputs == combined_actions.to_set_io()
+    assert starts[0].set_outputs, "the IO overlay must still travel on the start"
+
+
 async def test_start_carries_the_io_overlay_and_io_gates():
     """set_outputs derived from the actions, and the context's start/pause IO
     conditions, must all travel on the emitted StartMovementRequest."""

--- a/tests/cell/test_trajectory_cursor_parity.py
+++ b/tests/cell/test_trajectory_cursor_parity.py
@@ -22,6 +22,7 @@ from typing import AsyncIterator
 import pytest
 
 from nova import api
+from nova.actions.io import io_write
 from nova.actions.motions import lin
 from nova.cell.movement_controller.trajectory_cursor import TrajectoryCursor
 from nova.exceptions import ErrorDuringMovement
@@ -416,6 +417,56 @@ class TestFirstDispatchGate:
         assert not any(isinstance(r, api.models.StartMovementRequest) for r in requests)
         assert future.cancelled()
 
+    async def test_gate_holds_through_a_leading_playback_speed_request(self):
+        """A speed-carrying intent dispatches two commands; the gate must open on
+        the movement command, not on the leading ``PlaybackSpeedRequest``.
+
+        Regression (PR #475 review): the gate opened before the first yield, so
+        the monitor could run a fast stream to its end — failing the operation
+        and detaching — during the PlaybackSpeed suspension, after which the loop
+        still put an unmonitored ``StartMovementRequest`` on the wire.
+        """
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=_finite_states(),
+            joint_trajectory=_trajectory(3),
+            actions=_actions(3),
+            detach_on_standstill=True,
+            emit_motion_events=False,
+        )
+        future = cursor.forward(playback_speed_in_percent=50)
+        requests = await _drive(
+            cursor,
+            _responses(api.models.InitializeMovementResponse(), api.models.StartMovementResponse()),
+        )
+
+        assert any(isinstance(r, api.models.PlaybackSpeedRequest) for r in requests)
+        assert any(isinstance(r, api.models.StartMovementRequest) for r in requests)
+        result = await future
+        assert result.error is None
+
+    async def test_stop_mid_intent_suppresses_the_movement_command(self):
+        """A detach landing between a ``PlaybackSpeedRequest`` and its start must
+        suppress the start: a speed setting without its movement is harmless, an
+        unmonitored movement command is not."""
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=_blocking_states(),
+            joint_trajectory=_trajectory(3),
+            actions=_actions(3),
+            emit_motion_events=False,
+        )
+        cursor.forward(playback_speed_in_percent=50)
+
+        request_loop = cursor._request_loop()
+        first = await anext(request_loop)
+        assert isinstance(first, api.models.PlaybackSpeedRequest)
+
+        cursor.detach()
+        with pytest.raises(StopAsyncIteration):
+            await anext(request_loop)
+        cursor._initialize_task.cancel()
+
 
 class TestOperationRequiresAcknowledgement:
     """A terminal state must not complete an operation that was never commanded."""
@@ -521,6 +572,22 @@ class TestOptionalConstructorArguments:
         )
         assert cursor.actions is None
         assert cursor.current_action is None
+        cursor._initialize_task.cancel()
+
+    async def test_actions_without_motions_are_not_a_zero_length_trajectory(self):
+        """Only non-motion actions (e.g. a lone ``io_write``) carry no location
+        mapping either — they must not trip the end-location check against a real
+        trajectory. Regression (PR #475 review): the preplanned-trajectory path
+        with an IO-only overlay raised ``ValueError`` in the constructor."""
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=_finite_states(),
+            joint_trajectory=_trajectory(3),
+            actions=[io_write(key="OUT#900", value=True)],
+            emit_motion_events=False,
+        )
+        assert cursor.actions is None
+        assert cursor._raw_actions is not None
         cursor._initialize_task.cancel()
 
     async def test_joint_trajectory_is_optional(self):

--- a/tests/cell/test_trajectory_cursor_parity.py
+++ b/tests/cell/test_trajectory_cursor_parity.py
@@ -367,6 +367,56 @@ class TestStopWinsOverPendingIntent:
         cursor._initialize_task.cancel()
 
 
+class TestFirstDispatchGate:
+    """An intent queued before ``cntrl`` starts must reach the wire first.
+
+    A mocked (or merely fast) state stream can otherwise be consumed to its end
+    in a single scheduling slice, tearing the cursor down before the request
+    loop's first turn — the queued start would be dropped and the operation
+    failed without anything having been sent.
+    """
+
+    async def test_prequeued_intent_is_dispatched_before_a_fast_stream_ends(self):
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=_finite_states(),
+            joint_trajectory=_trajectory(3),
+            actions=_actions(3),
+            detach_on_standstill=True,
+            emit_motion_events=False,
+        )
+        future = cursor.forward()
+        requests = await _drive(
+            cursor,
+            _responses(api.models.InitializeMovementResponse(), api.models.StartMovementResponse()),
+        )
+
+        assert any(isinstance(r, api.models.StartMovementRequest) for r in requests)
+        result = await future
+        assert result.error is None
+        assert result.final_location == pytest.approx(3.0)
+
+    async def test_detach_before_cntrl_still_wins_over_the_queued_intent(self):
+        """A stop must keep winning: nothing is sent, and nothing deadlocks on
+        the gate the queued intent would otherwise have opened."""
+        cursor = TrajectoryCursor(
+            motion_id="traj-1",
+            motion_group_state_stream=_finite_states(),
+            joint_trajectory=_trajectory(3),
+            actions=_actions(3),
+            detach_on_standstill=True,
+            emit_motion_events=False,
+        )
+        future = cursor.forward()
+        cursor.detach()
+        requests = await _drive(
+            cursor, _responses(api.models.InitializeMovementResponse()), timeout=2.0
+        )
+
+        assert not any(isinstance(r, api.models.StartMovementRequest) for r in requests)
+        assert future.cancelled()
+
+
 class TestOperationRequiresAcknowledgement:
     """A terminal state must not complete an operation that was never commanded."""
 


### PR DESCRIPTION
> Stacked on #472 (Phases A+B). This PR is **Phase C** of [`docs/architecture/incoming/move-forward-to-cursor.md`](docs/architecture/incoming/move-forward-to-cursor.md): after it, `TrajectoryCursor` is the sole implementation of the `executeTrajectory` protocol, and `move_forward` remains only as a backwards-compatible adapter.

## What changes

`move_forward` no longer implements the protocol loop. It configures a cursor for one-shot execution and starts it:

- IO overlay from `combined_actions.to_set_io()`, `start_on_io` / `pause_on_io` from the context — all constructor-level defaults on the cursor, carried on every emitted start (the #472 override contract)
- `detach_on_standstill=True`, `emit_motion_events=False`
- autostart via `cursor.forward()` before returning `cursor.cntrl` — adapter policy, not a cursor flag, exactly as §3 of the plan prescribes

`MovementControllerContext` gains an **optional** `joint_trajectory` (D11), populated at the single production construction site in `MotionGroup._execute`. Nothing else on the plug-in seam changes; no caller of `execute()` / `plan_and_execute()` changes.

## The gate

Phase C's acceptance criterion is that the existing `move_forward` test files pass **without any edits**:

- `tests/cell/test_process_motion_group_state.py`
- `tests/nova/cell/motion_group/test_pause_on_io.py`
- `tests/nova/cell/motion_group/test_motion_group_task_cancelation.py`
- `tests/nova/cell/motion_group/test_motion_group_movement.py`

All pass unchanged. Full unit suite: **767 passed** (4 new). `ruff` and `ty` clean.

## One cursor change was needed: the first-dispatch gate

The gate fixtures surfaced a real scheduling hazard, not a mock artefact to paper over: a state stream that can be consumed to its end in a single scheduling slice (an in-memory mock — or, depending on Python-minor `wait_for` internals, a fast real stream) lets the state monitor tear the cursor down before `_request_loop` has had its first turn. The adapter's queued start would be dropped and the operation failed with nothing ever sent — the D12/D16 artefact from the plan, measured on `main`.

Fix: when `cntrl` starts with an intent already queued (the adapter shape), it creates a gate. The state monitor may process its **first** state — that is the liveness handshake the startup timeout needs — but holds before pulling further states until the queued command has been dispatched. Deterministic by construction: the gate opens before the dispatching `yield`, and the monitor (a different task) can only resume once the request loop suspends, i.e. once the command has reached the consumer.

The #472 stop semantics are preserved: an explicit `detach()` still wins over a queued intent. Every `_request_loop` exit path and `detach()` itself open the gate, so a parked monitor can never deadlock — pinned by `test_detach_before_cntrl_still_wins_over_the_queued_intent`.

Interactive cursors (no intent queued at `cntrl` start) get no gate and are unaffected.

## Deliberately not in this PR

- **`on_cursor` (D10).** Exposing the live cursor to `execute()` callers needs plumbing through `execute()`/`stream_execute()` signatures and should settle §6 open question 5 (what `detach()` means for an exposed cursor) in the same change. D10 is P1 quality-of-transition; the adapter does not need it.
- **Deleting the old protocol code paths beyond `move_forward` itself** — `stall_watchdog` folding and README cleanup remain Phase E.

Sequencing note: this lands before the stall-watchdog rebase (§5 step 2), deviating from the plan's order — the adapter is the smaller, gate-verified change, and the watchdog has never run in production. The watchdog rebase (§5 step 2) now targets a single implementation, which is the point of the ordering rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)