### PR TITLE
fix: Prevent infinite loop when tracing hull outlines

### DIFF
--- a/nova_rerun_bridge/hull_visualizer.py
+++ b/nova_rerun_bridge/hull_visualizer.py
@@ -93,20 +93,27 @@ class HullVisualizer:
             adj.setdefault(a, []).append(b)
             adj.setdefault(b, []).append(a)
 
-        # Walk along the boundary edges to form a closed loop
+        # Walk along the boundary edges to form a closed loop. Degenerate hulls can have
+        # pinch vertices (degree > 2) where the boundary is not a simple cycle, so every
+        # edge may only be traversed once - otherwise the walk loops forever.
         start = boundary_edges[0][0]
         loop = [start]
         current = start
         prev = None
+        visited_edges: set[tuple[int, int]] = set()
         while True:
             neighbors = adj[current]
             next_vertex = None
             for n in neighbors:
-                if n != prev:
-                    next_vertex = n
-                    break
+                if n == prev:
+                    continue
+                if (min(current, n), max(current, n)) in visited_edges:
+                    continue
+                next_vertex = n
+                break
             if next_vertex is None:
                 break
+            visited_edges.add((min(current, next_vertex), max(current, next_vertex)))
             loop.append(next_vertex)
             prev, current = current, next_vertex
             if next_vertex == start:

--- a/tests/nova_rerun_bridge/test_hull_visualizer.py
+++ b/tests/nova_rerun_bridge/test_hull_visualizer.py
@@ -1,0 +1,62 @@
+import numpy as np
+import pytest
+
+from nova_rerun_bridge.hull_visualizer import HullVisualizer
+
+# One coplanar face of a convex hull computed from CAD collision geometry. The triangles fan
+# out from vertex 3 and partly only touch there, so the face boundary is not a simple cycle:
+# vertex 3 has more than two boundary neighbours. Walking such a boundary while only avoiding
+# the previous vertex circles the same sub-loop forever and never returns to the start vertex.
+PINCHED_FACE_POINTS = np.array(
+    [
+        [4.9489, 0.591, -1.3391],
+        [-7.8748, 15.4831, -2.4483],
+        [-14.0382, 20.7235, -2.447],
+        [-2.8719, 0.7592, 0.4698],
+        [1.2711, -16.2252, 4.2223],
+        [5.2076, -11.5949, 1.9971],
+        [6.9272, -7.074, 0.3286],
+        [6.4301, -2.6627, -0.7834],
+    ]
+)
+PINCHED_FACE_SIMPLICES = [
+    np.array([3, 5, 6]),
+    np.array([3, 1, 2]),
+    np.array([3, 5, 4]),
+    np.array([3, 7, 0]),
+    np.array([3, 7, 6]),
+]
+
+
+@pytest.mark.timeout(30)
+def test_merge_coplanar_triangles_terminates_on_pinched_boundary():
+    polygon = HullVisualizer.merge_coplanar_triangles_to_polygon(
+        PINCHED_FACE_POINTS, PINCHED_FACE_SIMPLICES
+    )
+
+    # Every boundary edge is walked at most once, so the outline stays bounded.
+    assert 0 < len(polygon) <= 2 * len(PINCHED_FACE_POINTS)
+
+
+@pytest.mark.timeout(60)
+def test_compute_hull_outlines_from_duplicated_points():
+    """Convex hulls exported from CAD repeat vertices; outlines must still be produced."""
+    cube = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [1.0, 0.0, 1.0],
+            [1.0, 1.0, 1.0],
+            [0.0, 1.0, 1.0],
+        ]
+    )
+    points = np.vstack([cube, cube, cube])
+
+    polygons = HullVisualizer.compute_hull_outlines_from_points(points)
+
+    assert len(polygons) == 6
+    for polygon in polygons:
+        assert np.allclose(polygon[0], polygon[-1])


### PR DESCRIPTION
## Problem

`HullVisualizer.merge_coplanar_triangles_to_polygon()` can hang forever.

Convex hulls computed from CAD collision geometry often contain coplanar faces whose boundary is **not a simple cycle** — a pinch vertex with more than two boundary neighbours (e.g. triangles that fan out from one vertex and only touch there). The boundary walk only skipped the previous vertex:

```python
for n in neighbors:
    if n != prev:
        next_vertex = n
        break
```

At a pinch vertex this can step into a sub-loop that does not contain `start`, so `next_vertex == start` never becomes true and `next_vertex is None` never happens. The `while True` loop spins forever while `loop` grows without bound.

Hit this while logging a real collision setup (681 convex hull colliders) with `nova_rerun_bridge`: `log_colliders_once()` froze on one collider at 0% CPU with steadily growing memory, so nothing was ever visualized.

## Fix

Traverse every boundary edge at most once. This bounds the walk by the number of boundary edges and terminates on non-simple boundaries, while behaviour on well-formed (simple-cycle) boundaries is unchanged.

## Test

`tests/nova_rerun_bridge/test_hull_visualizer.py` contains the minimized real-world face (8 points, 5 triangles) that triggered the hang, plus a sanity check that hulls with duplicated input vertices still yield outlines.

Verified the regression test reproduces the bug — reverting the fix makes it hit the `pytest-timeout` limit inside the `while True` loop:

```
File "tests/nova_rerun_bridge/test_hull_visualizer.py", line 33, in test_merge_coplanar_triangles_terminates_on_pinched_boundary
  polygon = HullVisualizer.merge_coplanar_triangles_to_polygon(
File "nova_rerun_bridge/hull_visualizer.py", line 101, in merge_coplanar_triangles_to_polygon
  while True:
+++++++++++++++++++++++++++++++++++ Timeout ++++++++++++++++++++++++++++++++++++
```

With the fix, `tests/nova_rerun_bridge` passes (32 tests) and the 681-collider scene logs completely in ~4 s.