### PR TITLE
fix(cell): share the api gateway of a cell with its controllers

### DIFF
--- a/nova/cell/cell.py
+++ b/nova/cell/cell.py
@@ -73,8 +73,6 @@ class Cell:
                 id=controller_id,
                 config=self._api_client.config,
             ),
-            # Share the cell's gateway so the controller reuses its api client (and therefore
-            # its aiohttp session) instead of opening a second one that nobody closes.
             api_gateway=self._api_client,
         )
 

--- a/nova/cell/cell.py
+++ b/nova/cell/cell.py
@@ -72,7 +72,10 @@ class Cell:
                 controller_id=controller_id,
                 id=controller_id,
                 config=self._api_client.config,
-            )
+            ),
+            # Share the cell's gateway so the controller reuses its api client (and therefore
+            # its aiohttp session) instead of opening a second one that nobody closes.
+            api_gateway=self._api_client,
         )
 
     def _create_controller_from_config(

--- a/nova/cell/controller.py
+++ b/nova/cell/controller.py
@@ -1,7 +1,7 @@
 from typing import AsyncGenerator, Literal, Sized
 
 from nova import api
-from nova.core.gateway import NovaDevice
+from nova.core.gateway import ApiGateway, NovaDevice
 
 from .io import IOAccess
 from .motion_group import MotionGroup
@@ -19,8 +19,8 @@ class Controller(Sized, AbstractController, NovaDevice, IODevice):
         cell_id: str
         controller_id: str
 
-    def __init__(self, configuration: Configuration):
-        super().__init__(configuration)
+    def __init__(self, configuration: Configuration, *, api_gateway: ApiGateway | None = None):
+        super().__init__(configuration, api_gateway=api_gateway)
         self._motion_group_ids = None
         self._io_access = IOAccess(
             api_client=self._nova_api,

--- a/nova/core/gateway.py
+++ b/nova/core/gateway.py
@@ -146,9 +146,15 @@ class NovaDevice(ConfigurablePeriphery, Device, ABC, is_abstract=True):
     class Configuration(ConfigurablePeriphery.Configuration):
         config: NovaConfig
 
-    def __init__(self, configuration: Configuration, **kwargs):
+    def __init__(
+        self, configuration: Configuration, *, api_gateway: ApiGateway | None = None, **kwargs
+    ):
         self._nova_config = configuration.config
-        self._nova_api_gateway: ApiGateway | None = None
+        self._nova_api_gateway: ApiGateway | None = api_gateway
+        # A gateway owns an api.ApiClient and with it an aiohttp session. Only close the gateway
+        # if we created it ourselves; a shared one belongs to its owner (usually the Nova
+        # instance) and is closed there.
+        self._owns_api_gateway = api_gateway is None
         super().__init__(configuration, **kwargs)
 
     @property
@@ -164,5 +170,5 @@ class NovaDevice(ConfigurablePeriphery, Device, ABC, is_abstract=True):
 
     async def close(self):
         await super().close()
-        if self._nova_api_gateway is not None:
+        if self._owns_api_gateway and self._nova_api_gateway is not None:
             await self._nova_api_gateway.close()

--- a/tests/cell/test_controller_api_gateway.py
+++ b/tests/cell/test_controller_api_gateway.py
@@ -1,0 +1,68 @@
+"""Controllers must reuse their cell's api gateway instead of opening a second one.
+
+Each ApiGateway owns an api.ApiClient, which lazily creates an aiohttp.ClientSession on its
+first request. A controller that builds its own gateway therefore leaks a session unless it is
+explicitly closed, which the program runner never does.
+"""
+
+from nova import Nova
+from nova.cell.controller import Controller
+from nova.config import NovaConfig
+
+CONFIG = NovaConfig(host="http://localhost")
+
+
+def _standalone_controller() -> Controller:
+    return Controller(
+        configuration=Controller.Configuration(
+            cell_id="cell", controller_id="demo", id="demo", config=CONFIG
+        )
+    )
+
+
+def test_controller_from_cell_shares_the_nova_api_client():
+    nova = Nova(config=CONFIG)
+    controller = nova.cell()._create_controller("demo")
+
+    assert controller._nova_api is nova.api
+    assert controller._nova_api._api_client is nova.api._api_client
+    assert controller._owns_api_gateway is False
+
+
+def test_motion_group_shares_the_nova_api_client():
+    nova = Nova(config=CONFIG)
+    motion_group = nova.cell()._create_controller("demo")[0]
+
+    assert motion_group._api_client._api_client is nova.api._api_client
+
+
+async def test_closing_a_controller_does_not_close_the_shared_gateway():
+    """Nova outlives the controllers handed out by its cell, so its session must survive."""
+    nova = Nova(config=CONFIG)
+    controller = nova.cell()._create_controller("demo")
+
+    closed = False
+
+    async def spy():
+        nonlocal closed
+        closed = True
+
+    nova.api.close = spy  # ty: ignore[invalid-assignment]
+
+    await controller.close()
+    assert closed is False, "controller closed a gateway it does not own"
+
+    await nova.api.close()
+    assert closed is True
+
+
+async def test_standalone_controller_owns_and_closes_its_gateway():
+    controller = _standalone_controller()
+    gateway = controller._nova_api
+
+    assert controller._owns_api_gateway is True
+
+    await controller.close()
+
+    rest_client = gateway._api_client.rest_client
+    assert rest_client.pool_manager is None or rest_client.pool_manager.closed


### PR DESCRIPTION
## Problem

Running any program leaves an unclosed aiohttp session behind. `examples/start_here.py` ends with:

```
[ERROR] asyncio: Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x10e345220>
[ERROR] asyncio: Unclosed connector
connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x10e33b2a0>, ...)])']
```

Harmless to the run's result, but it leaks a socket per program run — and in a long-lived `novax` host, one session per program execution.

## Root cause

One `ApiGateway` == one `api.ApiClient` == one lazily-created `aiohttp.ClientSession`. A program run created **two** gateways and closed only one:

1. `Nova` builds its own (`nova/core/nova.py:26`), closed by the runner at `nova/program/runner.py:587`. ✅
2. `Cell._create_controller` passed `Controller` only a `NovaConfig`, not the gateway the cell already held — so `NovaDevice._nova_api` (`nova/core/gateway.py:158`) minted a **second, private** gateway, eagerly, from `Controller.__init__`. ❌

All motion traffic ran over gateway #2: `Controller.motion_group()` passes `api_client=self._nova_api`, so `joints()`, `tcp_pose()`, `plan()` and `execute()` all used the controller's session — hence exactly one leaked session holding one pooled connection.

Nothing closed it. `NovaDevice.close()` would, but it is only reached through `RobotCell`'s exit stack, and the runner builds an **empty** `RobotCell` (`runner.py:482` — controller registration is commented out). The run happens on a thread whose event loop dies when `anyio.run` returns, so the orphan is only collected at interpreter exit, which is why the message prints last.

Ruled out as causes: `cleanup_controllers=False` only skips a `DELETE /controllers/{id}` call, and `execute()`/state streams use `websockets` inside `async with`, not aiohttp.

## Fix

Controllers created by a `Cell` now reuse that cell's gateway, which `Nova.close()` already closes. `NovaDevice` tracks whether it owns its gateway, so a controller never closes one it did not create — keeping Nova usable after `Controller.close()` in the `RobotCell` teardown path (`Cell.get_robot_cell()`, wandelscript). Directly-constructed devices still get and own their own gateway via the unchanged lazy fallback.

This also removes a latent leak in `_ensure_preconditions` (`runner.py:119`), which discarded a `Controller` carrying its own `ApiClient` — silent only because it never issued a request, so no session was ever created.

## Verification

- **A/B against a live NOVA instance**: reverting just the `cell.py` line reproduces `Unclosed client session`; with the fix the same run emits zero `Unclosed` lines and completes normally.
- **Ownership flag, live**: forced the session open through the controller, then `controller.close()` → session stays open and Nova stays usable; `Nova.close()` → session closed.
- **New test** `tests/cell/test_controller_api_gateway.py` (4 tests, no network) — 2 of them fail on the pre-fix code, all pass after.
- `782 passed, 6 skipped` on the full unit suite; `ruff format`, `ruff check`, `ty check` clean.

## Out of scope

Two lifecycle bugs found while investigating, deliberately not touched here:

- `nova/viewers/rerun.py:172` awaits `__aenter__` with no matching `__aexit__` (`_cleanup_active_viewers()` is sync). Real asymmetry, but it shares the caller's `Nova`, so it leaks no session.
- `novax/novax.py:50` builds `Nova()` in `__init__` but closes it only inside the lifespan; an app that never starts its lifespan never closes that gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
