### PR TITLE
feat: add singularity handling examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,8 @@ Examples on how to use the wandelbots-nova library.
 7. [Serialize program](serialize_program.py)
 8. [Merge trajectories with blending](merge_trajectories.py)
 9. [Kinematic configuration](kinematic_configuration.py)
+10. [Palletizing wrist handling](palletizing_wrist_singularity_handling.py)
+11. [Adaptive KUKA singularity handling](adaptive_singularity_handling.py)
 
 ## Usage
 

--- a/examples/adaptive_singularity_handling.py
+++ b/examples/adaptive_singularity_handling.py
@@ -1,0 +1,175 @@
+"""Plan a Cartesian line through a KUKA shoulder singularity.
+
+The example mirrors the low-level planner example with the SDK API:
+
+1. Calculate the pose at a known KUKA shoulder singularity.
+2. Build a Cartesian line from 200 mm before that pose to 200 mm after it.
+3. Show that default singularity handling fails.
+4. Show that adaptive sampling produces an executable trajectory.
+5. Execute the adaptive trajectory.
+
+The planner controls Cartesian sampling internally; unlike the low-level
+planner API, the SDK does not expose a sampling-time argument.
+"""
+
+import asyncio
+import math
+
+import nova
+from nova import api, run_program
+from nova.actions import cartesian_ptp, joint_ptp, linear
+from nova.cell import virtual_controller
+from nova.exceptions import PlanTrajectoryFailed
+from nova.types import MotionSettings, Pose
+
+KUKA_CONTROLLER = "kuka-kr16-r2010"
+SINGULARITY_OFFSET_MM = 200.0
+SINGULARITY_OFFSET_SIDE_MM = 0
+# This is the KUKA shoulder singularity reported by the planner. The start
+# joints are the same wrist branch, 200 mm before that singularity pose.
+SINGULARITY_JOINTS = (0, -2.5888, 2.0697, 0.0, 0.2, 0)
+START_JOINTS = (0, -2.9311, 1.653, 0, 1.2914, 0)
+
+
+@nova.program(
+    name="Adaptive Singularity Handling",
+    preconditions=nova.ProgramPreconditions(
+        controllers=[
+            virtual_controller(
+                name=KUKA_CONTROLLER,
+                manufacturer=api.models.Manufacturer.KUKA,
+                type="kuka-kr16_r2010_2",
+                position=[*START_JOINTS, 0.0],
+            )
+        ],
+        cleanup_controllers=False,
+    ),
+)
+async def adaptive_singularity_handling(ctx: nova.ProgramContext) -> None:
+    """Plan a line through a KUKA shoulder singularity."""
+    controller = await ctx.cell.controller(KUKA_CONTROLLER)
+    motion_group = controller[0]
+    tcp = "Flange"
+    settings = MotionSettings(tcp_velocity_limit=500)
+
+    # Reset the virtual robot so reruns also work when the controller already exists.
+    async def move_to_start() -> None:
+        positioning_action = joint_ptp(START_JOINTS, settings=settings)
+        positioning_trajectory = await motion_group.plan([positioning_action], tcp)
+        await motion_group.execute(positioning_trajectory, tcp, actions=[positioning_action])
+        await asyncio.sleep(3)
+
+    await move_to_start()
+
+    singularity_poses = await motion_group.forward_kinematics([list(SINGULARITY_JOINTS)], tcp)
+    if len(singularity_poses) != 1:
+        raise RuntimeError("KUKA forward kinematics returned no singularity pose")
+    singularity_pose = singularity_poses[0]
+    orientation = singularity_pose.orientation.to_tuple()
+
+    start_pose = Pose(
+        (
+            singularity_pose.position.x - 2 * SINGULARITY_OFFSET_MM,
+            singularity_pose.position.y + SINGULARITY_OFFSET_SIDE_MM,
+            singularity_pose.position.z,
+            *orientation,
+        )
+    )
+    print(start_pose)
+    target_pose = Pose(
+        (
+            start_pose.position.x + 5 * SINGULARITY_OFFSET_MM,
+            start_pose.position.y + SINGULARITY_OFFSET_SIDE_MM,
+            start_pose.position.z,
+            *start_pose.orientation.to_tuple(),
+        )
+    )
+    print(target_pose)
+    actions = [cartesian_ptp(start_pose, settings=settings), linear(target_pose, settings=settings)]
+
+    print("Planning the Cartesian line with default singularity handling...")
+    try:
+        no_handling_trajectory = await motion_group.plan(
+            actions=actions,
+            tcp=tcp,
+            start_joint_position=START_JOINTS,
+            singularity_handling=api.models.SingularityHandling.NONE,
+        )
+    except PlanTrajectoryFailed as exc:
+        print("  Expected: planning failed at the shoulder singularity.")
+        error = exc.error
+        partial_trajectory = (
+            error.joint_trajectory
+            if isinstance(error, api.models.PlanTrajectoryFailedResponse)
+            else None
+        )
+        if partial_trajectory is not None and partial_trajectory.joint_positions:
+            print(
+                "  Executing the viable part of the trajectory with "
+                f"{len(partial_trajectory.joint_positions)} samples."
+            )
+            await motion_group.execute(partial_trajectory, tcp, actions=actions)
+            await asyncio.sleep(3)
+            print("  Executed the viable part of the trajectory.")
+            await move_to_start()
+        else:
+            print("  No viable part of the trajectory to execute.")
+    else:
+        print("  Success: the line planned without singularity handling; executing it.")
+        await motion_group.execute(no_handling_trajectory, tcp, actions=actions)
+        await asyncio.sleep(3)
+        print("  Executed the trajectory planned without singularity handling.")
+        await move_to_start()
+
+    print("Planning it again with ADAPTIVE_SAMPLING...")
+    try:
+        trajectory = await motion_group.plan(
+            actions=actions,
+            tcp=tcp,
+            start_joint_position=START_JOINTS,
+            singularity_handling=api.models.SingularityHandling.ADAPTIVE_SAMPLING,
+        )
+    except PlanTrajectoryFailed as exc:
+        print("  Planning with adaptive sampling failed at the shoulder singularity.")
+        error = exc.error
+        partial_trajectory = (
+            error.joint_trajectory
+            if isinstance(error, api.models.PlanTrajectoryFailedResponse)
+            else None
+        )
+        if partial_trajectory is not None and partial_trajectory.joint_positions:
+            print(
+                "  Executing the viable part of the trajectory with "
+                f"{len(partial_trajectory.joint_positions)} samples."
+            )
+            await motion_group.execute(partial_trajectory, tcp, actions=actions)
+            await asyncio.sleep(3)
+            print("  Executed the viable part of the trajectory.")
+            await move_to_start()
+        else:
+            print("  No viable part of the trajectory to execute.")
+        return
+
+    if not trajectory.joint_positions:
+        raise RuntimeError("Adaptive singularity handling returned an empty trajectory")
+
+    closest_sample = min(
+        trajectory.joint_positions, key=lambda joints: math.dist(joints.root, SINGULARITY_JOINTS)
+    )
+    singularity_distance = math.dist(closest_sample.root, SINGULARITY_JOINTS)
+
+    print(
+        "  Success: adaptive sampling produced an executable trajectory with "
+        f"{len(trajectory.joint_positions)} samples."
+    )
+    print(f"  Closest sample to the shoulder singularity: {singularity_distance:.6f} rad.")
+
+    await motion_group.execute(trajectory, tcp, actions=actions)
+    await asyncio.sleep(3)
+    print("  Executed the adaptive trajectory through the shoulder singularity.")
+
+    await move_to_start()
+
+
+if __name__ == "__main__":
+    run_program(adaptive_singularity_handling)

--- a/examples/palletizing_wrist_singularity_handling.py
+++ b/examples/palletizing_wrist_singularity_handling.py
@@ -1,0 +1,97 @@
+"""Demonstrate the palletizing wrist singularity handling flag.
+
+The flange points down while the tool mimics a palletizing pick-and-drop:
+approach, descend to pick, lift, transfer, descend to drop, and lift away.
+The Cartesian path crosses the KUKA wrist singularity.
+
+Without special handling, the planner stops at the singularity. With
+``PALLETIZING_WRIST``, it bridges the singularity by changing the wrist branch.
+
+Prerequisites:
+- A NOVA instance
+- ``NOVA_API`` and ``NOVA_ACCESS_TOKEN`` set in the environment
+"""
+
+import asyncio
+
+import nova
+from nova import api, run_program
+from nova.actions import joint_ptp, linear
+from nova.cell import virtual_controller
+from nova.exceptions import PlanTrajectoryFailed
+from nova.types import MotionSettings, Pose
+
+KUKA_CONTROLLER = "kuka-kr16-r2010"
+START_JOINTS = (0.0, -1.5, 2.2708, 0.0, 0.8, 0.0)
+PICKUP_TRAVEL = 1000
+TRANSFER_DISTANCE = 400
+DROP_TRAVEL = 1000
+
+
+@nova.program(
+    name="Singularity Handling",
+    preconditions=nova.ProgramPreconditions(
+        controllers=[
+            virtual_controller(
+                name=KUKA_CONTROLLER,
+                manufacturer=api.models.Manufacturer.KUKA,
+                type="kuka-kr16_r2010_2",
+                position=[*START_JOINTS, 0.0],
+            )
+        ],
+        cleanup_controllers=False,
+    ),
+)
+async def singularity_handling(ctx: nova.ProgramContext) -> None:
+    """Plan and execute a palletizing pick-and-drop through a wrist singularity."""
+    controller = await ctx.cell.controller(KUKA_CONTROLLER)
+    motion_group = controller[0]
+    tcp = "Flange"
+    settings = MotionSettings(tcp_velocity_limit=500)
+
+    # Reset the virtual robot to the approach pose so reruns also work when the
+    # controller already exists from an earlier execution.
+    positioning_action = joint_ptp(START_JOINTS, settings=settings)
+    positioning_trajectory = await motion_group.plan([positioning_action], tcp)
+    await motion_group.execute(positioning_trajectory, tcp, actions=[positioning_action])
+
+    # The flange points down, so positive local Z moves the tool down in base Z.
+    start_poses = await motion_group.forward_kinematics([list(START_JOINTS)], tcp)
+    if len(start_poses) != 1:
+        raise RuntimeError("KUKA forward kinematics returned no start pose")
+    approach_pose = start_poses[0]
+    pickup_pose = approach_pose @ Pose((0, 0, PICKUP_TRAVEL, 0, 0, 0))
+    transfer_pose = approach_pose @ Pose((0, TRANSFER_DISTANCE, 0, 0, 0, 0))
+    drop_pose = transfer_pose @ Pose((0, 0, DROP_TRAVEL, 0, 0, 0))
+    actions = [
+        linear(pickup_pose, settings=settings),
+        linear(approach_pose, settings=settings),
+        linear(transfer_pose, settings=settings),
+        linear(drop_pose, settings=settings),
+        linear(transfer_pose, settings=settings),
+    ]
+
+    print("Planning pick-and-drop motion without singularity handling...")
+    try:
+        await motion_group.plan(actions=actions, tcp=tcp, start_joint_position=START_JOINTS)
+    except PlanTrajectoryFailed as exc:
+        print(f"  Expected: planning failed at the wrist singularity: {exc.error.error_feedback}")
+    else:
+        raise RuntimeError("The motion unexpectedly planned without singularity handling")
+
+    print("Planning the same pick-and-drop with PALLETIZING_WRIST...")
+    trajectory = await motion_group.plan(
+        actions=actions,
+        tcp=tcp,
+        start_joint_position=START_JOINTS,
+        singularity_handling=api.models.SingularityHandling.PALLETIZING_WRIST,
+    )
+    print(f"  Success: planned {len(trajectory.joint_positions)} trajectory points.")
+
+    await motion_group.execute(trajectory, tcp, actions=actions)
+    await asyncio.sleep(1)
+    print("  Executed the pick-and-drop through the wrist singularity.")
+
+
+if __name__ == "__main__":
+    run_program(singularity_handling)


### PR DESCRIPTION
## Summary
- add a palletizing wrist singularity handling example
- add an adaptive KUKA shoulder singularity handling example
- list both examples in the examples README

## Validation
- `uv run ruff check examples/README.md examples/adaptive_singularity_handling.py examples/palletizing_wrist_singularity_handling.py`