### PR TITLE
feat(cell): multi-motion-group planner, synchronized IO and MultiMotionGroup facade

### DIFF
--- a/.github/workflows/nova-run-examples.yaml
+++ b/.github/workflows/nova-run-examples.yaml
@@ -133,6 +133,10 @@ jobs:
             run_cmd: "python examples/multi_motion_group.py"
           - id: bus_io_sync_two_controllers
             run_cmd: "python examples/bus_io_sync_two_controllers.py"
+          # collision-free (RRT) examples are not run in CI: the endpoint is
+          # flaky/unsupported on the virtual instance (see the entry below).
+          # - id: multi_motion_group_facade
+          #   run_cmd: "python examples/multi_motion_group_facade.py"
           # - id: multi_step_movement_with_collision_free
           #   run_cmd: "python examples/multi_step_movement_with_collision_free.py"
           - id: welding

--- a/examples/multi_motion_group_facade.py
+++ b/examples/multi_motion_group_facade.py
@@ -1,0 +1,91 @@
+"""Plan and execute one synchronized ensemble through the MultiMotionGroup facade.
+
+``MultiMotionGroup`` is to several motion groups what ``MotionGroup`` is to one:
+a single object with ``plan`` / ``execute`` / ``plan_and_execute``. Here it plans
+a collision-free move for a robot and a positioner at once (the multi-motion-group
+RRT endpoint), fires an output between the two moves, and runs both groups
+synchronized through an IO barrier — all in one ``plan_and_execute`` call, with
+the same action list feeding both the plan and the execution.
+
+Contrast ``multi_motion_group.py``, which executes a *pre-recorded* trajectory
+through ``TrajectoryExecutor`` directly; this one plans live and adds IO.
+"""
+
+from pathlib import Path
+
+import nova
+from nova import api, run_program
+from nova.actions import io_write, jnt, multi_collision_free
+from nova.cell import MultiMotionGroup, virtual_controller
+
+CONTROLLER = "kuka"
+ROBOT, POSITIONER = f"0@{CONTROLLER}", f"1@{CONTROLLER}"
+TCPS = {ROBOT: "1", POSITIONER: "0"}
+
+# The barrier IO that releases both groups at the same instant, and an output the
+# plan flips between the two synchronized moves (fired on the controller clock,
+# anchored to the motion boundary — location 1, after the first move).
+SYNC_IO_ID = "OUT#1"
+STAGE_DONE_IO_ID = "OUT#2"
+
+_HERE = Path(__file__).parent
+
+
+def recorded() -> api.models.MultiJointTrajectory:
+    """Two known-good joint configs per group, reused here as plan endpoints so the
+    example needs no live poses: sample 0 is the start, the last sample the target."""
+    path = _HERE / "multi_motion_group_trajectory.json"
+    return api.models.MultiJointTrajectory.model_validate_json(path.read_text())
+
+
+def sample(group: str, index: int) -> list[float]:
+    return recorded().joint_positions_by_motion_group_key.root[group].root[index].root
+
+
+@nova.program(
+    name="multi_motion_group_facade",
+    preconditions=nova.ProgramPreconditions(
+        controllers=[
+            virtual_controller(
+                name=CONTROLLER,
+                manufacturer=api.models.Manufacturer.KUKA,
+                type="kuka-kr210_r2700_2",
+                controller_config_json=(_HERE / "multi_motion_group_controller.json").read_text(),
+                # Spawn the robot where the plan starts; ``position`` places the
+                # first motion group only, so the positioner is moved below.
+                position=[*sample(ROBOT, 0), 0.0],
+            )
+        ]
+    ),
+)
+async def multi_motion_group_facade(ctx: nova.ProgramContext):
+    """Plan + synchronized execute of two motion groups via MultiMotionGroup."""
+    controller = await ctx.nova.cell().controller(CONTROLLER)
+    groups = {name: controller.motion_group(name) for name in TCPS}
+
+    # Bring each group to the shared start config before the synchronized run.
+    for name, group in groups.items():
+        await group.plan_and_execute([jnt(sample(name, 0))], tcp=TCPS[name])
+
+    ensemble = (
+        MultiMotionGroup.builder(groups).sync_on_io(SYNC_IO_ID, controller=CONTROLLER).build()
+    )
+
+    start = {name: tuple(sample(name, 0)) for name in TCPS}
+    target = {name: tuple(sample(name, -1)) for name in TCPS}
+
+    # One call plans both collision-free segments (RRT), lays the IO write onto
+    # the seam between them, and runs the ensemble synchronized through the barrier.
+    await ensemble.plan_and_execute(
+        [
+            multi_collision_free(target),
+            io_write(STAGE_DONE_IO_ID, True, device_id=CONTROLLER),
+            multi_collision_free(start),
+        ],
+        tcp=TCPS,
+    )
+    print("synchronized plan_and_execute finished; stage-done output was set at the seam")
+
+
+if __name__ == "__main__":
+    run_program(multi_motion_group_facade)

--- a/nova/actions/__init__.py
+++ b/nova/actions/__init__.py
@@ -11,6 +11,7 @@ from nova.actions.motions import (
     joint_ptp,
     lin,
     linear,
+    multi_collision_free,
     ptp,
 )
 from nova.actions.trajectory_builder import TrajectoryBuilder
@@ -29,6 +30,7 @@ __all__ = [
     "lin",
     "wait",
     "collision_free",
+    "multi_collision_free",
     "MovementController",
     "MovementControllerContext",
     "TrajectoryBuilder",

--- a/nova/actions/container.py
+++ b/nova/actions/container.py
@@ -1,14 +1,42 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Annotated, AsyncIterator, Callable
 
 import pydantic
 
 from nova import api
+from nova.actions.base import Action
 from nova.actions.io import WriteAction
 from nova.actions.mock import WaitAction
 from nova.actions.motions import CollisionFreeMotion, Motion
 from nova.types import MotionSettings, MovementControllerFunction, Pose
+
+
+def located_writes(actions: Iterable[Action]) -> list[tuple[int, WriteAction]]:
+    """Pair each :class:`WriteAction` with its motion index along the path.
+
+    The index is the number of motions preceding the write; waits are skipped
+    and do not advance it. This is the location convention IO rides on — an
+    integer location marks a motion-command boundary — and it is shared by both
+    the single-motion-group (:meth:`CombinedActions.to_set_io`) and the
+    synchronized multi-motion-group IO overlays.
+    """
+    out: list[tuple[int, WriteAction]] = []
+    motion_index = 0
+    for action in actions:
+        if action.is_motion():
+            motion_index += 1
+        elif isinstance(action, WriteAction):
+            out.append((motion_index, action))
+    return out
+
+
+def write_to_set_io(write: WriteAction, location: float) -> api.models.SetIO:
+    """Build the :class:`api.models.SetIO` overlay entry for a write at ``location``."""
+    return api.models.SetIO(
+        io=api.models.IOValue(write.to_api_model()), location=location, io_origin=write.origin
+    )
 
 
 class ActionLocation(pydantic.BaseModel):
@@ -147,15 +175,7 @@ class CombinedActions(pydantic.BaseModel):
         return motion_commands
 
     def to_set_io(self) -> list[api.models.SetIO]:
-        return [
-            api.models.SetIO(
-                io=api.models.IOValue(action.action.to_api_model()),
-                location=action.path_parameter,
-                io_origin=action.action.origin,
-            )
-            for action in self.actions
-            if isinstance(action.action, WriteAction)
-        ]
+        return [write_to_set_io(write, location) for location, write in located_writes(self.items)]
 
 
 # TODO: should not be located here

--- a/nova/actions/motions.py
+++ b/nova/actions/motions.py
@@ -370,6 +370,70 @@ class CollisionFreeMotion(Motion):
         raise NotImplementedError("CollisionFreeMotion.to_api_model is not implemented yet")
 
 
+class MultiCollisionFreeMotion(Action):
+    """A synchronized collision-free motion across several motion groups.
+
+    The multi-group counterpart of :class:`CollisionFreeMotion`: one action that
+    targets every group at once and is planned by the multi-motion-group RRT
+    endpoint into a single, time-synchronized trajectory (all groups sharing one
+    ``times``/``locations``). Unlike :class:`CollisionFreeMotion` it carries no
+    single ``target``; the per-group targets live in :attr:`targets`.
+
+    Attributes:
+        targets: The target per motion group, keyed by name — a pose (resolved
+            via inverse kinematics) or a joint tuple.
+        settings: Optional motion settings per group, folded into that group's
+            planning limits. Groups left out plan at their controller limits.
+        collision_setups: Optional cross-group and environment collision setup
+            per group. ``None`` plans against the groups' own geometry only.
+        algorithm: RRT settings shared by the whole search. ``None`` uses the
+            endpoint default.
+    """
+
+    type: Literal["multi_collision_free"] = "multi_collision_free"
+    targets: dict[str, Pose | tuple[float, ...]]
+    settings: dict[str, MotionSettings] = {}
+    collision_setups: dict[str, api.models.MultiCollisionSetup] | None = None
+    algorithm: api.models.RRTConnectAlgorithm | None = None
+
+    def is_motion(self) -> bool:
+        return True
+
+    def to_api_model(self) -> api.models.MultiSearchCollisionFreeRequest:
+        """"""
+        # The request also needs each group's setup and start joints, which the
+        # action does not carry; MultiMotionGroupPlanner assembles it instead.
+        raise NotImplementedError("MultiCollisionFreeMotion.to_api_model is not implemented")
+
+
+def multi_collision_free(
+    targets: dict[str, Pose | tuple[float, ...]],
+    settings: dict[str, MotionSettings] | None = None,
+    collision_setups: dict[str, api.models.MultiCollisionSetup] | None = None,
+    algorithm: api.models.RRTConnectAlgorithm | None = None,
+    **kwargs: Any,
+) -> MultiCollisionFreeMotion:
+    """Convenience factory for a synchronized collision-free motion.
+
+    Args:
+        targets: The target per motion group (pose or joint tuple), keyed by name.
+        settings: Optional per-group motion settings.
+        collision_setups: Optional per-group collision setup.
+        algorithm: Shared RRT settings; ``None`` uses the endpoint default.
+
+    Returns:
+        The multi-motion-group collision-free motion.
+    """
+    kwargs.update(utils.get_caller_metas())
+    return MultiCollisionFreeMotion(
+        targets=targets,
+        settings=settings or {},
+        collision_setups=collision_setups,
+        algorithm=algorithm,
+        metas=kwargs,
+    )
+
+
 def collision_free(
     target: Pose | tuple[float, ...],
     settings: MotionSettings = MotionSettings(),

--- a/nova/cell/__init__.py
+++ b/nova/cell/__init__.py
@@ -10,6 +10,7 @@ from nova.cell.controllers import (
 )
 from nova.cell.motion_group import MotionGroup
 from nova.cell.motion_group_models import MotionGroupModel
+from nova.cell.multi_motion_group_planner import MultiMotionGroupPlanner
 from nova.cell.multi_trajectory_cursor import (
     IOSyncConfig,
     IOSyncDriver,
@@ -33,6 +34,7 @@ __all__ = [
     "IOSyncDriver",
     "MotionGroup",
     "MotionGroupModel",
+    "MultiMotionGroupPlanner",
     "MultiTrajectoryCursor",
     "SessionMonitor",
     "SyncDriftError",

--- a/nova/cell/__init__.py
+++ b/nova/cell/__init__.py
@@ -10,6 +10,7 @@ from nova.cell.controllers import (
 )
 from nova.cell.motion_group import MotionGroup
 from nova.cell.motion_group_models import MotionGroupModel
+from nova.cell.multi_motion_group import MultiMotionGroup, MultiMotionGroupBuilder
 from nova.cell.multi_motion_group_planner import MultiMotionGroupPlanner
 from nova.cell.multi_trajectory_cursor import (
     IOSyncConfig,
@@ -34,6 +35,8 @@ __all__ = [
     "IOSyncDriver",
     "MotionGroup",
     "MotionGroupModel",
+    "MultiMotionGroup",
+    "MultiMotionGroupBuilder",
     "MultiMotionGroupPlanner",
     "MultiTrajectoryCursor",
     "SessionMonitor",

--- a/nova/cell/multi_motion_group.py
+++ b/nova/cell/multi_motion_group.py
@@ -1,0 +1,145 @@
+"""One synchronized ensemble of motion groups, planned and executed as a unit.
+
+:class:`MultiMotionGroup` is to several motion groups what :class:`MotionGroup`
+is to one: a single object exposing ``plan`` / ``execute`` / ``plan_and_execute``.
+It is a thin facade over the two halves that already do the work —
+:class:`~nova.cell.multi_motion_group_planner.MultiMotionGroupPlanner` for
+planning and :class:`~nova.cell.trajectory_executor.TrajectoryExecutor` for
+synchronized execution — sharing one action list across both, exactly as
+:meth:`MotionGroup.plan_and_execute` passes ``actions`` to both its own halves.
+
+    ```python
+    ensemble = (
+        MultiMotionGroup.builder({"0@robot": robot_mg, "0@positioner": positioner_mg})
+        .sync_on_io("sync_out", controller="robot")
+        .build()
+    )
+    await ensemble.plan_and_execute(
+        [
+            multi_collision_free({"0@robot": Pose(...), "0@positioner": (j1, ..., j6)}),
+            io_write("OUT#1", True, device_id="robot"),
+        ],
+        tcp={"0@robot": "flange", "0@positioner": None},
+    )
+    ```
+
+The ensemble is cell-scoped because planning is: the multi-motion-group RRT
+endpoint reasons about the groups' mutual geometry in a single, cell-scoped
+request. Execution itself may span cells (only the IO barrier is cell-bound),
+so the planner is built lazily — an execute-only ensemble of a pre-planned
+trajectory never triggers the single-cell requirement.
+"""
+
+from collections.abc import AsyncGenerator, Iterable, Mapping
+from contextlib import asynccontextmanager
+
+from nova import api
+from nova.cell.motion_group import MotionGroup
+from nova.cell.multi_motion_group_planner import MultiMotionGroupPlanner
+from nova.cell.multi_trajectory_cursor import MultiTrajectoryCursor
+from nova.cell.robot_cell import ActionsLike
+from nova.cell.trajectory_executor import GroupArgs, TrajectoryExecutor, TrajectoryExecutorBuilder
+
+
+class MultiMotionGroup:
+    """A synchronized ensemble of motion groups planned and executed as a unit.
+
+    Built with :meth:`builder`, which states the sync barrier the same way
+    :class:`TrajectoryExecutor` does. ``plan`` and ``execute`` take the same
+    ensemble action list; ``plan_and_execute`` chains them, mirroring
+    :meth:`MotionGroup.plan_and_execute`.
+    """
+
+    def __init__(self, executor: TrajectoryExecutor):
+        self._executor = executor
+        # Planning is cell-scoped, execution need not be — so the planner is
+        # only constructed when a plan is actually requested.
+        self._planner: MultiMotionGroupPlanner | None = None
+
+    @property
+    def motion_groups(self) -> dict[str, MotionGroup]:
+        """The motion groups in this ensemble, keyed by name."""
+        return self._executor.motion_groups
+
+    def _get_planner(self) -> MultiMotionGroupPlanner:
+        if self._planner is None:
+            self._planner = MultiMotionGroupPlanner(self._executor.motion_groups)
+        return self._planner
+
+    async def plan(
+        self,
+        actions: ActionsLike,
+        tcp: Mapping[str, str | None] | str | None = None,
+        start_joint_position: Mapping[str, tuple[float, ...]] | None = None,
+    ) -> api.models.MultiJointTrajectory:
+        """Plan one synchronized collision-free trajectory for the action list.
+
+        Delegates to :meth:`MultiMotionGroupPlanner.plan`; see it for the action
+        types, the per-group ``tcp``/``start_joint_position`` and the raised
+        errors. Returns a pure trajectory — :class:`WriteAction` entries carry no
+        joint samples and become the IO overlay only at :meth:`execute` time.
+        """
+        return await self._get_planner().plan(actions, tcp, start_joint_position)
+
+    async def execute(
+        self,
+        trajectory: api.models.MultiJointTrajectory,
+        actions: ActionsLike | None = None,
+        groups: Mapping[str, GroupArgs] | None = None,
+    ) -> None:
+        """Execute the trajectory front to end, synchronized through the barrier.
+
+        Pass the same ``actions`` list given to :meth:`plan` to fire its
+        location-anchored IO. Delegates to :meth:`TrajectoryExecutor.execute`.
+        """
+        await self._executor.execute(trajectory, actions=actions, groups=groups)
+
+    @asynccontextmanager
+    async def attach(
+        self,
+        trajectory: api.models.MultiJointTrajectory,
+        actions: ActionsLike | None = None,
+        groups: Mapping[str, GroupArgs] | None = None,
+    ) -> AsyncGenerator[MultiTrajectoryCursor, None]:
+        """Open an interactive session over the trajectory, delegating to
+        :meth:`TrajectoryExecutor.attach`."""
+        async with self._executor.attach(trajectory, actions=actions, groups=groups) as cursor:
+            yield cursor
+
+    async def plan_and_execute(
+        self,
+        actions: ActionsLike,
+        tcp: Mapping[str, str | None] | str | None = None,
+        start_joint_position: Mapping[str, tuple[float, ...]] | None = None,
+        groups: Mapping[str, GroupArgs] | None = None,
+    ) -> None:
+        """Plan and execute in one call, passing ``actions`` to both halves — the
+        multi-group counterpart of :meth:`MotionGroup.plan_and_execute`."""
+        trajectory = await self.plan(actions, tcp, start_joint_position)
+        await self.execute(trajectory, actions=actions, groups=groups)
+
+    @classmethod
+    def builder(
+        cls, motion_groups: Mapping[str, MotionGroup] | Iterable[MotionGroup]
+    ) -> "MultiMotionGroupBuilder":
+        """Start fluent assembly: ``MultiMotionGroup.builder(...)...build()``.
+
+        Takes the motion groups the same way :meth:`TrajectoryExecutor.builder`
+        does — a mapping of names, or just the groups keyed by their ids.
+        """
+        return MultiMotionGroupBuilder(motion_groups)
+
+
+class MultiMotionGroupBuilder(TrajectoryExecutorBuilder):
+    """Fluent assembly of a :class:`MultiMotionGroup`.
+
+    Identical to :class:`TrajectoryExecutorBuilder` — same ``sync_on_io`` /
+    ``release_io`` / ``clear_io`` / ``watch`` / ``monitors`` — but :meth:`build`
+    returns a :class:`MultiMotionGroup` wrapping the executor it assembles.
+    """
+
+    # Narrows the return type past the base builder's TrajectoryExecutor: a
+    # MultiMotionGroupBuilder is only ever used as itself, never through a
+    # TrajectoryExecutorBuilder reference expecting build() -> TrajectoryExecutor.
+    def build(self) -> MultiMotionGroup:  # ty: ignore[invalid-method-override]
+        return MultiMotionGroup(super().build())

--- a/nova/cell/multi_motion_group_planner.py
+++ b/nova/cell/multi_motion_group_planner.py
@@ -1,0 +1,270 @@
+"""Collision-free planning of one synchronized trajectory across motion groups.
+
+:class:`MultiMotionGroupPlanner` is to :class:`MotionGroup.plan` what
+:class:`TrajectoryExecutor` is to :meth:`MotionGroup.execute`: the multi-group
+counterpart. ``plan`` takes one ensemble action list — the same shape
+:meth:`MotionGroup.plan` accepts — and returns the
+:class:`api.models.MultiJointTrajectory` the executor consumes, so the two
+compose end to end:
+
+    ```python
+    planner = MultiMotionGroupPlanner({"0@kuka": robot_mg, "1@kuka": positioner_mg})
+    trajectory = await planner.plan(
+        [
+            multi_collision_free({"0@kuka": Pose(...), "1@kuka": (j1, j2, j3, j4, j5, j6)}),
+            wait(0.5),
+            multi_collision_free({"0@kuka": (...), "1@kuka": (...)}),
+        ],
+        tcp={"0@kuka": "1", "1@kuka": "0"},
+    )
+
+    executor = TrajectoryExecutor.builder(planner.motion_groups).sync_on_io("OUT#1").build()
+    await executor.execute(trajectory)
+    ```
+
+The batch logic mirrors :meth:`MotionGroup.plan`: a
+:class:`~nova.actions.motions.MultiCollisionFreeMotion` is planned by the
+multi-motion-group RRT endpoint (``search_collision_free_multi_motion_group``)
+into a synchronized segment; a :class:`~nova.actions.mock.WaitAction` becomes an
+ensemble hold; segments are concatenated into one shared ``times``/``locations``
+— the invariant synchronized execution rests on.
+
+Like :meth:`MotionGroup.plan`, ``plan`` returns a pure trajectory: a
+:class:`~nova.actions.io.WriteAction` in the action list contributes no joint
+samples and is ignored here. Its location-anchored IO overlay is derived from
+the same action list at execute time, by
+:meth:`~nova.cell.trajectory_executor.TrajectoryExecutor.execute` — so the
+``actions`` list is passed to both, exactly as in the single-motion-group flow.
+"""
+
+from collections.abc import Iterable, Mapping
+
+from nova import api
+from nova.actions.io import WriteAction
+from nova.actions.mock import WaitAction
+from nova.actions.motions import MultiCollisionFreeMotion
+from nova.cell.motion_group import MotionGroup, _find_and_sort_best_joint_solutions
+from nova.cell.robot_cell import ActionsLike, _normalize_actions
+from nova.exceptions import NoInverseKinematicsSolutionFound, PlanTrajectoryFailed
+from nova.types import Pose
+from nova.utils.joint_trajectory import combine_multi_trajectories
+
+_WAIT_TIMESTEP = 0.050  # 50 ms, matching MotionGroup._build_wait_trajectory
+
+
+class MultiMotionGroupPlanner:
+    """Plan one synchronized, collision-free trajectory across several motion groups.
+
+    Created once for the motion groups to coordinate; ``plan`` is called per
+    action list. All groups must live in one cell — the RRT endpoint is
+    cell-scoped and reasons about their mutual geometry in a single request.
+    """
+
+    def __init__(self, motion_groups: Mapping[str, MotionGroup] | Iterable[MotionGroup]):
+        self._motion_groups = (
+            dict(motion_groups)
+            if isinstance(motion_groups, Mapping)
+            else {motion_group.id: motion_group for motion_group in motion_groups}
+        )
+        if not self._motion_groups:
+            raise ValueError("At least one motion group is required")
+
+        cells = {motion_group._cell for motion_group in self._motion_groups.values()}
+        if len(cells) > 1:
+            raise ValueError(
+                f"Multi-motion-group planning is cell-scoped but the motion groups span "
+                f"{sorted(cells)}. Plan one cell at a time."
+            )
+        self._cell = next(iter(cells))
+        # Controllers in a cell share the cell's gateway; the single RRT request
+        # goes to one, so pin it here.
+        self._api_client = next(iter(self._motion_groups.values()))._api_client
+
+    @property
+    def motion_groups(self) -> dict[str, MotionGroup]:
+        """The motion groups this planner coordinates, keyed by name.
+
+        Handy to hand straight to :meth:`TrajectoryExecutor.builder`."""
+        return dict(self._motion_groups)
+
+    async def plan(
+        self,
+        actions: ActionsLike,
+        tcp: Mapping[str, str | None] | str | None = None,
+        start_joint_position: Mapping[str, tuple[float, ...]] | None = None,
+    ) -> api.models.MultiJointTrajectory:
+        """Plan a synchronized collision-free trajectory for the action list.
+
+        Mirrors :meth:`MotionGroup.plan`: an ensemble action list is batched and
+        each batch planned in turn, every segment continuing from the previous
+        one's end, then all concatenated into a single shared parameterization.
+
+        Args:
+            actions: The ensemble actions — one or a sequence of
+                :class:`~nova.actions.motions.MultiCollisionFreeMotion` (each
+                planned by RRT into a synchronized segment),
+                :class:`~nova.actions.mock.WaitAction` (an ensemble hold) and
+                :class:`~nova.actions.io.WriteAction` (ignored here — it carries
+                no joint samples; pass the same list to the executor for its IO
+                overlay). Every motion's ``targets`` must cover exactly the
+                planner's groups.
+            tcp: The TCP per group, or a single TCP shared by all. Required for
+                any group whose target is a pose (for inverse kinematics); also
+                selects the motion group setup. ``None`` for a group means no TCP.
+            start_joint_position: The start joint position per group. A group
+                left out starts from its current joints.
+
+        Returns:
+            The synchronized trajectory, ready for :meth:`TrajectoryExecutor.execute`.
+
+        Raises:
+            ValueError: An action type has no place in a collision-free plan, or
+                a motion's targets do not match the planner's motion groups.
+            PlanTrajectoryFailed: The RRT search found no coordinated path.
+            NoInverseKinematicsSolutionFound: A pose target has no IK solution.
+        """
+        actions_list = _normalize_actions(actions)
+        if not actions_list:
+            raise ValueError("No actions provided")
+
+        setups = {
+            name: await motion_group.get_setup(tcp_name=self._tcp_for(name, tcp))
+            for name, motion_group in self._motion_groups.items()
+        }
+        current: dict[str, tuple[float, ...]] = {
+            name: (start_joint_position or {}).get(name) or await motion_group.joints()
+            for name, motion_group in self._motion_groups.items()
+        }
+
+        segments: list[api.models.MultiJointTrajectory] = []
+        for action in actions_list:
+            if isinstance(action, MultiCollisionFreeMotion):
+                segment = await self._plan_multi_collision_free(action, tcp, current, setups)
+            elif isinstance(action, WaitAction):
+                segment = self._build_wait_segment(current, action.wait_for_in_seconds)
+            elif isinstance(action, WriteAction):
+                # IO is not baked into the trajectory: exactly as in
+                # MotionGroup.plan, a WriteAction contributes no joint samples and
+                # is ignored here. Its location-anchored overlay is derived from
+                # the same action list at execute time
+                # (TrajectoryExecutor.execute(..., actions=...)).
+                continue
+            else:
+                raise ValueError(
+                    f"Action type '{type(action).__name__}' is not supported by synchronized "
+                    "collision-free planning; use multi_collision_free(), wait() or io_write()."
+                )
+            # The segment's last sample is the next batch's start, per group.
+            for name, samples in segment.joint_positions_by_motion_group_key.root.items():
+                current[name] = tuple(samples.root[-1].root)
+            segments.append(segment)
+
+        return combine_multi_trajectories(segments)
+
+    def _tcp_for(self, name: str, tcp: Mapping[str, str | None] | str | None) -> str | None:
+        return tcp.get(name) if isinstance(tcp, Mapping) else tcp
+
+    async def _plan_multi_collision_free(
+        self,
+        action: MultiCollisionFreeMotion,
+        tcp: Mapping[str, str | None] | str | None,
+        current: Mapping[str, tuple[float, ...]],
+        setups: Mapping[str, api.models.MotionGroupSetup],
+    ) -> api.models.MultiJointTrajectory:
+        if set(action.targets) != set(self._motion_groups):
+            raise ValueError(
+                f"Motion targets {sorted(action.targets)} must match the planner's "
+                f"motion groups {sorted(self._motion_groups)}"
+            )
+
+        path_definitions: dict[str, api.models.JointPTPMotion] = {}
+        for name, target in action.targets.items():
+            motion_group = self._motion_groups[name]
+            group_tcp = self._tcp_for(name, tcp)
+            start = current[name]
+            target_joints = await self._resolve_target(
+                target, group_tcp, start, motion_group, setups[name]
+            )
+            settings = action.settings.get(name)
+            path_definitions[name] = api.models.JointPTPMotion(
+                start_joint_position=api.models.DoubleArray(list(start)),
+                target_joint_position=api.models.DoubleArray(list(target_joints)),
+                limits_override=(
+                    settings.as_limits_settings()
+                    if settings is not None and settings.has_limits_override()
+                    else None
+                ),
+            )
+
+        request = api.models.MultiSearchCollisionFreeRequest(
+            motion_group_setups_by_motion_group_key=api.models.MotionGroupSetupDictionary(
+                dict(setups)
+            ),
+            path_definitions_by_motion_group_key=api.models.JointPTPMotionDictionary(
+                path_definitions
+            ),
+            collision_setups=(
+                api.models.MultiCollisionSetupDictionary(dict(action.collision_setups))
+                if action.collision_setups is not None
+                else None
+            ),
+            algorithm_settings=action.algorithm,
+        )
+
+        response = (
+            await self._api_client.trajectory_planning_api.search_collision_free_multi_motion_group(
+                cell=self._cell, multi_search_collision_free_request=request
+            )
+        )
+
+        if isinstance(response.response, api.models.PlanCollisionFreeFailedResponse):
+            raise PlanTrajectoryFailed(
+                error=response.response, motion_group_id=", ".join(sorted(self._motion_groups))
+            )
+        if not isinstance(response.response, api.models.MultiJointTrajectory):
+            raise ValueError("Multi-motion-group planning returned no trajectory")
+        return response.response
+
+    def _build_wait_segment(
+        self, current: Mapping[str, tuple[float, ...]], wait_time: float
+    ) -> api.models.MultiJointTrajectory:
+        """Hold every group at its current joints for ``wait_time`` seconds.
+
+        The multi-group counterpart of ``MotionGroup._build_wait_trajectory``:
+        50 ms steps, locations flat at 0 (a hold makes no path progress)."""
+        num_steps = max(2, int(wait_time / _WAIT_TIMESTEP) + 1)
+        times = [i * _WAIT_TIMESTEP for i in range(num_steps)]
+        times[-1] = wait_time
+        return api.models.MultiJointTrajectory(
+            joint_positions_by_motion_group_key={
+                name: [api.models.Joints(list(joints)) for _ in range(num_steps)]
+                for name, joints in current.items()
+            },
+            times=times,
+            locations=[api.models.Location(0.0) for _ in range(num_steps)],
+        )
+
+    async def _resolve_target(
+        self,
+        target: Pose | tuple[float, ...],
+        tcp: str | None,
+        start: tuple[float, ...],
+        motion_group: MotionGroup,
+        setup: api.models.MotionGroupSetup,
+    ) -> tuple[float, ...]:
+        """Resolve a target to joints, solving IK for a pose and picking the
+        solution closest to the start."""
+        if isinstance(target, tuple):
+            return target
+        if tcp is None:
+            raise ValueError(
+                f"TCP is required for a pose target on '{motion_group.id}'; pass tcp or use a "
+                "joint-space target instead."
+            )
+        solutions = await motion_group._inverse_kinematics(
+            poses=[target], tcp=tcp, motion_group_setup=setup
+        )
+        if not solutions or not solutions[0]:
+            raise NoInverseKinematicsSolutionFound(target)
+        joint_limits = setup.global_limits.joints if setup.global_limits is not None else None
+        return _find_and_sort_best_joint_solutions(start, solutions[0], joint_limits)[0]

--- a/nova/cell/trajectory_executor.py
+++ b/nova/cell/trajectory_executor.py
@@ -145,6 +145,11 @@ class TrajectoryExecutor:
         self._monitors = tuple(monitors)
         self._sync = sync
 
+    @property
+    def motion_groups(self) -> dict[str, MotionGroup]:
+        """The motion groups this executor drives, keyed by name."""
+        return dict(self._motion_groups)
+
     async def execute(
         self,
         trajectory: api.models.MultiJointTrajectory,

--- a/nova/cell/trajectory_executor.py
+++ b/nova/cell/trajectory_executor.py
@@ -44,6 +44,7 @@ from dataclasses import dataclass
 from typing import Self
 
 from nova import api
+from nova.actions.container import located_writes, write_to_set_io
 from nova.actions.io import WriteAction, io_write
 from nova.cell.motion_group import MotionGroup
 from nova.cell.movement_controller.trajectory_cursor import MovementOption, TrajectoryCursor
@@ -54,6 +55,7 @@ from nova.cell.multi_trajectory_cursor import (
     SyncDriver,
     _StreamBroadcaster,
 )
+from nova.cell.robot_cell import ActionsLike, _normalize_actions
 from nova.cell.session_monitor import SessionMonitor, SyncDriftMonitor
 
 
@@ -61,10 +63,11 @@ from nova.cell.session_monitor import SessionMonitor, SyncDriftMonitor
 class GroupArgs:
     """Per-group arguments for one execution.
 
-    Actions are not part of this: an action list belongs to one motion group's
-    trajectory, whose integer locations are *its* action boundaries, and the
-    ensemble has one shared parameterization instead. Synchronized execution
-    therefore carries no action metadata and no IO overlay derived from it.
+    Actions are not part of this: the ensemble action list is one shared list,
+    not per group, and is passed straight to :meth:`TrajectoryExecutor.execute`
+    /:meth:`~TrajectoryExecutor.attach`. The executor routes each write to the
+    owning group and anchors it on the shared ``locations`` parameterization,
+    so no per-group action metadata is needed here.
 
     Attributes:
         tcp: TCP the trajectory was planned for; passed to trajectory loading.
@@ -145,26 +148,45 @@ class TrajectoryExecutor:
     async def execute(
         self,
         trajectory: api.models.MultiJointTrajectory,
+        actions: ActionsLike | None = None,
         groups: Mapping[str, GroupArgs] | None = None,
     ) -> None:
-        """Execute the trajectory front to end, synchronized through the barrier."""
-        async with self.attach(trajectory, groups) as cursor:
+        """Execute the trajectory front to end, synchronized through the barrier.
+
+        ``actions`` is the same ensemble action list passed to
+        :meth:`MultiMotionGroupPlanner.plan`; its :class:`WriteAction` entries
+        become the location-anchored IO overlay fired during execution (see
+        :meth:`attach`)."""
+        async with self.attach(trajectory, actions=actions, groups=groups) as cursor:
             await cursor.forward()
 
     @asynccontextmanager
     async def attach(
         self,
         trajectory: api.models.MultiJointTrajectory,
+        actions: ActionsLike | None = None,
         groups: Mapping[str, GroupArgs] | None = None,
     ) -> AsyncGenerator[MultiTrajectoryCursor, None]:
         """Open a session for interactive control: load the trajectory, open the
         sockets, initialize — but do not move. Starting is the caller's call
         (:meth:`MultiTrajectoryCursor.forward`); exiting the context detaches
-        every cursor and closes every socket."""
+        every cursor and closes every socket.
+
+        ``actions`` mirrors the list given to
+        :meth:`MultiMotionGroupPlanner.plan`. It is not baked into the loaded
+        trajectory: each :class:`WriteAction` is turned into a
+        :class:`api.models.SetIO` anchored at its motion index (the count of
+        motions before it, waits skipped — the same convention as single-group
+        execution) and attached to the owning group's cursor, which re-emits the
+        overlay on every start. Every write is fired once, by the single group
+        it routes to; since all groups share one ``locations`` array that instant
+        is synchronized across the ensemble."""
         per_group = self._split_for_groups(trajectory)
         unknown_group_args = set(groups or {}) - set(self._motion_groups)
         if unknown_group_args:
             raise ValueError(f"Group args given for unknown groups: {sorted(unknown_group_args)}")
+
+        overlay = self._build_io_overlay(actions)
 
         cursors: dict[str, TrajectoryCursor] = {}
         broadcasters: dict[str, _StreamBroadcaster[api.models.MotionGroupState]] = {}
@@ -181,6 +203,7 @@ class TrajectoryExecutor:
                 detach_on_standstill=False,
                 emit_motion_events=False,
                 ignore_controller_limits=group_args.ignore_controller_limits,
+                set_outputs=overlay[name] or None,
             )
             cursors[name] = cursor
             broadcasters[name] = _StreamBroadcaster(cursor)
@@ -242,6 +265,47 @@ class TrajectoryExecutor:
             )
             for key, joint_samples in joint_positions_by_group.items()
         }
+
+    def _build_io_overlay(self, actions: ActionsLike | None) -> dict[str, list[api.models.SetIO]]:
+        """Turn the action list's writes into a per-group ``SetIO`` overlay.
+
+        Each write is routed to exactly one group and anchored at its motion
+        index; all other groups get an empty list."""
+        overlay: dict[str, list[api.models.SetIO]] = {name: [] for name in self._motion_groups}
+        for motion_index, write in located_writes(_normalize_actions(actions or [])):
+            group = self._route_write(write)
+            overlay[group].append(write_to_set_io(write, motion_index))
+        return overlay
+
+    def _route_write(self, write: WriteAction) -> str:
+        """Pick the single group whose execute stream fires this write.
+
+        A controller output goes to the group on that controller; a cell-wide
+        bus variable goes to one deterministic group (all groups share the
+        ``locations`` array, so which one carries it does not change the instant).
+        """
+        if write.origin is api.models.IOOrigin.BUS_IO:
+            return min(self._motion_groups)
+
+        controllers = {
+            name: motion_group._controller_id for name, motion_group in self._motion_groups.items()
+        }
+        if write.device_id is None:
+            distinct = set(controllers.values())
+            if len(distinct) > 1:
+                raise ValueError(
+                    f"The controller for IO '{write.key}' is ambiguous: the motion groups span "
+                    f"controllers {sorted(distinct)}. Set the write's device_id explicitly."
+                )
+            return min(self._motion_groups)
+
+        matching = sorted(name for name, ctrl in controllers.items() if ctrl == write.device_id)
+        if not matching:
+            raise ValueError(
+                f"No motion group is on controller '{write.device_id}' for IO '{write.key}'; "
+                f"known controllers are {sorted(set(controllers.values()))}."
+            )
+        return matching[0]
 
     async def _run_execute_trajectory(self, name: str, cursor: TrajectoryCursor) -> None:
         # Addressed through the group's own cell and gateway: executing does not

--- a/nova/utils/joint_trajectory.py
+++ b/nova/utils/joint_trajectory.py
@@ -27,3 +27,43 @@ def combine_trajectories(
         current_end_location = final_trajectory.locations[-1]
 
     return final_trajectory
+
+
+def combine_multi_trajectories(
+    trajectories: list[api.models.MultiJointTrajectory],
+) -> api.models.MultiJointTrajectory:
+    """Concatenate synchronized multi-motion-group trajectories end to end.
+
+    The multi-group counterpart of :func:`combine_trajectories`: every segment
+    shares one ``times``/``locations`` across all its groups, and the seam shifts
+    later segments to continue from the previous end — so the result keeps the
+    single shared parameterization synchronized execution rests on. All segments
+    must cover the same set of motion groups.
+    """
+    final_trajectory = trajectories[0]
+    keys = set(final_trajectory.joint_positions_by_motion_group_key.root)
+    current_end_time = final_trajectory.times[-1]
+    current_end_location = final_trajectory.locations[-1]
+
+    for trajectory in trajectories[1:]:
+        if set(trajectory.joint_positions_by_motion_group_key.root) != keys:
+            raise ValueError(
+                "All segments must cover the same motion groups; got "
+                f"{sorted(trajectory.joint_positions_by_motion_group_key.root)} vs {sorted(keys)}"
+            )
+
+        # Skip each segment's first point: it duplicates the previous seam.
+        final_trajectory.times.extend(t + current_end_time for t in trajectory.times[1:])
+        final_trajectory.locations.extend(
+            api.models.Location(location.root + current_end_location.root)
+            for location in trajectory.locations[1:]
+        )
+        for key, samples in trajectory.joint_positions_by_motion_group_key.root.items():
+            final_trajectory.joint_positions_by_motion_group_key.root[key].root.extend(
+                samples.root[1:]
+            )
+
+        current_end_time = final_trajectory.times[-1]
+        current_end_location = final_trajectory.locations[-1]
+
+    return final_trajectory

--- a/tests/actions/test_located_writes.py
+++ b/tests/actions/test_located_writes.py
@@ -1,0 +1,55 @@
+"""Tests for the shared IO-overlay helpers in ``nova.actions.container``.
+
+``located_writes`` anchors each write on the count of preceding motions (waits
+skipped); ``to_set_io`` builds on it and must keep its historical behavior."""
+
+from nova import api
+from nova.actions.container import CombinedActions, located_writes, write_to_set_io
+from nova.actions.io import io_write
+from nova.actions.mock import wait
+from nova.actions.motions import joint_ptp
+
+
+def _ptp(sample: float):
+    return joint_ptp((sample,) * 6)
+
+
+class TestLocatedWrites:
+    def test_index_counts_preceding_motions(self):
+        writes = located_writes(
+            [
+                io_write("OUT#0", True),  # 0 motions before
+                _ptp(1.0),
+                io_write("OUT#1", True),  # 1 motion before
+                _ptp(2.0),
+                _ptp(3.0),
+                io_write("OUT#3", True),  # 3 motions before
+            ]
+        )
+        assert [(index, w.key) for index, w in writes] == [(0, "OUT#0"), (1, "OUT#1"), (3, "OUT#3")]
+
+    def test_wait_does_not_advance_index(self):
+        writes = located_writes([_ptp(1.0), wait(0.5), io_write("OUT#1", True)])
+        assert [index for index, _ in writes] == [1]
+
+    def test_no_writes__empty(self):
+        assert located_writes([_ptp(1.0), wait(0.5)]) == []
+
+    def test_write_to_set_io_carries_value_location_and_origin(self):
+        write = io_write("OUT#1", True, origin=api.models.IOOrigin.BUS_IO)
+        set_io = write_to_set_io(write, 2)
+        assert set_io.location == 2
+        assert set_io.io_origin is api.models.IOOrigin.BUS_IO
+        assert set_io.io.root.io == "OUT#1"
+
+
+class TestToSetIoRegression:
+    def test_matches_located_writes_over_mixed_list(self):
+        items = [_ptp(1.0), io_write("OUT#1", True), wait(0.5), _ptp(2.0), io_write("OUT#2", False)]
+        combined = CombinedActions(items=tuple(items))
+
+        result = combined.to_set_io()
+
+        assert [s.location for s in result] == [1, 2]
+        assert [s.io.root.io for s in result] == ["OUT#1", "OUT#2"]
+        assert [s.io.root.value for s in result] == [True, False]

--- a/tests/cell/test_multi_motion_group.py
+++ b/tests/cell/test_multi_motion_group.py
@@ -1,0 +1,123 @@
+"""Tests for the MultiMotionGroup facade: that it assembles the executor through
+the shared builder and delegates plan/execute/plan_and_execute to the two halves
+(the planner and the executor, each covered end to end in its own suite)."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nova.actions.io import io_write
+from nova.actions.motions import multi_collision_free
+from nova.cell.multi_motion_group import MultiMotionGroup, MultiMotionGroupBuilder
+from nova.cell.trajectory_executor import GroupArgs, TrajectoryExecutor
+from tests.cell.multi_group_doubles import IOGateway, motion_group
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestBuilder:
+    def test_builder_returns_a_multi_motion_group_builder(self):
+        builder = MultiMotionGroup.builder({"a": motion_group(IOGateway())})
+        assert isinstance(builder, MultiMotionGroupBuilder)
+
+    def test_build_wraps_a_trajectory_executor_with_the_same_groups(self):
+        gateway = IOGateway()
+        groups = {"a": motion_group(gateway), "b": motion_group(gateway)}
+
+        ensemble = (
+            MultiMotionGroup.builder(groups)
+            .sync_on_io("sync-io", controller="controller-a")
+            .build()
+        )
+
+        assert isinstance(ensemble, MultiMotionGroup)
+        assert isinstance(ensemble._executor, TrajectoryExecutor)
+        assert set(ensemble.motion_groups) == {"a", "b"}
+
+
+def _fake_executor() -> MagicMock:
+    executor = MagicMock(spec=TrajectoryExecutor)
+    executor.execute = AsyncMock()
+    executor.motion_groups = {"a": object(), "b": object()}
+    return executor
+
+
+class TestDelegation:
+    async def test_plan_delegates_to_the_planner(self):
+        ensemble = MultiMotionGroup(_fake_executor())
+        ensemble._planner = MagicMock(plan=AsyncMock(return_value="TRAJ"))
+        actions = [multi_collision_free({"a": (0.0,) * 6})]
+
+        result = await ensemble.plan(actions, tcp="flange", start_joint_position={"a": (0.1,) * 6})
+
+        ensemble._planner.plan.assert_awaited_once_with(actions, "flange", {"a": (0.1,) * 6})
+        assert result == "TRAJ"
+
+    async def test_execute_delegates_to_the_executor(self):
+        executor = _fake_executor()
+        ensemble = MultiMotionGroup(executor)
+        actions = [io_write("OUT#1", True, device_id="c")]
+        group_args = {"a": GroupArgs()}
+
+        await ensemble.execute("TRAJ", actions=actions, groups=group_args)
+
+        executor.execute.assert_awaited_once_with("TRAJ", actions=actions, groups=group_args)
+
+    async def test_attach_delegates_to_the_executor(self):
+        executor = _fake_executor()
+
+        @asynccontextmanager
+        async def fake_attach(trajectory, actions=None, groups=None):
+            fake_attach.args = (trajectory, actions, groups)
+            yield "CURSOR"
+
+        executor.attach = fake_attach
+        ensemble = MultiMotionGroup(executor)
+        actions = [io_write("OUT#1", True, device_id="c")]
+
+        async with ensemble.attach("TRAJ", actions=actions) as cursor:
+            assert cursor == "CURSOR"
+        assert fake_attach.args == ("TRAJ", actions, None)
+
+    async def test_plan_and_execute_chains_the_same_actions_into_both_halves(self):
+        executor = _fake_executor()
+        ensemble = MultiMotionGroup(executor)
+        ensemble._planner = MagicMock(plan=AsyncMock(return_value="TRAJ"))
+        actions = [multi_collision_free({"a": (0.0,) * 6}), io_write("OUT#1", True, device_id="c")]
+
+        await ensemble.plan_and_execute(actions, tcp="flange")
+
+        ensemble._planner.plan.assert_awaited_once_with(actions, "flange", None)
+        # the planned trajectory and the very same actions reach execute
+        executor.execute.assert_awaited_once_with("TRAJ", actions=actions, groups=None)
+
+
+class TestLazyPlanner:
+    async def test_planner_is_built_once_from_the_executor_groups_on_first_plan(self, monkeypatch):
+        executor = _fake_executor()
+        created: list[dict] = []
+        fake_planner = MagicMock(plan=AsyncMock(return_value="TRAJ"))
+
+        def fake_ctor(groups):
+            created.append(groups)
+            return fake_planner
+
+        monkeypatch.setattr("nova.cell.multi_motion_group.MultiMotionGroupPlanner", fake_ctor)
+        ensemble = MultiMotionGroup(executor)
+
+        await ensemble.plan([multi_collision_free({"a": (0.0,) * 6})])
+        await ensemble.plan([multi_collision_free({"a": (1.0,) * 6})])
+
+        # built exactly once, from the executor's motion groups, then cached
+        assert created == [executor.motion_groups]
+
+    async def test_execute_only_never_builds_the_planner(self):
+        # An execute-only ensemble must not trigger the planner's single-cell
+        # requirement (execution may span cells; planning may not).
+        executor = _fake_executor()
+        ensemble = MultiMotionGroup(executor)
+
+        await ensemble.execute("TRAJ")
+
+        assert ensemble._planner is None

--- a/tests/cell/test_multi_motion_group_planner.py
+++ b/tests/cell/test_multi_motion_group_planner.py
@@ -1,0 +1,268 @@
+"""Tests for MultiMotionGroupPlanner: how it batches an ensemble action list into
+the multi-RRT request(s) and interprets the response, over a faked gateway."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nova import api
+from nova.actions.io import ReadAction, io_write
+from nova.actions.mock import wait
+from nova.actions.motions import multi_collision_free
+from nova.cell.multi_motion_group_planner import MultiMotionGroupPlanner
+from nova.exceptions import NoInverseKinematicsSolutionFound, PlanTrajectoryFailed
+from nova.types import Pose
+
+pytestmark = pytest.mark.asyncio
+
+
+def _setup() -> api.models.MotionGroupSetup:
+    return api.models.MotionGroupSetup(motion_group_model="UniversalRobots_UR5e", cycle_time=4)
+
+
+def _multi_trajectory(*keys: str, sample: float = 0.0) -> api.models.MultiJointTrajectory:
+    return api.models.MultiJointTrajectory(
+        joint_positions_by_motion_group_key={key: [[sample] * 6] * 3 for key in keys},
+        times=[0.0, 1.0, 2.0],
+        locations=[0.0, 1.0, 2.0],
+    )
+
+
+def _gateway(
+    response: api.models.MultiSearchCollisionFreeResponse | None = None,
+    responses: list[api.models.MultiSearchCollisionFreeResponse] | None = None,
+) -> MagicMock:
+    gateway = MagicMock()
+    gateway.trajectory_planning_api = MagicMock()
+    gateway.trajectory_planning_api.search_collision_free_multi_motion_group = (
+        AsyncMock(side_effect=responses)
+        if responses is not None
+        else AsyncMock(return_value=response)
+    )
+    return gateway
+
+
+def _ok(*keys: str, sample: float = 0.0) -> api.models.MultiSearchCollisionFreeResponse:
+    return api.models.MultiSearchCollisionFreeResponse(
+        response=_multi_trajectory(*keys, sample=sample)
+    )
+
+
+def _motion_group(
+    api_client: MagicMock,
+    group_id: str,
+    current_joints: tuple[float, ...] = (0.0,) * 6,
+    ik_solutions: list[tuple[float, ...]] | None = None,
+    cell: str = "cell",
+) -> MagicMock:
+    group = MagicMock()
+    group.id = group_id
+    group._cell = cell
+    group._api_client = api_client
+    group.get_setup = AsyncMock(return_value=_setup())
+    group.joints = AsyncMock(return_value=current_joints)
+    group._inverse_kinematics = AsyncMock(return_value=[ik_solutions or []])
+    return group
+
+
+def _request_of(api_client: MagicMock, call_index: int = 0):
+    return (
+        api_client.trajectory_planning_api.search_collision_free_multi_motion_group.call_args_list[
+            call_index
+        ].kwargs["multi_search_collision_free_request"]
+    )
+
+
+class TestValidation:
+    async def test_no_groups__raises(self):
+        with pytest.raises(ValueError, match="At least one motion group"):
+            MultiMotionGroupPlanner({})
+
+    async def test_groups_span_cells__raises(self):
+        api_client = MagicMock()
+        with pytest.raises(ValueError, match="cell-scoped"):
+            MultiMotionGroupPlanner(
+                {
+                    "a": _motion_group(api_client, "a", cell="cell-1"),
+                    "b": _motion_group(api_client, "b", cell="cell-2"),
+                }
+            )
+
+    async def test_iterable_of_groups_keyed_by_id(self):
+        api_client = _gateway(_ok("0@kuka", "1@kuka"))
+        planner = MultiMotionGroupPlanner(
+            [_motion_group(api_client, "0@kuka"), _motion_group(api_client, "1@kuka")]
+        )
+        assert set(planner.motion_groups) == {"0@kuka", "1@kuka"}
+
+    async def test_no_actions__raises(self):
+        api_client = _gateway(_ok("a"))
+        planner = MultiMotionGroupPlanner({"a": _motion_group(api_client, "a")})
+        with pytest.raises(ValueError, match="No actions"):
+            await planner.plan([])
+
+    async def test_targets_not_matching_groups__raises(self):
+        api_client = _gateway(_ok("a", "b"))
+        planner = MultiMotionGroupPlanner(
+            {"a": _motion_group(api_client, "a"), "b": _motion_group(api_client, "b")}
+        )
+        with pytest.raises(ValueError, match="must match the planner"):
+            await planner.plan(multi_collision_free({"a": (1.0,) * 6}))
+
+    async def test_unsupported_action__raises(self):
+        api_client = _gateway(_ok("a"))
+        planner = MultiMotionGroupPlanner({"a": _motion_group(api_client, "a")})
+        with pytest.raises(ValueError, match="not supported"):
+            await planner.plan(ReadAction(key="IN#1", device_id="ctrl"))
+
+    async def test_write_action_is_ignored__no_raise_and_pure_trajectory(self):
+        # A WriteAction carries no joint samples: exactly as in MotionGroup.plan
+        # it is skipped, leaving the trajectory identical to the motion alone.
+        api_client = _gateway(_ok("a", sample=1.0))
+        planner = MultiMotionGroupPlanner({"a": _motion_group(api_client, "a")})
+
+        with_write = await planner.plan(
+            [io_write("OUT#1", True, device_id="ctrl"), multi_collision_free({"a": (1.0,) * 6})]
+        )
+
+        assert isinstance(with_write, api.models.MultiJointTrajectory)
+        # one RRT call, no extra samples from the write
+        assert (
+            api_client.trajectory_planning_api.search_collision_free_multi_motion_group.await_count
+            == 1
+        )
+        assert len(with_write.joint_positions_by_motion_group_key.root["a"].root) == 3
+
+
+class TestRequestAssembly:
+    async def test_joint_targets_build_path_definitions(self):
+        api_client = _gateway(_ok("a", "b"))
+        planner = MultiMotionGroupPlanner(
+            {
+                "a": _motion_group(api_client, "a", current_joints=(0.1,) * 6),
+                "b": _motion_group(api_client, "b", current_joints=(0.2,) * 6),
+            }
+        )
+
+        result = await planner.plan(
+            multi_collision_free({"a": (1.0,) * 6, "b": (2.0,) * 6}),
+            start_joint_position={"a": (0.5,) * 6},
+        )
+
+        assert isinstance(result, api.models.MultiJointTrajectory)
+        paths = _request_of(api_client).path_definitions_by_motion_group_key.root
+        assert set(paths) == {"a", "b"}
+        # explicit start honored for "a", current-joints fallback for "b"
+        assert tuple(paths["a"].start_joint_position.root) == (0.5,) * 6
+        assert tuple(paths["a"].target_joint_position.root) == (1.0,) * 6
+        assert tuple(paths["b"].start_joint_position.root) == (0.2,) * 6
+        assert tuple(paths["b"].target_joint_position.root) == (2.0,) * 6
+        assert set(_request_of(api_client).motion_group_setups_by_motion_group_key.root) == {
+            "a",
+            "b",
+        }
+
+    async def test_shared_tcp_and_algorithm_on_action(self):
+        api_client = _gateway(_ok("a"))
+        group = _motion_group(api_client, "a")
+        planner = MultiMotionGroupPlanner({"a": group})
+
+        algorithm = api.models.RRTConnectAlgorithm(max_iterations=42)
+        await planner.plan(
+            multi_collision_free({"a": (1.0,) * 6}, algorithm=algorithm), tcp="flange"
+        )
+
+        group.get_setup.assert_awaited_once_with(tcp_name="flange")
+        assert _request_of(api_client).algorithm_settings.max_iterations == 42
+
+    async def test_pose_target_resolves_ik_nearest_to_start(self):
+        api_client = _gateway(_ok("a"))
+        far, near = (3.0,) * 6, (0.1,) * 6
+        group = _motion_group(api_client, "a", current_joints=(0.0,) * 6, ik_solutions=[far, near])
+        planner = MultiMotionGroupPlanner({"a": group})
+
+        await planner.plan(multi_collision_free({"a": Pose((1, 2, 3, 4, 5, 6))}), tcp="flange")
+
+        group._inverse_kinematics.assert_awaited_once()
+        target = tuple(
+            _request_of(api_client)
+            .path_definitions_by_motion_group_key.root["a"]
+            .target_joint_position.root
+        )
+        assert target == near
+
+    async def test_pose_target_without_tcp__raises(self):
+        api_client = _gateway(_ok("a"))
+        planner = MultiMotionGroupPlanner({"a": _motion_group(api_client, "a")})
+        with pytest.raises(ValueError, match="TCP is required"):
+            await planner.plan(multi_collision_free({"a": Pose((1, 2, 3, 4, 5, 6))}))
+
+    async def test_pose_target_no_ik_solution__raises(self):
+        api_client = _gateway(_ok("a"))
+        group = _motion_group(api_client, "a", ik_solutions=[])
+        planner = MultiMotionGroupPlanner({"a": group})
+        with pytest.raises(NoInverseKinematicsSolutionFound):
+            await planner.plan(multi_collision_free({"a": Pose((1, 2, 3, 4, 5, 6))}), tcp="flange")
+
+
+class TestBatching:
+    async def test_wait_between_motions_concatenates_segments(self):
+        # Two distinct RRT segments plus a hold in the middle.
+        api_client = _gateway(responses=[_ok("a", sample=1.0), _ok("a", sample=2.0)])
+        group = _motion_group(api_client, "a", current_joints=(0.0,) * 6)
+        planner = MultiMotionGroupPlanner({"a": group})
+
+        result = await planner.plan(
+            [
+                multi_collision_free({"a": (1.0,) * 6}),
+                wait(0.1),
+                multi_collision_free({"a": (2.0,) * 6}),
+            ]
+        )
+
+        # two RRT calls, one per motion; the wait is planned locally
+        assert (
+            api_client.trajectory_planning_api.search_collision_free_multi_motion_group.await_count
+            == 2
+        )
+        # 3 + (3 hold - 1 seam) + (3 - 1 seam) = 3 + 2 + 2 = 7 samples on the shared timeline
+        samples = result.joint_positions_by_motion_group_key.root["a"].root
+        assert len(samples) == 7
+        assert len(result.times) == 7
+        # second motion's start joints = end of the hold = end of the first segment
+        second_start = tuple(
+            _request_of(api_client, 1)
+            .path_definitions_by_motion_group_key.root["a"]
+            .start_joint_position.root
+        )
+        assert second_start == (1.0,) * 6
+
+    async def test_wait_holds_current_joints(self):
+        api_client = _gateway(_ok("a"))
+        planner = MultiMotionGroupPlanner(
+            {"a": _motion_group(api_client, "a", current_joints=(0.7,) * 6)}
+        )
+        result = await planner.plan(wait(0.1))
+        samples = result.joint_positions_by_motion_group_key.root["a"].root
+        assert all(tuple(s.root) == (0.7,) * 6 for s in samples)
+        assert all(loc.root == 0.0 for loc in result.locations)
+        api_client.trajectory_planning_api.search_collision_free_multi_motion_group.assert_not_awaited()
+
+
+class TestResponse:
+    async def test_failed_response__raises(self):
+        failure = api.models.PlanCollisionFreeFailedResponse(
+            error_feedback=api.models.ErrorMaxIterationsExceeded()
+        )
+        api_client = _gateway(api.models.MultiSearchCollisionFreeResponse(response=failure))
+        planner = MultiMotionGroupPlanner(
+            {"a": _motion_group(api_client, "a"), "b": _motion_group(api_client, "b")}
+        )
+        with pytest.raises(PlanTrajectoryFailed, match="a, b"):
+            await planner.plan(multi_collision_free({"a": (1.0,) * 6, "b": (1.0,) * 6}))
+
+    async def test_empty_response__raises(self):
+        api_client = _gateway(api.models.MultiSearchCollisionFreeResponse(response=None))
+        planner = MultiMotionGroupPlanner({"a": _motion_group(api_client, "a")})
+        with pytest.raises(ValueError, match="no trajectory"):
+            await planner.plan(multi_collision_free({"a": (1.0,) * 6}))

--- a/tests/cell/test_trajectory_executor.py
+++ b/tests/cell/test_trajectory_executor.py
@@ -13,6 +13,8 @@ import pytest
 
 from nova import api
 from nova.actions.io import io_write
+from nova.actions.mock import wait
+from nova.actions.motions import multi_collision_free
 from nova.cell.multi_trajectory_cursor import IOSyncConfig, IOSyncDriver, SyncDriver
 from nova.cell.session_monitor import SyncDriftError, SyncDriftMonitor
 from nova.cell.trajectory_executor import TrajectoryExecutor
@@ -24,6 +26,12 @@ from tests.cell.multi_group_doubles import (
     sync_driver,
     watch_condition,
 )
+
+
+def _move():
+    """A synchronized motion — the overlay counts it, its targets are irrelevant here."""
+    return multi_collision_free({"a": (0.0,) * 6, "b": (0.0,) * 6})
+
 
 pytestmark = pytest.mark.asyncio
 
@@ -231,6 +239,66 @@ class TestIOSyncDriver:
 
         gateway.bus_ios_api.set_bus_io_values.assert_awaited_once()
         assert gateway.bus_ios_api.get_bus_io_values.await_count == 2
+
+
+class TestIOOverlay:
+    def _executor(
+        self, gateway, controllers=("controller-a", "controller-b")
+    ) -> TrajectoryExecutor:
+        motion_groups = {
+            "a": motion_group(gateway, controller=controllers[0]),
+            "b": motion_group(gateway, controller=controllers[1]),
+        }
+        return TrajectoryExecutor(motion_groups, sync=sync_driver(gateway, groups=("a", "b")))
+
+    def test_no_actions__all_overlays_empty(self):
+        overlay = self._executor(IOGateway())._build_io_overlay(None)
+        assert overlay == {"a": [], "b": []}
+
+    def test_write_anchored_on_preceding_motion_count(self):
+        overlay = self._executor(IOGateway())._build_io_overlay(
+            [_move(), _move(), io_write("OUT#1", True, device_id="controller-a")]
+        )
+        assert [s.location for s in overlay["a"]] == [2]
+        assert overlay["b"] == []
+
+    def test_wait_does_not_advance_the_location(self):
+        overlay = self._executor(IOGateway())._build_io_overlay(
+            [_move(), wait(0.5), io_write("OUT#1", True, device_id="controller-a")]
+        )
+        assert [s.location for s in overlay["a"]] == [1]
+
+    def test_controller_origin_routes_to_the_group_on_that_controller(self):
+        overlay = self._executor(IOGateway())._build_io_overlay(
+            [io_write("OUT#1", True, device_id="controller-b")]
+        )
+        assert overlay["a"] == []
+        assert [s.io.root.io for s in overlay["b"]] == ["OUT#1"]
+
+    def test_controller_origin_without_device_id__ambiguous__raises(self):
+        with pytest.raises(ValueError, match="ambiguous"):
+            self._executor(IOGateway())._build_io_overlay([io_write("OUT#1", True)])
+
+    def test_controller_origin_without_device_id__shared_controller__routes_to_one(self):
+        executor = self._executor(IOGateway(), controllers=("controller-a", "controller-a"))
+        overlay = executor._build_io_overlay([io_write("OUT#1", True)])
+        assert [s.io.root.io for s in overlay["a"]] == ["OUT#1"]
+        assert overlay["b"] == []
+
+    def test_controller_origin__no_matching_group__raises(self):
+        with pytest.raises(ValueError, match="No motion group is on controller"):
+            self._executor(IOGateway())._build_io_overlay(
+                [io_write("OUT#1", True, device_id="controller-x")]
+            )
+
+    def test_bus_origin__fires_once_on_one_group(self):
+        overlay = self._executor(IOGateway())._build_io_overlay(
+            [io_write("bus-var", True, origin=api.models.IOOrigin.BUS_IO)]
+        )
+        # exactly one group carries it — a shared instant, not duplicated
+        assert sum(len(entries) for entries in overlay.values()) == 1
+        assert [s.io.root.io for s in overlay["a"]] == ["bus-var"]
+        assert overlay["b"] == []
 
 
 class TestSyncDriftMonitor:

--- a/tests/cell/test_trajectory_executor_session.py
+++ b/tests/cell/test_trajectory_executor_session.py
@@ -21,6 +21,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from nova import api
+from nova.actions.io import io_write
+from nova.actions.motions import multi_collision_free
 from nova.cell.session_monitor import SyncDriftError
 from nova.cell.trajectory_executor import GroupArgs, TrajectoryExecutor
 from tests.cell.multi_group_doubles import (
@@ -387,3 +389,48 @@ class TestSynchronizedExecution:
         # Assert: the late forward fails loudly instead of deadlocking the exit
         with pytest.raises(RuntimeError):
             await asyncio.wait_for(run(), timeout=5)
+
+
+class TestIOOverlayReachesTheController:
+    async def test_execute__write_rides_the_owning_groups_start_only(self):
+        # Arrange: two groups on distinct controllers; the write targets b's.
+        gateway = _FakeGateway()
+        state_queues = {"a": asyncio.Queue(), "b": asyncio.Queue()}
+        executor = (
+            TrajectoryExecutor.builder(
+                {
+                    "a": motion_group(
+                        gateway, state_queues["a"], controller="ctrl-a", trajectory_id="traj-a"
+                    ),
+                    "b": motion_group(
+                        gateway, state_queues["b"], controller="ctrl-b", trajectory_id="traj-b"
+                    ),
+                }
+            )
+            .sync_on_io("sync-io", controller="ctrl-a")
+            .build()
+        )
+        actions = [
+            multi_collision_free({"a": (0.0,) * 6, "b": (0.0,) * 6}),
+            io_write("OUT#1", True, device_id="ctrl-b"),
+        ]
+
+        # Act: run the barrier through to completion
+        execute_task = asyncio.create_task(
+            executor.execute(multi_trajectory("a", "b"), actions=actions)
+        )
+        await gateway.reached("start", 2)
+        state_queues["a"].put_nowait(wait_for_io_state(at_milliseconds=10))
+        state_queues["b"].put_nowait(wait_for_io_state(at_milliseconds=20))
+        await gateway.reached("write", 2)
+        state_queues["a"].put_nowait(ended_state(2.0, at_milliseconds=30))
+        state_queues["b"].put_nowait(ended_state(2.0, at_milliseconds=40))
+        await asyncio.wait_for(execute_task, timeout=5)
+
+        # Assert: b's start carries the overlay at the motion boundary (1 motion
+        # precedes the write); a's start carries none.
+        b_outputs = gateway.start_requests["traj-b"][0].set_outputs
+        assert [s.io.root.io for s in b_outputs] == ["OUT#1"]
+        assert b_outputs[0].location == 1
+        assert b_outputs[0].io.root.value is True
+        assert not gateway.start_requests["traj-a"][0].set_outputs


### PR DESCRIPTION
Continuation on top of the executor PR (#489), targeting `feat/trajectory-executor`.

> Re-created after PR #490 was accidentally delivered by a direct push to the base branch (a stray bare `git push` hit the wrong remote). The base was reset to its prior state (`919bcf6`); this PR carries the exact same work for proper review.

## What

- **`MultiMotionGroupPlanner`** — the multi-group counterpart of `MotionGroup.plan`. Batches an ensemble action list (`multi_collision_free` / `wait` / `io_write`) into one synchronized `MultiJointTrajectory` via the multi-motion-group RRT endpoint. Returns a pure trajectory: a `WriteAction` carries no joint samples and is ignored at plan time.
- **Synchronized IO in the executor** — `TrajectoryExecutor.execute()` / `attach()` accept `actions`. The same list feeds both `plan(...)` and `execute(..., actions=...)`. Each `WriteAction` becomes a `SetIO` anchored at its motion index (waits skipped) and rides the owning group's cursor, re-emitted on every start; fired once, on the shared `locations` array so the instant is synchronized. Routing: controller output → the group on that controller; bus IO → one deterministic group.
- **`MultiMotionGroup` facade** — one object with `plan` / `execute` / `plan_and_execute` over the planner and executor, built via `MultiMotionGroup.builder(...).sync_on_io(...)`. Planner is constructed lazily (execute-only ensembles may span cells; planning may not).
- **Shared helpers** — `located_writes` / `write_to_set_io` in `nova.actions.container`; `CombinedActions.to_set_io()` delegates to them (behavior unchanged, regression-tested).
- **Example** — `examples/multi_motion_group_facade.py`: one `plan_and_execute` plans a collision-free move for a robot + positioner, lays an `io_write` on the seam, runs both synchronized. Added as a commented CI matrix entry (like the other collision-free example — the multi-RRT endpoint is flaky/unsupported on the CI virtual instance).

## Tests

`located_writes`/`to_set_io` regression; planner ignores writes at plan time; executor overlay derivation + routing + end-to-end SetIO reaching the right group's `StartMovementRequest`; facade builder/lazy-planner/delegation.

Gates green locally: `ruff format/check/I`, `ty check nova/` (only the pre-existing unrelated `rerun` diagnostic), `pytest tests/cell tests/actions -m "not integration"` → 312 passed.