### PR TITLE
fix(nova-rerun-bridge): Derive hull outlines from trimesh face adjacency

### DIFF
--- a/nova_rerun_bridge/hull_visualizer.py
+++ b/nova_rerun_bridge/hull_visualizer.py
@@ -5,6 +5,10 @@ import trimesh
 from scipy.spatial import ConvexHull
 from scipy.spatial.qhull import QhullError
 
+# Adjacent hull triangles are treated as one flat face below this angle, so the edge between
+# them is not part of the wireframe.
+COPLANAR_ANGLE_TOLERANCE = 1e-6
+
 
 class HullVisualizer:
     @staticmethod
@@ -29,108 +33,14 @@ class HullVisualizer:
         return (mesh.vertices.tolist(), mesh.faces.tolist(), mesh.vertex_normals.tolist())
 
     @staticmethod
-    def plane_from_triangle(p0, p1, p2, normal_epsilon=1e-6):
-        # Compute normal
-        v1 = p1 - p0
-        v2 = p2 - p0
-        n = np.cross(v1, v2)
-        norm = np.linalg.norm(n)
-        if norm < normal_epsilon:
-            return None, None
-        n = n / norm
-        # Plane: n·x = d
-        d = np.dot(n, p0)
-        return n, d
-
-    @staticmethod
-    def group_coplanar_triangles(points, hull, angle_epsilon=1e-6, dist_epsilon=1e-6):
-        # Group triangles by their plane (normal and distance)
-        plane_map = {}
-        for simplex in hull.simplices:
-            p0, p1, p2 = points[simplex]
-            n, d = HullVisualizer.plane_from_triangle(p0, p1, p2)
-            if n is None:
-                continue
-
-            # Ensure a canonical representation of the plane normal
-            for i_comp in range(3):
-                if abs(n[i_comp]) > angle_epsilon:
-                    if n[i_comp] < 0:
-                        n = -n
-                        d = -d
-                    break
-
-            # Round normal and distance for stable hashing
-            n_rounded = tuple(np.round(n, 6))
-            d_rounded = round(d, 3)
-
-            key = (n_rounded, d_rounded)
-            if key not in plane_map:
-                plane_map[key] = []
-            plane_map[key].append(simplex)
-
-        return plane_map
-
-    @staticmethod
-    def merge_coplanar_triangles_to_polygon(points, simplices):
-        # Extract polygon outline from coplanar triangles
-        edges = {}
-        for tri in simplices:
-            for i in range(3):
-                a = tri[i]
-                b = tri[(i + 1) % 3]
-                e = (min(a, b), max(a, b))
-                edges[e] = edges.get(e, 0) + 1
-
-        # Keep only outer edges (appear once)
-        boundary_edges = [e for e, count in edges.items() if count == 1]
-        if not boundary_edges:
-            return []
-
-        # Build adjacency
-        adj = {}
-        for a, b in boundary_edges:
-            adj.setdefault(a, []).append(b)
-            adj.setdefault(b, []).append(a)
-
-        # Walk along the boundary edges to form a closed loop. Degenerate hulls can have
-        # pinch vertices (degree > 2) where the boundary is not a simple cycle, so every
-        # edge may only be traversed once - otherwise the walk loops forever.
-        start = boundary_edges[0][0]
-        loop = [start]
-        current = start
-        prev = None
-        visited_edges: set[tuple[int, int]] = set()
-        while True:
-            neighbors = adj[current]
-            next_vertex = None
-            for n in neighbors:
-                if n == prev:
-                    continue
-                if (min(current, n), max(current, n)) in visited_edges:
-                    continue
-                next_vertex = n
-                break
-            if next_vertex is None:
-                break
-            visited_edges.add((min(current, next_vertex), max(current, next_vertex)))
-            loop.append(next_vertex)
-            prev, current = current, next_vertex
-            if next_vertex == start:
-                break
-
-        polygon_points = points[loop]
-        return polygon_points
-
-    @staticmethod
     def compute_hull_outlines_from_geometries(child_geometries: list[Any]) -> list[np.ndarray]:
-        """Compute polygon outlines from geometry child objects.
+        """Compute the wireframe outline from geometry child objects.
 
         Args:
             child_geometries: List of geometry objects containing convex hulls
 
         Returns:
-            List of closed polygons as Nx3 numpy arrays
+            List of line strips as Nx3 numpy arrays
         """
         all_points = []
         for child in child_geometries:
@@ -145,13 +55,13 @@ class HullVisualizer:
 
     @staticmethod
     def compute_hull_outlines_from_points(points: np.ndarray) -> list[np.ndarray]:
-        """Compute polygon outlines directly from point coordinates.
+        """Compute the wireframe outline of the convex hull of the given points.
 
         Args:
             points: List of [x,y,z] coordinates
 
         Returns:
-            List of closed polygons as Nx3 numpy arrays
+            List of line strips as Nx3 numpy arrays
         """
         if len(points) < 4:
             return []
@@ -239,20 +149,31 @@ class HullVisualizer:
 
     @staticmethod
     def _compute_hull_from_points(points: np.ndarray) -> list[np.ndarray]:
-        """Internal helper to compute hull from numpy points array."""
-        try:
-            hull = ConvexHull(points)
-            plane_map = HullVisualizer.group_coplanar_triangles(points, hull)
+        """Internal helper to compute the hull wireframe from a numpy points array.
 
-            polygons = []
-            for simplices in plane_map.values():
-                polygon_points = HullVisualizer.merge_coplanar_triangles_to_polygon(
-                    points, simplices
-                )
-                if len(polygon_points) > 2:
-                    closed_loop = np.vstack([polygon_points, polygon_points[0]])
-                    polygons.append(closed_loop)
-            return polygons
+        The visible edges of a convex hull are the ones whose two adjacent triangles are not
+        coplanar, so trimesh's face adjacency does the coplanar grouping for us. Edges are
+        returned as individual two-point strips - the wireframe looks the same as closed face
+        outlines, and no boundary ordering is needed. That matters because hulls of CAD
+        geometry regularly have faces whose boundary is not a simple cycle.
+        """
+        try:
+            points = np.asarray(points)
+            hull = ConvexHull(points)
+
+            # qhull does not wind the hull triangles consistently, so re-wind them against the
+            # outward plane normals it reports. Without this, two coplanar triangles can appear
+            # to meet at 180 degrees and their shared edge is mistaken for a hull edge.
+            faces = np.array(hull.simplices)
+            windings = np.cross(
+                points[faces[:, 1]] - points[faces[:, 0]], points[faces[:, 2]] - points[faces[:, 0]]
+            )
+            flipped = np.einsum("ij,ij->i", windings, hull.equations[:, :3]) < 0
+            faces[flipped] = faces[flipped][:, ::-1]
+
+            mesh = trimesh.Trimesh(vertices=points, faces=faces, process=False)
+            sharp = mesh.face_adjacency_angles > COPLANAR_ANGLE_TOLERANCE
+            return list(points[mesh.face_adjacency_edges[sharp]])
 
         except QhullError:
             # ConvexHull failed - likely because points are coplanar

--- a/tests/nova_rerun_bridge/test_hull_visualizer.py
+++ b/tests/nova_rerun_bridge/test_hull_visualizer.py
@@ -3,60 +3,95 @@ import pytest
 
 from nova_rerun_bridge.hull_visualizer import HullVisualizer
 
-# One coplanar face of a convex hull computed from CAD collision geometry. The triangles fan
-# out from vertex 3 and partly only touch there, so the face boundary is not a simple cycle:
-# vertex 3 has more than two boundary neighbours. Walking such a boundary while only avoiding
-# the previous vertex circles the same sub-loop forever and never returns to the start vertex.
-PINCHED_FACE_POINTS = np.array(
+CUBE = np.array(
     [
-        [4.9489, 0.591, -1.3391],
-        [-7.8748, 15.4831, -2.4483],
-        [-14.0382, 20.7235, -2.447],
-        [-2.8719, 0.7592, 0.4698],
-        [1.2711, -16.2252, 4.2223],
-        [5.2076, -11.5949, 1.9971],
-        [6.9272, -7.074, 0.3286],
-        [6.4301, -2.6627, -0.7834],
+        [0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [1.0, 1.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [1.0, 0.0, 1.0],
+        [1.0, 1.0, 1.0],
+        [0.0, 1.0, 1.0],
     ]
 )
-PINCHED_FACE_SIMPLICES = [
-    np.array([3, 5, 6]),
-    np.array([3, 1, 2]),
-    np.array([3, 5, 4]),
-    np.array([3, 7, 0]),
-    np.array([3, 7, 6]),
-]
+CUBE_EDGES = {
+    (0, 1),
+    (1, 2),
+    (2, 3),
+    (0, 3),
+    (4, 5),
+    (5, 6),
+    (6, 7),
+    (4, 7),
+    (0, 4),
+    (1, 5),
+    (2, 6),
+    (3, 7),
+}
 
 
-@pytest.mark.timeout(30)
-def test_merge_coplanar_triangles_terminates_on_pinched_boundary():
-    polygon = HullVisualizer.merge_coplanar_triangles_to_polygon(
-        PINCHED_FACE_POINTS, PINCHED_FACE_SIMPLICES
-    )
+def edge_set(strips: list[np.ndarray]) -> set[tuple[int, int]]:
+    """Map line strips back onto CUBE vertex indices, ignoring direction."""
+    lookup = {tuple(np.round(p, 6)): i for i, p in enumerate(CUBE)}
+    edges = set()
+    for strip in strips:
+        indices = [lookup[tuple(np.round(p, 6))] for p in strip]
+        for a, b in zip(indices, indices[1:]):
+            edges.add((min(a, b), max(a, b)))
+    return edges
 
-    # Every boundary edge is walked at most once, so the outline stays bounded.
-    assert 0 < len(polygon) <= 2 * len(PINCHED_FACE_POINTS)
+
+def test_compute_hull_outlines_returns_hull_edges():
+    """A cube outline is its 12 edges - diagonals inside a face must not show up."""
+    assert edge_set(HullVisualizer.compute_hull_outlines_from_points(CUBE)) == CUBE_EDGES
+
+
+def test_compute_hull_outlines_ignores_duplicated_points():
+    """Convex hulls exported from CAD repeat vertices, which must not change the outline."""
+    points = np.vstack([CUBE, CUBE, CUBE])
+
+    assert edge_set(HullVisualizer.compute_hull_outlines_from_points(points)) == CUBE_EDGES
+
+
+def test_compute_hull_outlines_ignores_points_inside_a_face():
+    """Points on a face split it into coplanar triangles; their shared edges are not drawn.
+
+    Such faces are what made the previous plane-grouping implementation hang: their boundary
+    is not always a simple cycle.
+    """
+    face_points = np.array([[0.5, 0.5, 1.0], [0.25, 0.25, 1.0], [0.75, 0.25, 1.0]])
+    points = np.vstack([CUBE, face_points])
+
+    strips = HullVisualizer.compute_hull_outlines_from_points(points)
+
+    drawn = {tuple(np.round(p, 6)) for strip in strips for p in strip}
+    assert drawn == {tuple(np.round(p, 6)) for p in CUBE}
+    assert edge_set(strips) == CUBE_EDGES
 
 
 @pytest.mark.timeout(60)
-def test_compute_hull_outlines_from_duplicated_points():
-    """Convex hulls exported from CAD repeat vertices; outlines must still be produced."""
-    cube = np.array(
-        [
-            [0.0, 0.0, 0.0],
-            [1.0, 0.0, 0.0],
-            [1.0, 1.0, 0.0],
-            [0.0, 1.0, 0.0],
-            [0.0, 0.0, 1.0],
-            [1.0, 0.0, 1.0],
-            [1.0, 1.0, 1.0],
-            [0.0, 1.0, 1.0],
-        ]
-    )
-    points = np.vstack([cube, cube, cube])
+def test_compute_hull_mesh_from_outlines():
+    """The outline of a hull still hulls back into the same solid."""
+    strips = HullVisualizer.compute_hull_outlines_from_points(CUBE)
 
-    polygons = HullVisualizer.compute_hull_outlines_from_points(points)
+    vertices, triangles, normals = HullVisualizer.compute_hull_mesh(strips)
 
-    assert len(polygons) == 6
-    for polygon in polygons:
-        assert np.allclose(polygon[0], polygon[-1])
+    assert len(vertices) == 8
+    assert len(triangles) == 12
+    assert len(normals) == len(vertices)
+
+
+def test_compute_hull_outlines_of_planar_points():
+    """Fully flat input has no 3D hull; it falls back to the 2D outline."""
+    square = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]])
+
+    strips = HullVisualizer.compute_hull_outlines_from_points(square)
+
+    assert len(strips) == 1
+    assert np.allclose(strips[0][0], strips[0][-1])
+    assert len(strips[0]) == 5
+
+
+def test_compute_hull_outlines_needs_four_points():
+    assert HullVisualizer.compute_hull_outlines_from_points(CUBE[:3]) == []


### PR DESCRIPTION
Follow-up to #483, now that it is merged.

## Why

#483 stopped `merge_coplanar_triangles_to_polygon()` from looping forever, but the hand-rolled geometry that made the hang possible is still there:

1. group hull triangles into planes with a rounded normal/offset hash (`group_coplanar_triangles`)
2. walk each plane's boundary edges into a closed polygon (`merge_coplanar_triangles_to_polygon`)

Step 2 is the one that hung. Step 1 has its own problem: two triangles of the same flat face whose normals round to different keys end up in different plane groups, so the triangulation seam between them is drawn as if it were a hull edge.

## What

An edge is visible exactly when its two adjacent triangles are not coplanar — `trimesh` answers that directly:

```python
mesh = trimesh.Trimesh(vertices=points, faces=faces, process=False)
sharp = mesh.face_adjacency_angles > COPLANAR_ANGLE_TOLERANCE
return list(points[mesh.face_adjacency_edges[sharp]])
```

No plane grouping, no boundary ordering, so the class of bug fixed in #483 can no longer occur. Edges come back as two-point strips; all 12 call sites already pass the result straight to `rr.LineStrips3D` (and sometimes `compute_hull_mesh`), both of which render segments and closed polylines identically.

One subtlety worth reviewing: qhull does **not** wind hull triangles consistently, so the triangles are re-wound against the outward plane normals qhull reports in `hull.equations`. Without that, two coplanar triangles appear to meet at 180° and their shared edge survives the filter. Passing `face_normals=` to `Trimesh` does not help — trimesh recomputes them from the winding.

Deletes `plane_from_triangle`, `group_coplanar_triangles` and `merge_coplanar_triangles_to_polygon` (−158/+114 lines), including the walk guard added in #483. The planar-input fallback (`_is_coplanar` / `_compute_2d_hull_polygon`) is unchanged.

## Verification

Compared old vs new outlines over a real collision setup with 681 convex hull colliders, edge set by edge set:

| | |
|---|---|
| colliders with identical outlines | 446 / 681 |
| colliders where the new code **adds** an edge | 0 |
| colliders where the old code drew extra edges | 234 (983 edges) |
| dihedral angle of those 983 edges | ≤ 6e-5° — triangulation seams inside flat faces |
| degenerate zero-length segments emitted | 7037 → 0 (old code appended the start vertex twice) |
| time to compute all outlines | 0.27 s → 0.11 s |

So nothing visible is lost and the near-coplanar seams are gone. The remaining differences all sit within one explicit tolerance constant instead of being decided by two rounding steps in a hash key.

The topology-level regression test from #483 goes away with the function it covered; the new tests cover the contract instead: a cube outlines to exactly its 12 edges, duplicated input vertices do not change that, points lying inside a face are absorbed (the coplanar-face case that used to hang), planar input still falls back to a 2D outline, and the outline still hulls back into the same solid via `compute_hull_mesh`.