### PR TITLE
feat(cell): multi-motion-group planning and execution (MultiMotionGroup)

### DIFF
--- a/.github/workflows/nova-run-examples.yaml
+++ b/.github/workflows/nova-run-examples.yaml
@@ -133,6 +133,10 @@ jobs:
             run_cmd: "python examples/multi_motion_group.py"
           - id: bus_io_sync_two_controllers
             run_cmd: "python examples/bus_io_sync_two_controllers.py"
+          # collision-free (RRT) examples are not run in CI: the endpoint is
+          # flaky/unsupported on the virtual instance (see the entry below).
+          # - id: multi_motion_group_planning
+          #   run_cmd: "python examples/multi_motion_group_planning.py"
           # - id: multi_step_movement_with_collision_free
           #   run_cmd: "python examples/multi_step_movement_with_collision_free.py"
           - id: welding

--- a/examples/bus_io_sync_two_controllers.py
+++ b/examples/bus_io_sync_two_controllers.py
@@ -15,7 +15,7 @@ from datetime import datetime
 
 import nova
 from nova import api, run_program
-from nova.cell import GroupArgs, TrajectoryExecutor, virtual_controller
+from nova.cell import GroupArgs, MultiMotionGroup, virtual_controller
 
 CONTROLLERS = ("kuka-a", "kuka-b")
 SYNC_IO = "sync-bus"
@@ -133,8 +133,8 @@ async def bus_io_sync_two_controllers(ctx: nova.ProgramContext):
     await declare_bus_trigger(ctx, gateway, cell.cell_id)
 
     trajectory = await ramp_from_here(groups)
-    executor = (
-        TrajectoryExecutor.builder(groups)
+    ensemble = (
+        MultiMotionGroup.builder(groups)
         .sync_on_io(SYNC_IO, origin=api.models.IOOrigin.BUS_IO)
         .build()
     )
@@ -145,7 +145,7 @@ async def bus_io_sync_two_controllers(ctx: nova.ProgramContext):
     ]
     try:
         tcps = {name: (await group.tcp_names())[0] for name, group in groups.items()}
-        await executor.execute(
+        await ensemble.execute(
             trajectory, groups={name: GroupArgs(tcp=tcp) for name, tcp in tcps.items()}
         )
     finally:

--- a/examples/multi_motion_group.py
+++ b/examples/multi_motion_group.py
@@ -1,9 +1,18 @@
+"""Run a pre-recorded synchronized trajectory with MultiMotionGroup.
+
+``MultiMotionGroup`` is the single primitive for several motion groups — like
+``MotionGroup`` for one. Here it only executes: a trajectory recorded for a robot
+and a positioner is run through the IO barrier with ``MultiMotionGroup.execute``,
+no planning involved. See ``multi_motion_group_planning.py`` for the
+``plan_and_execute`` counterpart.
+"""
+
 from pathlib import Path
 
 import nova
 from nova import api, run_program
 from nova.actions import jnt
-from nova.cell import GroupArgs, TrajectoryExecutor, virtual_controller
+from nova.cell import GroupArgs, MultiMotionGroup, virtual_controller
 
 CONTROLLER = "kuka"
 ROBOT, POSITIONER = f"0@{CONTROLLER}", f"1@{CONTROLLER}"
@@ -53,10 +62,10 @@ async def multi_motion_group_trajectory(ctx: nova.ProgramContext):
         # A trajectory can only be executed from its own first sample.
         await group.plan_and_execute([jnt(samples[name][0])], tcp=TCPS[name])
 
-    executor = (
-        TrajectoryExecutor.builder(groups).sync_on_io(SYNC_IO_ID, controller=CONTROLLER).build()
+    ensemble = (
+        MultiMotionGroup.builder(groups).sync_on_io(SYNC_IO_ID, controller=CONTROLLER).build()
     )
-    await executor.execute(
+    await ensemble.execute(
         trajectory, groups={name: GroupArgs(tcp=tcp) for name, tcp in TCPS.items()}
     )
 

--- a/examples/multi_motion_group_planning.py
+++ b/examples/multi_motion_group_planning.py
@@ -1,0 +1,81 @@
+"""Plan and execute one synchronized ensemble with MultiMotionGroup.
+
+``MultiMotionGroup`` is to several motion groups what ``MotionGroup`` is to one:
+a single object with ``plan`` / ``execute`` / ``plan_and_execute``. Here it plans
+a collision-free move for a robot and a positioner at once (the multi-motion-group
+RRT endpoint), fires an output between the two moves, and runs both groups
+synchronized through an IO barrier — all in one ``plan_and_execute`` call, with
+the same action list feeding both the plan and the execution.
+
+Contrast ``multi_motion_group.py``, which runs a *pre-recorded* trajectory with
+``MultiMotionGroup.execute``; this one plans live and adds IO.
+"""
+
+from pathlib import Path
+
+import nova
+from nova.actions import io_write, jnt, multi_collision_free
+from nova.cell import MultiMotionGroup, virtual_controller
+
+CONTROLLER = "kuka"
+ROBOT, POSITIONER = f"0@{CONTROLLER}", f"1@{CONTROLLER}"
+TCPS = {ROBOT: "1", POSITIONER: "0"}
+
+# The barrier IO that releases both groups at the same instant, and an output the
+# plan flips between the two synchronized moves (fired on the controller clock,
+# anchored to the motion boundary — location 1, after the first move).
+SYNC_IO_ID = "OUT#1"
+STAGE_DONE_IO_ID = "OUT#2"
+
+# Fixed joint configs the plan moves between — robot (6 joints) and positioner
+# (2 joints). The move is planned collision-free, so no live poses are needed.
+START = {ROBOT: (0.267, -1.497, 2.035, -1.157, 0.5, 1.133), POSITIONER: (-0.167, 3.06)}
+TARGET = {ROBOT: (0.0, -1.564, 1.57, 0.0, 1.57, 0.0), POSITIONER: (0.0, 0.0)}
+
+_HERE = Path(__file__).parent
+
+
+@nova.program(
+    name="multi_motion_group_planning",
+    preconditions=nova.ProgramPreconditions(
+        controllers=[
+            virtual_controller(
+                name=CONTROLLER,
+                manufacturer=nova.api.models.Manufacturer.KUKA,
+                type="kuka-kr210_r2700_2",
+                controller_config_json=(_HERE / "multi_motion_group_controller.json").read_text(),
+                # Spawn the robot where the plan starts; ``position`` places the
+                # first motion group only, so the positioner is moved below.
+                position=[*START[ROBOT], 0.0],
+            )
+        ]
+    ),
+)
+async def multi_motion_group_planning(ctx: nova.ProgramContext):
+    """Plan + synchronized execute of two motion groups via MultiMotionGroup."""
+    controller = await ctx.nova.cell().controller(CONTROLLER)
+    groups = {name: controller.motion_group(name) for name in TCPS}
+
+    # Bring each group to the shared start config before the synchronized run.
+    for name, group in groups.items():
+        await group.plan_and_execute([jnt(START[name])], tcp=TCPS[name])
+
+    ensemble = (
+        MultiMotionGroup.builder(groups).sync_on_io(SYNC_IO_ID, controller=CONTROLLER).build()
+    )
+
+    # One call plans both collision-free segments (RRT), lays the IO write onto
+    # the seam between them, and runs the ensemble synchronized through the barrier.
+    await ensemble.plan_and_execute(
+        [
+            multi_collision_free(TARGET),
+            io_write(STAGE_DONE_IO_ID, True, device_id=CONTROLLER),
+            multi_collision_free(START),
+        ],
+        tcp=TCPS,
+    )
+    print("synchronized plan_and_execute finished; stage-done output was set at the seam")
+
+
+if __name__ == "__main__":
+    nova.run_program(multi_motion_group_planning)

--- a/nova/actions/__init__.py
+++ b/nova/actions/__init__.py
@@ -11,6 +11,7 @@ from nova.actions.motions import (
     joint_ptp,
     lin,
     linear,
+    multi_collision_free,
     ptp,
 )
 from nova.actions.trajectory_builder import TrajectoryBuilder
@@ -29,6 +30,7 @@ __all__ = [
     "lin",
     "wait",
     "collision_free",
+    "multi_collision_free",
     "MovementController",
     "MovementControllerContext",
     "TrajectoryBuilder",

--- a/nova/actions/container.py
+++ b/nova/actions/container.py
@@ -1,14 +1,40 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Annotated, AsyncIterator, Callable
 
 import pydantic
 
 from nova import api
+from nova.actions.base import Action
 from nova.actions.io import WriteAction
 from nova.actions.mock import WaitAction
 from nova.actions.motions import CollisionFreeMotion, Motion
 from nova.types import MotionSettings, MovementControllerFunction, Pose
+
+
+def located_writes(actions: Iterable[Action]) -> list[tuple[int, WriteAction]]:
+    """Pair each :class:`WriteAction` with its motion index along the path.
+
+    The index is the number of motions preceding the write; waits are skipped
+    and do not advance it. This is the location convention IO rides on — an
+    integer location marks a motion-command boundary — and it is shared by both
+    the single-motion-group (:meth:`CombinedActions.to_set_io`) and the
+    synchronized multi-motion-group IO overlays.
+    """
+    out: list[tuple[int, WriteAction]] = []
+    motion_index = 0
+    for action in actions:
+        if action.is_motion():
+            motion_index += 1
+        elif isinstance(action, WriteAction):
+            out.append((motion_index, action))
+    return out
+
+
+def write_to_set_io(write: WriteAction, location: float) -> api.models.SetIO:
+    """Build the :class:`api.models.SetIO` overlay entry for a write at ``location``."""
+    return api.models.SetIO(io=write.to_api_model(), location=location, io_origin=write.origin)
 
 
 class ActionLocation(pydantic.BaseModel):
@@ -147,15 +173,7 @@ class CombinedActions(pydantic.BaseModel):
         return motion_commands
 
     def to_set_io(self) -> list[api.models.SetIO]:
-        return [
-            api.models.SetIO(
-                io=action.action.to_api_model(),
-                location=action.path_parameter,
-                io_origin=action.action.origin,
-            )
-            for action in self.actions
-            if isinstance(action.action, WriteAction)
-        ]
+        return [write_to_set_io(write, location) for location, write in located_writes(self.items)]
 
 
 # TODO: should not be located here

--- a/nova/actions/motions.py
+++ b/nova/actions/motions.py
@@ -367,6 +367,69 @@ class CollisionFreeMotion(Motion):
         raise NotImplementedError("CollisionFreeMotion.to_api_model is not implemented yet")
 
 
+class MultiCollisionFreeMotion(Action):
+    """A synchronized collision-free motion across several motion groups.
+
+    The multi-group counterpart of :class:`CollisionFreeMotion`: one action that
+    targets every group at once and is planned by the multi-motion-group RRT
+    endpoint into a single, time-synchronized trajectory (all groups sharing one
+    ``times``/``locations``). Unlike :class:`CollisionFreeMotion` it carries no
+    single ``target``; the per-group targets live in :attr:`targets`.
+
+    Attributes:
+        targets: The target per motion group, keyed by name — a pose (resolved
+            via inverse kinematics) or a joint tuple.
+        settings: Optional motion settings per group, folded into that group's
+            planning limits. Groups left out plan at their controller limits.
+        collision_setups: Optional cross-group and environment collision setup
+            per group. ``None`` plans against the groups' own geometry only.
+        algorithm: RRT settings shared by the whole search. ``None`` uses the
+            endpoint default.
+    """
+
+    type: Literal["multi_collision_free"] = "multi_collision_free"
+    targets: dict[str, Pose | tuple[float, ...]]
+    settings: dict[str, MotionSettings] = {}
+    collision_setups: dict[str, api.models.MultiCollisionSetup] | None = None
+    algorithm: api.models.RRTConnectAlgorithm | None = None
+
+    def is_motion(self) -> bool:
+        return True
+
+    def to_api_model(self) -> api.models.MultiSearchCollisionFreeRequest:
+        # The request also needs each group's setup and start joints, which the
+        # action does not carry; MultiMotionGroupPlanner assembles it instead.
+        raise NotImplementedError("MultiCollisionFreeMotion.to_api_model is not implemented")
+
+
+def multi_collision_free(
+    targets: dict[str, Pose | tuple[float, ...]],
+    settings: dict[str, MotionSettings] | None = None,
+    collision_setups: dict[str, api.models.MultiCollisionSetup] | None = None,
+    algorithm: api.models.RRTConnectAlgorithm | None = None,
+    **kwargs: Any,
+) -> MultiCollisionFreeMotion:
+    """Convenience factory for a synchronized collision-free motion.
+
+    Args:
+        targets: The target per motion group (pose or joint tuple), keyed by name.
+        settings: Optional per-group motion settings.
+        collision_setups: Optional per-group collision setup.
+        algorithm: Shared RRT settings; ``None`` uses the endpoint default.
+
+    Returns:
+        The multi-motion-group collision-free motion.
+    """
+    kwargs.update(utils.get_caller_metas())
+    return MultiCollisionFreeMotion(
+        targets=targets,
+        settings=settings or {},
+        collision_setups=collision_setups,
+        algorithm=algorithm,
+        metas=kwargs,
+    )
+
+
 def collision_free(
     target: Pose | tuple[float, ...],
     settings: MotionSettings = MotionSettings(),

--- a/nova/cell/__init__.py
+++ b/nova/cell/__init__.py
@@ -10,6 +10,8 @@ from nova.cell.controllers import (
 )
 from nova.cell.motion_group import MotionGroup
 from nova.cell.motion_group_models import MotionGroupModel
+from nova.cell.multi_motion_group import MultiMotionGroup, MultiMotionGroupBuilder
+from nova.cell.multi_motion_group_planner import MultiMotionGroupPlanner
 from nova.cell.multi_trajectory_cursor import IOSyncDriver, MultiTrajectoryCursor, SyncDriver
 from nova.cell.session_monitor import (
     DEFAULT_MAX_DRIFT,
@@ -17,7 +19,7 @@ from nova.cell.session_monitor import (
     SyncDriftError,
     SyncDriftMonitor,
 )
-from nova.cell.trajectory_executor import GroupArgs, TrajectoryExecutor, TrajectoryExecutorBuilder
+from nova.cell.trajectory_executor import GroupArgs, TrajectoryExecutor
 
 __all__ = [
     "Cell",
@@ -27,13 +29,15 @@ __all__ = [
     "IOSyncDriver",
     "MotionGroup",
     "MotionGroupModel",
+    "MultiMotionGroup",
+    "MultiMotionGroupBuilder",
+    "MultiMotionGroupPlanner",
     "MultiTrajectoryCursor",
     "SessionMonitor",
     "SyncDriftError",
     "SyncDriftMonitor",
     "SyncDriver",
     "TrajectoryExecutor",
-    "TrajectoryExecutorBuilder",
     "yaskawa_controller",
     "fanuc_controller",
     "universal_robots_controller",

--- a/nova/cell/multi_motion_group.py
+++ b/nova/cell/multi_motion_group.py
@@ -1,0 +1,286 @@
+"""One synchronized ensemble of motion groups, planned and executed as a unit.
+
+:class:`MultiMotionGroup` is to several motion groups what :class:`MotionGroup`
+is to one: a single object exposing ``plan`` / ``execute`` / ``plan_and_execute``.
+It composes the two halves that do the work —
+:class:`~nova.cell.multi_motion_group_planner.MultiMotionGroupPlanner` for
+planning and :class:`~nova.cell.trajectory_executor.TrajectoryExecutor` for
+synchronized execution — sharing one action list across both, exactly as
+:meth:`MotionGroup.plan_and_execute` passes ``actions`` to both its own halves.
+
+    ```python
+    ensemble = (
+        MultiMotionGroup.builder({"0@robot": robot_mg, "0@positioner": positioner_mg})
+        .sync_on_io("sync_out", controller="robot")
+        .build()
+    )
+    await ensemble.plan_and_execute(
+        [
+            multi_collision_free({"0@robot": Pose(...), "0@positioner": (j1, ..., j6)}),
+            io_write("OUT#1", True, device_id="robot"),
+        ],
+        tcp={"0@robot": "flange", "0@positioner": None},
+    )
+
+    # Execute-only, mirroring MotionGroup.execute — the planner stays dormant:
+    await ensemble.execute(recorded_trajectory)
+    ```
+
+The ensemble is cell-scoped: the multi-motion-group RRT endpoint reasons about
+the groups' mutual geometry in one cell-scoped request, and the sync barrier
+gates them on one cell's IO.
+"""
+
+from collections.abc import AsyncGenerator, Iterable, Mapping
+from contextlib import asynccontextmanager
+from typing import Self
+
+from nova import api
+from nova.actions.io import WriteAction, io_write
+from nova.actions.mock import WaitAction
+from nova.cell.motion_group import MotionGroup
+from nova.cell.multi_motion_group_planner import MultiMotionGroupPlanner
+from nova.cell.multi_trajectory_cursor import IOSyncDriver, MultiTrajectoryCursor
+from nova.cell.robot_cell import ActionsLike, _normalize_actions
+from nova.cell.session_monitor import SessionMonitor, SyncDriftMonitor
+from nova.cell.trajectory_executor import GroupArgs, TrajectoryExecutor
+
+
+class MultiMotionGroup:
+    """A synchronized ensemble of motion groups planned and executed as a unit.
+
+    Assembled with :meth:`builder`, which states the sync barrier. ``plan`` and
+    ``execute`` take the same ensemble action list; ``plan_and_execute`` chains
+    them, mirroring :meth:`MotionGroup.plan_and_execute`. A pre-planned
+    trajectory can be run with :meth:`execute` alone, leaving the planner idle.
+
+    Wraps two collaborators over the same motion groups — a
+    :class:`~nova.cell.multi_motion_group_planner.MultiMotionGroupPlanner` and a
+    :class:`~nova.cell.trajectory_executor.TrajectoryExecutor`; :meth:`builder`
+    wires them, or pass your own to the constructor.
+    """
+
+    def __init__(self, executor: TrajectoryExecutor, planner: MultiMotionGroupPlanner):
+        if set(executor.motion_groups) != set(planner.motion_groups):
+            raise ValueError(
+                "executor and planner must cover the same motion groups: "
+                f"{sorted(executor.motion_groups)} vs {sorted(planner.motion_groups)}"
+            )
+        self._executor = executor
+        self._planner = planner
+
+    @property
+    def motion_groups(self) -> dict[str, MotionGroup]:
+        """The motion groups in this ensemble, keyed by name."""
+        return self._executor.motion_groups
+
+    async def plan(
+        self,
+        actions: ActionsLike,
+        tcp: Mapping[str, str | None] | str | None = None,
+        start_joint_position: Mapping[str, tuple[float, ...]] | None = None,
+    ) -> api.models.MultiJointTrajectory:
+        """Plan one synchronized collision-free trajectory for the action list.
+
+        Delegates to :meth:`MultiMotionGroupPlanner.plan`; see it for the action
+        types, the per-group ``tcp``/``start_joint_position`` and the raised
+        errors. Returns a pure trajectory — :class:`WriteAction` entries carry no
+        joint samples and become the IO overlay only at :meth:`execute` time.
+        """
+        return await self._planner.plan(actions, tcp, start_joint_position)
+
+    async def execute(
+        self,
+        trajectory: api.models.MultiJointTrajectory,
+        groups: Mapping[str, GroupArgs] | None = None,
+        actions: ActionsLike | None = None,
+    ) -> None:
+        """Execute the trajectory front to end, synchronized through the barrier.
+
+        Pass the same ``actions`` list given to :meth:`plan` to fire its
+        location-anchored IO. Delegates to :meth:`TrajectoryExecutor.execute`.
+        """
+        await self._executor.execute(trajectory, actions=actions, groups=groups)
+
+    @asynccontextmanager
+    async def attach(
+        self,
+        trajectory: api.models.MultiJointTrajectory,
+        groups: Mapping[str, GroupArgs] | None = None,
+        actions: ActionsLike | None = None,
+    ) -> AsyncGenerator[MultiTrajectoryCursor, None]:
+        """Open an interactive session over the trajectory, delegating to
+        :meth:`TrajectoryExecutor.attach`."""
+        async with self._executor.attach(trajectory, actions=actions, groups=groups) as cursor:
+            yield cursor
+
+    async def plan_and_execute(
+        self,
+        actions: ActionsLike,
+        tcp: Mapping[str, str | None] | str | None = None,
+        start_joint_position: Mapping[str, tuple[float, ...]] | None = None,
+        groups: Mapping[str, GroupArgs] | None = None,
+    ) -> None:
+        """Plan and execute in one call, passing ``actions`` to both halves — the
+        multi-group counterpart of :meth:`MotionGroup.plan_and_execute`.
+
+        An all-non-motion list (only writes/waits) is applied directly, without
+        planning — the same short-circuit :meth:`MotionGroup.plan_and_execute` has.
+        """
+        actions_list = _normalize_actions(actions)
+        if actions_list and all(isinstance(a, (WaitAction, WriteAction)) for a in actions_list):
+            await self._executor.apply_non_motion_actions(actions_list)
+            return
+        trajectory = await self.plan(actions_list, tcp, start_joint_position)
+        await self.execute(trajectory, actions=actions_list, groups=groups)
+
+    @classmethod
+    def builder(
+        cls, motion_groups: Mapping[str, MotionGroup] | Iterable[MotionGroup]
+    ) -> "MultiMotionGroupBuilder":
+        """Start fluent assembly: ``MultiMotionGroup.builder(...)...build()``.
+
+        ``motion_groups`` is either a mapping of names to motion groups, or just
+        the motion groups — then their ids are the names.
+        """
+        return MultiMotionGroupBuilder(motion_groups)
+
+
+class MultiMotionGroupBuilder:
+    """Fluent assembly of a :class:`MultiMotionGroup`.
+
+    The basic scenario is two calls — the motion groups and the sync IO:
+
+    ```python
+    ensemble = (
+        MultiMotionGroup.builder([robot_mg, positioner_mg])
+        .sync_on_io("sync_out", controller="robot")
+        .build()
+    )
+    ```
+
+    :meth:`sync_on_io` states all three pieces of the barrier — the release
+    write, the clear write and every group's start condition — so nothing is
+    inferred later. :meth:`release_io`, :meth:`clear_io` and :meth:`watch` state
+    the same pieces one at a time, for topologies where they are not one boolean
+    IO; called after :meth:`sync_on_io` they replace what it set. A drift monitor
+    runs by default — :meth:`monitors` replaces it.
+    """
+
+    def __init__(self, motion_groups: Mapping[str, MotionGroup] | Iterable[MotionGroup]):
+        self._motion_groups = (
+            dict(motion_groups)
+            if isinstance(motion_groups, Mapping)
+            else {motion_group.id: motion_group for motion_group in motion_groups}
+        )
+        if not self._motion_groups:
+            raise ValueError("At least one motion group is required")
+        self._release: WriteAction | None = None
+        self._clear: WriteAction | None = None
+        self._watch: dict[str, api.models.StartOnIO] = {}
+        self._monitors: tuple[SessionMonitor, ...] | None = None
+
+    def sync_on_io(
+        self,
+        io: str,
+        controller: str | None = None,
+        *,
+        origin: api.models.IOOrigin = api.models.IOOrigin.CONTROLLER,
+        release_value: bool = True,
+    ) -> Self:
+        """Synchronize on one boolean IO: releasing the barrier writes
+        ``release_value`` to it, clearing writes the other value, and every
+        group watches it for ``release_value``.
+
+        ``controller`` may be omitted when all motion groups share one; pass
+        ``origin=IOOrigin.BUS_IO`` for a cell-wide bus variable.
+        """
+        self._release = self._write(io, release_value, controller, origin)
+        self._clear = self._write(io, not release_value, controller, origin)
+        condition = api.models.StartOnIO(
+            io=api.models.IOBooleanValue(io=io, value=release_value),
+            comparator=api.models.Comparator.COMPARATOR_EQUALS,
+            io_origin=origin,
+        )
+        self._watch = {motion_group: condition for motion_group in self._motion_groups}
+        return self
+
+    def release_io(
+        self,
+        io: str,
+        value: bool,
+        controller: str | None = None,
+        *,
+        origin: api.models.IOOrigin = api.models.IOOrigin.CONTROLLER,
+    ) -> Self:
+        """Release the barrier with this write — the counterpart of
+        :meth:`clear_io` when the two are not one IO's two values."""
+        self._release = self._write(io, value, controller, origin)
+        return self
+
+    def clear_io(
+        self,
+        io: str,
+        value: bool,
+        controller: str | None = None,
+        *,
+        origin: api.models.IOOrigin = api.models.IOOrigin.CONTROLLER,
+    ) -> Self:
+        """Clear the barrier with this write — the counterpart of
+        :meth:`release_io`."""
+        self._clear = self._write(io, value, controller, origin)
+        return self
+
+    def watch(self, motion_group: str, condition: api.models.StartOnIO) -> Self:
+        """Gate one group's start on this condition instead of on the release
+        write itself (e.g. the wired input the sync IO physically lands on)."""
+        if motion_group not in self._motion_groups:
+            raise ValueError(
+                f"Unknown motion group '{motion_group}'; known groups are {sorted(self._motion_groups)}"
+            )
+        self._watch[motion_group] = condition
+        return self
+
+    def monitors(self, *monitors: SessionMonitor) -> Self:
+        """Replace the default session monitors (a :class:`SyncDriftMonitor`);
+        call with no arguments to run without any."""
+        self._monitors = monitors
+        return self
+
+    def build(self) -> MultiMotionGroup:
+        if self._release is None:
+            raise ValueError("The barrier has no release write: call sync_on_io() or release_io()")
+        if self._clear is None:
+            raise ValueError("The barrier has no clear write: call sync_on_io() or clear_io()")
+        # The IO barrier writes into a single cell — bus IO is cell-scoped, a
+        # controller output is addressed as (cell, controller) — and synchronized
+        # execution is single-cell anyway, so any group's cell and gateway serve.
+        barrier_motion_group = next(iter(self._motion_groups.values()))
+        executor = TrajectoryExecutor(
+            self._motion_groups,
+            IOSyncDriver(
+                clear=self._clear,
+                release=self._release,
+                watch=self._watch,
+                api_client=barrier_motion_group._api_client,
+                cell=barrier_motion_group._cell,
+            ),
+            self._monitors if self._monitors is not None else (SyncDriftMonitor(),),
+        )
+        return MultiMotionGroup(executor, MultiMotionGroupPlanner(self._motion_groups))
+
+    def _write(
+        self, io: str, value: bool, controller: str | None, origin: api.models.IOOrigin
+    ) -> WriteAction:
+        """Build a sync write, resolving its controller when it is unambiguous."""
+        if origin is not api.models.IOOrigin.BUS_IO and controller is None:
+            controllers = {
+                motion_group._controller_id for motion_group in self._motion_groups.values()
+            }
+            if len(controllers) > 1:
+                raise ValueError(
+                    f"The controller for sync IO '{io}' is ambiguous: the motion groups span "
+                    f"controllers {sorted(controllers)}. Pass the controller explicitly."
+                )
+            controller = next(iter(controllers))
+        return io_write(io, value, device_id=controller, origin=origin)

--- a/nova/cell/multi_motion_group_planner.py
+++ b/nova/cell/multi_motion_group_planner.py
@@ -1,0 +1,260 @@
+"""Collision-free planning of one synchronized trajectory across motion groups.
+
+:class:`MultiMotionGroupPlanner` is to :class:`MotionGroup.plan` what
+:class:`TrajectoryExecutor` is to :meth:`MotionGroup.execute`: the multi-group
+counterpart. ``plan`` takes one ensemble action list — the same shape
+:meth:`MotionGroup.plan` accepts — and returns the
+:class:`api.models.MultiJointTrajectory` the executor consumes, so the two
+compose end to end:
+
+    ```python
+    planner = MultiMotionGroupPlanner({"0@kuka": robot_mg, "1@kuka": positioner_mg})
+    trajectory = await planner.plan(
+        [
+            multi_collision_free({"0@kuka": Pose(...), "1@kuka": (j1, j2, j3, j4, j5, j6)}),
+            wait(0.5),
+            multi_collision_free({"0@kuka": (...), "1@kuka": (...)}),
+        ],
+        tcp={"0@kuka": "1", "1@kuka": "0"},
+    )
+
+    ensemble = MultiMotionGroup.builder(planner.motion_groups).sync_on_io("OUT#1").build()
+    await ensemble.execute(trajectory)
+    ```
+
+The batch logic mirrors :meth:`MotionGroup.plan`: a
+:class:`~nova.actions.motions.MultiCollisionFreeMotion` is planned by the
+multi-motion-group RRT endpoint (``search_collision_free_multi_motion_group``)
+into a synchronized segment; a :class:`~nova.actions.mock.WaitAction` becomes an
+ensemble hold; segments are concatenated into one shared ``times``/``locations``
+— the invariant synchronized execution rests on.
+
+Like :meth:`MotionGroup.plan`, ``plan`` returns a pure trajectory: a
+:class:`~nova.actions.io.WriteAction` in the action list contributes no joint
+samples and is ignored here. Its location-anchored IO overlay is derived from
+the same action list at execute time, by
+:meth:`~nova.cell.trajectory_executor.TrajectoryExecutor.execute` — so the
+``actions`` list is passed to both, exactly as in the single-motion-group flow.
+"""
+
+from collections.abc import Mapping
+
+from nova import api
+from nova.actions.io import WriteAction
+from nova.actions.mock import WaitAction
+from nova.actions.motions import MultiCollisionFreeMotion
+from nova.cell.motion_group import MotionGroup, _find_and_sort_best_joint_solutions
+from nova.cell.robot_cell import ActionsLike, _normalize_actions
+from nova.exceptions import NoInverseKinematicsSolutionFound, PlanTrajectoryFailed
+from nova.types import Pose
+from nova.utils.joint_trajectory import combine_multi_trajectories
+
+_WAIT_TIMESTEP = 0.050  # 50 ms, matching MotionGroup._build_wait_trajectory
+
+
+class MultiMotionGroupPlanner:
+    """Plan one synchronized, collision-free trajectory across several motion groups.
+
+    Created once for the motion groups to coordinate; ``plan`` is called per
+    action list. All groups must live in one cell — the RRT endpoint is
+    cell-scoped and reasons about their mutual geometry in a single request.
+    """
+
+    def __init__(self, motion_groups: Mapping[str, MotionGroup]):
+        self._motion_groups = dict(motion_groups)
+        if not self._motion_groups:
+            raise ValueError("At least one motion group is required")
+
+        cells = {motion_group._cell for motion_group in self._motion_groups.values()}
+        if len(cells) > 1:
+            raise ValueError(
+                f"Multi-motion-group planning is cell-scoped but the motion groups span "
+                f"{sorted(cells)}. Plan one cell at a time."
+            )
+        self._cell = next(iter(cells))
+        # Controllers in a cell share the cell's gateway; the single RRT request
+        # goes to one, so pin it here.
+        self._api_client = next(iter(self._motion_groups.values()))._api_client
+
+    @property
+    def motion_groups(self) -> dict[str, MotionGroup]:
+        """The motion groups this planner coordinates, keyed by name.
+
+        Handy to hand straight to :meth:`MultiMotionGroup.builder`."""
+        return dict(self._motion_groups)
+
+    async def plan(
+        self,
+        actions: ActionsLike,
+        tcp: Mapping[str, str | None] | str | None = None,
+        start_joint_position: Mapping[str, tuple[float, ...]] | None = None,
+    ) -> api.models.MultiJointTrajectory:
+        """Plan a synchronized collision-free trajectory for the action list.
+
+        Mirrors :meth:`MotionGroup.plan`: an ensemble action list is batched and
+        each batch planned in turn, every segment continuing from the previous
+        one's end, then all concatenated into a single shared parameterization.
+
+        Args:
+            actions: The ensemble actions — one or a sequence of
+                :class:`~nova.actions.motions.MultiCollisionFreeMotion` (each
+                planned by RRT into a synchronized segment),
+                :class:`~nova.actions.mock.WaitAction` (an ensemble hold) and
+                :class:`~nova.actions.io.WriteAction` (ignored here — it carries
+                no joint samples; pass the same list to the executor for its IO
+                overlay). Every motion's ``targets`` must cover exactly the
+                planner's groups.
+            tcp: The TCP per group, or a single TCP shared by all. Required for
+                any group whose target is a pose (for inverse kinematics); also
+                selects the motion group setup. ``None`` for a group means no TCP.
+            start_joint_position: The start joint position per group. A group
+                left out starts from its current joints.
+
+        Returns:
+            The synchronized trajectory, ready for :meth:`TrajectoryExecutor.execute`.
+
+        Raises:
+            ValueError: An action type has no place in a collision-free plan, or
+                a motion's targets do not match the planner's motion groups.
+            PlanTrajectoryFailed: The RRT search found no coordinated path.
+            NoInverseKinematicsSolutionFound: A pose target has no IK solution.
+        """
+        actions_list = _normalize_actions(actions)
+        if not actions_list:
+            raise ValueError("No actions provided")
+
+        setups = {
+            name: await motion_group.get_setup(tcp_name=self._tcp_for(name, tcp))
+            for name, motion_group in self._motion_groups.items()
+        }
+        current: dict[str, tuple[float, ...]] = {
+            name: (start_joint_position or {}).get(name) or await motion_group.joints()
+            for name, motion_group in self._motion_groups.items()
+        }
+
+        segments: list[api.models.MultiJointTrajectory] = []
+        for action in actions_list:
+            if isinstance(action, MultiCollisionFreeMotion):
+                segment = await self._plan_multi_collision_free(action, tcp, current, setups)
+            elif isinstance(action, WaitAction):
+                segment = self._build_wait_segment(current, action.wait_for_in_seconds)
+            elif isinstance(action, WriteAction):
+                # Writes carry no joint samples; their IO overlay is derived at
+                # execute time (see the module docstring).
+                continue
+            else:
+                raise ValueError(
+                    f"Action type '{type(action).__name__}' is not supported by synchronized "
+                    "collision-free planning; use multi_collision_free(), wait() or io_write()."
+                )
+            # The segment's last sample is the next batch's start, per group.
+            for name, samples in segment.joint_positions_by_motion_group_key.items():
+                current[name] = tuple(samples[-1])
+            segments.append(segment)
+
+        if not segments:
+            raise ValueError(
+                "The action list has no motion or wait to plan; it carries only writes."
+            )
+        return combine_multi_trajectories(segments)
+
+    def _tcp_for(self, name: str, tcp: Mapping[str, str | None] | str | None) -> str | None:
+        return tcp.get(name) if isinstance(tcp, Mapping) else tcp
+
+    async def _plan_multi_collision_free(
+        self,
+        action: MultiCollisionFreeMotion,
+        tcp: Mapping[str, str | None] | str | None,
+        current: Mapping[str, tuple[float, ...]],
+        setups: Mapping[str, api.models.MotionGroupSetup],
+    ) -> api.models.MultiJointTrajectory:
+        if set(action.targets) != set(self._motion_groups):
+            raise ValueError(
+                f"Motion targets {sorted(action.targets)} must match the planner's "
+                f"motion groups {sorted(self._motion_groups)}"
+            )
+
+        path_definitions: dict[str, api.models.JointPTPMotion] = {}
+        for name, target in action.targets.items():
+            motion_group = self._motion_groups[name]
+            group_tcp = self._tcp_for(name, tcp)
+            start = current[name]
+            target_joints = await self._resolve_target(
+                target, group_tcp, start, motion_group, setups[name]
+            )
+            settings = action.settings.get(name)
+            path_definitions[name] = api.models.JointPTPMotion(
+                start_joint_position=list(start),
+                target_joint_position=list(target_joints),
+                limits_override=(
+                    settings.as_limits_settings()
+                    if settings is not None and settings.has_limits_override()
+                    else None
+                ),
+            )
+
+        request = api.models.MultiSearchCollisionFreeRequest(
+            motion_group_setups_by_motion_group_key=dict(setups),
+            path_definitions_by_motion_group_key=path_definitions,
+            collision_setups=(
+                dict(action.collision_setups) if action.collision_setups is not None else None
+            ),
+            algorithm_settings=action.algorithm,
+        )
+
+        response = (
+            await self._api_client.trajectory_planning_api.search_collision_free_multi_motion_group(
+                cell=self._cell, multi_search_collision_free_request=request
+            )
+        )
+
+        if isinstance(response.response, api.models.PlanCollisionFreeFailedResponse):
+            raise PlanTrajectoryFailed(
+                error=response.response, motion_group_id=", ".join(sorted(self._motion_groups))
+            )
+        if not isinstance(response.response, api.models.MultiJointTrajectory):
+            raise ValueError("Multi-motion-group planning returned no trajectory")
+        return response.response
+
+    def _build_wait_segment(
+        self, current: Mapping[str, tuple[float, ...]], wait_time: float
+    ) -> api.models.MultiJointTrajectory:
+        """Hold every group at its current joints for ``wait_time`` seconds.
+
+        The multi-group counterpart of ``MotionGroup._build_wait_trajectory``:
+        50 ms steps, locations flat at 0 (a hold makes no path progress)."""
+        num_steps = max(2, int(wait_time / _WAIT_TIMESTEP) + 1)
+        times = [i * _WAIT_TIMESTEP for i in range(num_steps)]
+        times[-1] = wait_time
+        return api.models.MultiJointTrajectory(
+            joint_positions_by_motion_group_key={
+                name: [list(joints) for _ in range(num_steps)] for name, joints in current.items()
+            },
+            times=times,
+            locations=[0.0 for _ in range(num_steps)],
+        )
+
+    async def _resolve_target(
+        self,
+        target: Pose | tuple[float, ...],
+        tcp: str | None,
+        start: tuple[float, ...],
+        motion_group: MotionGroup,
+        setup: api.models.MotionGroupSetup,
+    ) -> tuple[float, ...]:
+        """Resolve a target to joints, solving IK for a pose and picking the
+        solution closest to the start."""
+        if isinstance(target, tuple):
+            return target
+        if tcp is None:
+            raise ValueError(
+                f"TCP is required for a pose target on '{motion_group.id}'; pass tcp or use a "
+                "joint-space target instead."
+            )
+        solutions = await motion_group._inverse_kinematics(
+            poses=[target], tcp=tcp, motion_group_setup=setup
+        )
+        if not solutions or not solutions[0]:
+            raise NoInverseKinematicsSolutionFound(target)
+        joint_limits = setup.global_limits.joints if setup.global_limits is not None else None
+        return _find_and_sort_best_joint_solutions(start, solutions[0], joint_limits)[0]

--- a/nova/cell/multi_trajectory_cursor.py
+++ b/nova/cell/multi_trajectory_cursor.py
@@ -3,13 +3,20 @@
 import asyncio
 import contextlib
 import logging
-from collections.abc import AsyncGenerator, AsyncIterable, Mapping
+from collections.abc import AsyncGenerator, AsyncIterable, Mapping, Sequence
 from dataclasses import dataclass
+from math import ceil
 from typing import Protocol
 
 from nova import api
+from nova.actions.base import Action
 from nova.actions.io import WriteAction
-from nova.cell.movement_controller.trajectory_cursor import OperationResult, TrajectoryCursor
+from nova.cell.movement_controller.trajectory_cursor import (
+    OperationResult,
+    OperationType,
+    TrajectoryCursor,
+    action_index_for_location,
+)
 from nova.cell.state_stream import StreamBroadcaster
 from nova.core.gateway import ApiGateway
 
@@ -60,7 +67,7 @@ class IOSyncDriver:
 
     - **Same controller / cell-wide bus IO**: one boolean trigger; every group
       watches it, clearing writes its inverse — derived by the builder's
-      :meth:`TrajectoryExecutorBuilder.sync_on_io`.
+      :meth:`MultiMotionGroupBuilder.sync_on_io`.
     - **Physically wired controllers**: the writes go to one controller's
       output; each group watches its own input the wire lands on. Spelled out
       explicitly — the executor cannot know how a cell is wired.
@@ -180,16 +187,36 @@ class MultiTrajectoryCursor:
 
     Obtained from :meth:`TrajectoryExecutor.attach`; drives all groups together
     through the start barrier with the single cursor's interactive contract —
-    ``forward`` / ``forward_to`` / ``pause``, ``current_location`` and
-    ``stream_state``.
+    ``forward`` / ``forward_to`` / ``forward_to_next_action`` / ``pause``,
+    ``current_location`` / ``current_action`` and ``stream_state``.
+
+    ``actions`` is the ensemble action list: its motions map location to action
+    for ``current_action`` and action stepping, exactly as on the single cursor.
+    All groups share one parameterization, so a location — and thus an action
+    boundary — means the same instant on every path.
 
     Backward movement is not exposed: driving the barrier in reverse is
     mechanically symmetric but unverified against real controllers.
     """
 
-    def __init__(self, cursors: dict[str, TrajectoryCursor], sync: SyncDriver):
+    def __init__(
+        self, cursors: dict[str, TrajectoryCursor], sync: SyncDriver, actions: Sequence[Action] = ()
+    ):
         self._cursors = cursors
         self._sync = sync
+        # Only motion actions carry a location boundary — the same mapping the
+        # single cursor builds from CombinedActions.motions.
+        self._actions = [action for action in actions if action.is_motion()]
+        if self._actions:
+            # IO overlay and action stepping anchor on integer motion indices, so
+            # every motion must span one location unit — the same contract the
+            # single cursor checks.
+            end = self.end_location
+            if abs(end - len(self._actions)) > 0.01:
+                raise ValueError(
+                    f"Trajectory end location ({end}) does not match the number of motion "
+                    f"actions ({len(self._actions)}); each motion must span one location unit."
+                )
         # One fan-out per group: a cursor tees its states into a single queue, but
         # the session has several consumers (barrier arm-wait, drift monitors,
         # user streams).
@@ -308,6 +335,32 @@ class MultiTrajectoryCursor:
             target_location=location, playback_speed_in_percent=playback_speed_in_percent
         )
 
+    def forward_to_next_action(
+        self, playback_speed_in_percent: int | None = None
+    ) -> asyncio.Future[dict[str, OperationResult]]:
+        """Move all groups forward to the start of the next action.
+
+        Steps the ensemble one action boundary (integer location) at a time; at
+        the end of the trajectory it returns immediately without commanding a
+        move, mirroring the single cursor's ``forward_to_next_action``.
+        """
+        target = float(ceil(self.current_location))
+        if target <= self.current_location:
+            target += 1.0
+        if target > self.end_location:
+            future: asyncio.Future[dict[str, OperationResult]] = asyncio.Future()
+            future.set_result(
+                {
+                    name: OperationResult(
+                        operation_type=OperationType.FORWARD_TO_NEXT_ACTION,
+                        final_location=cursor.current_location,
+                    )
+                    for name, cursor in self._cursors.items()
+                }
+            )
+            return future
+        return self.forward_to(target, playback_speed_in_percent=playback_speed_in_percent)
+
     async def _run_barrier(self, intent: _ForwardIntent) -> None:
         """Run one barrier and resolve the caller's future with its outcome.
 
@@ -400,6 +453,26 @@ class MultiTrajectoryCursor:
         """Location of the first motion group; with the shared parameterization
         all groups are at (drift-bounded) the same location."""
         return next(iter(self._cursors.values())).current_location
+
+    @property
+    def end_location(self) -> float:
+        """The location at the end of the shared trajectory."""
+        return next(iter(self._cursors.values())).end_location
+
+    @property
+    def current_action_index(self) -> int | None:
+        """Zero-based index of the action at the current location, or None when
+        the session carries no action metadata."""
+        if not self._actions:
+            return None
+        return action_index_for_location(self.current_location, len(self._actions))
+
+    @property
+    def current_action(self) -> Action | None:
+        """The ensemble action at the current location, or None when the session
+        carries no action metadata."""
+        index = self.current_action_index
+        return self._actions[index] if index is not None else None
 
     def stream_state(
         self, group: str | None = None

--- a/nova/cell/trajectory_executor.py
+++ b/nova/cell/trajectory_executor.py
@@ -20,13 +20,10 @@ image rather than on N network round-trips:
    start can never satisfy the barrier),
 4. the sync IO is set.
 
-Example:
-    ```python
-    executor = (
-        TrajectoryExecutor.builder({"0@robot": robot_mg, "0@positioner": positioner_mg})
-        .sync_on_io("sync_out", controller="robot")
-        .build()
-    )
+This is the execution machinery behind :class:`~nova.cell.multi_motion_group.MultiMotionGroup`;
+assemble it through :meth:`MultiMotionGroup.builder` (the user-facing entry) or construct it
+directly with an :class:`IOSyncDriver`. Then::
+
     await executor.execute(multi_joint_trajectory)
 
     # Or interactively:
@@ -34,32 +31,29 @@ Example:
         operation = cursor.forward()
         cursor.pause()
         await cursor.forward()  # resumes through the barrier again
-    ```
 """
 
 import asyncio
 import functools
-from collections.abc import AsyncGenerator, Iterable, Mapping, Sequence
+from collections.abc import AsyncGenerator, Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import Self
 
 from nova import api
-from nova.actions.io import WriteAction, io_write
+from nova.actions.base import Action
+from nova.actions.container import located_writes, write_to_set_io
+from nova.actions.io import WriteAction
+from nova.actions.mock import WaitAction
 from nova.cell.motion_group import MotionGroup
 from nova.cell.movement_controller.trajectory_cursor import TrajectoryCursor
-from nova.cell.multi_trajectory_cursor import IOSyncDriver, MultiTrajectoryCursor, SyncDriver
-from nova.cell.session_monitor import SessionMonitor, SyncDriftMonitor
+from nova.cell.multi_trajectory_cursor import MultiTrajectoryCursor, SyncDriver
+from nova.cell.robot_cell import ActionsLike, _normalize_actions
+from nova.cell.session_monitor import SessionMonitor
 
 
 @dataclass(frozen=True)
 class GroupArgs:
     """Per-group arguments for one execution.
-
-    Actions are not part of this: an action list belongs to one motion group's
-    trajectory, whose integer locations are *its* action boundaries, and the
-    ensemble has one shared parameterization instead. Synchronized execution
-    therefore carries no action metadata and no IO overlay derived from it.
 
     Attributes:
         tcp: TCP the trajectory was planned for; passed to trajectory loading.
@@ -97,9 +91,9 @@ class TrajectoryExecutor:
 
     Every execution goes through the barrier, so a single group with a
     hardware-gated start is a valid topology; plain single-group execution is
-    :meth:`MotionGroup.execute`'s job. Groups need not share a cell or gateway
-    — each is executed through its own — but a :class:`SyncDriver` may require
-    it (:class:`IOSyncDriver` writes within one cell).
+    :meth:`MotionGroup.execute`'s job. All groups must live in one cell — the
+    sync barrier gates them on that cell's IO (:class:`IOSyncDriver` writes
+    within one cell) — though each is still executed through its own gateway.
 
     ``monitors`` observe every session's state streams; one that raises aborts
     the session.
@@ -113,24 +107,50 @@ class TrajectoryExecutor:
     ):
         if not motion_groups:
             raise ValueError("At least one motion group is required")
-        groups_without_condition = set(motion_groups) - set(sync.start_conditions())
-        if groups_without_condition:
+
+        cells = {motion_group._cell for motion_group in motion_groups.values()}
+        if len(cells) > 1:
+            raise ValueError(
+                f"Synchronized execution is cell-scoped but the motion groups span "
+                f"{sorted(cells)}. The sync barrier gates them on one cell's IO."
+            )
+
+        motion_groups_without_condition = set(motion_groups) - set(sync.start_conditions())
+        if motion_groups_without_condition:
             raise ValueError(
                 f"The sync driver has no start condition for groups: "
-                f"{sorted(groups_without_condition)}"
+                f"{sorted(motion_groups_without_condition)}"
             )
 
         self._motion_groups = dict(motion_groups)
         self._monitors = tuple(monitors)
         self._sync = sync
+        # Controller id -> the groups on it, name-ordered so the first is the
+        # deterministic pick; fixed for the executor's lifetime.
+        self._motion_groups_by_controller: dict[str, list[str]] = {}
+        for name in sorted(self._motion_groups):
+            self._motion_groups_by_controller.setdefault(
+                self._motion_groups[name]._controller_id, []
+            ).append(name)
+
+    @property
+    def motion_groups(self) -> dict[str, MotionGroup]:
+        """The motion groups this executor drives, keyed by name."""
+        return dict(self._motion_groups)
 
     async def execute(
         self,
         trajectory: api.models.MultiJointTrajectory,
         groups: Mapping[str, GroupArgs] | None = None,
+        actions: ActionsLike | None = None,
     ) -> None:
-        """Execute the trajectory front to end, synchronized through the barrier."""
-        async with self.attach(trajectory, groups) as cursor:
+        """Execute the trajectory front to end, synchronized through the barrier.
+
+        ``actions`` is the same ensemble action list passed to
+        :meth:`MultiMotionGroupPlanner.plan`; its :class:`WriteAction` entries
+        become the location-anchored IO overlay fired during execution (see
+        :meth:`attach`)."""
+        async with self.attach(trajectory, actions=actions, groups=groups) as cursor:
             await cursor.forward()
 
     @asynccontextmanager
@@ -138,15 +158,29 @@ class TrajectoryExecutor:
         self,
         trajectory: api.models.MultiJointTrajectory,
         groups: Mapping[str, GroupArgs] | None = None,
+        actions: ActionsLike | None = None,
     ) -> AsyncGenerator[MultiTrajectoryCursor, None]:
         """Open a session for interactive control: load the trajectory, open the
         sockets, initialize — but do not move. Starting is the caller's call
         (:meth:`MultiTrajectoryCursor.forward`); exiting the context detaches
-        every cursor and closes every socket."""
+        every cursor and closes every socket.
+
+        ``actions`` mirrors the list given to
+        :meth:`MultiMotionGroupPlanner.plan`. It is not baked into the loaded
+        trajectory: each :class:`WriteAction` is turned into a
+        :class:`api.models.SetIO` anchored at its motion index (the count of
+        motions before it, waits skipped — the same convention as single-group
+        execution) and attached to the owning group's cursor, which re-emits the
+        overlay on every start. Every write is fired once, by the single group
+        it routes to; since all groups share one ``locations`` array that instant
+        is synchronized across the ensemble."""
         per_group = self._split_for_groups(trajectory)
         unknown_group_args = set(groups or {}) - set(self._motion_groups)
         if unknown_group_args:
             raise ValueError(f"Group args given for unknown groups: {sorted(unknown_group_args)}")
+
+        action_list = _normalize_actions(actions or [])
+        overlay = self._build_io_overlay(action_list)
 
         cursors: dict[str, TrajectoryCursor] = {}
         for name, joint_trajectory in per_group.items():
@@ -155,9 +189,8 @@ class TrajectoryExecutor:
             trajectory_id = await motion_group._load_planned_motion(
                 joint_trajectory, group_args.tcp
             )
-            # Binding the rate keeps the cursor's zero-arg stream factory seam
-            # untouched; with no rate the bare bound method is passed, exactly
-            # as before.
+            # Bind the rate so the cursor still receives a zero-arg stream
+            # factory; with no rate the bare bound method already is one.
             state_stream_source = (
                 functools.partial(motion_group.stream_state, group_args.state_stream_rate_msecs)
                 if group_args.state_stream_rate_msecs is not None
@@ -170,9 +203,10 @@ class TrajectoryExecutor:
                 detach_on_standstill=False,
                 emit_motion_events=False,
                 ignore_controller_limits=group_args.ignore_controller_limits,
+                set_outputs=overlay[name] or None,
             )
 
-        cursor = MultiTrajectoryCursor(cursors, self._sync)
+        cursor = MultiTrajectoryCursor(cursors, self._sync, actions=action_list)
         try:
             async with asyncio.TaskGroup() as task_group:
                 # control() owns the barrier and the state fan-out in its own
@@ -224,176 +258,64 @@ class TrajectoryExecutor:
             for key, joint_samples in joint_positions_by_group.items()
         }
 
+    def _build_io_overlay(self, actions: Sequence[Action]) -> dict[str, list[api.models.SetIO]]:
+        """Turn the action list's writes into a per-group ``SetIO`` overlay.
+
+        Each write is routed to exactly one group and anchored at its motion
+        index; all other groups get an empty list. A controller output goes to
+        the group on that controller; a cell-wide bus variable goes to one
+        deterministic group (all groups share the ``locations`` array, so which
+        one carries it does not change the instant).
+        """
+        overlay: dict[str, list[api.models.SetIO]] = {name: [] for name in self._motion_groups}
+        for location, write in located_writes(actions):
+            overlay[self._motion_group_for_write(write)].append(write_to_set_io(write, location))
+        return overlay
+
+    async def apply_non_motion_actions(self, actions: Sequence[Action]) -> None:
+        """Run an all-non-motion action list directly, without a trajectory.
+
+        The multi-group counterpart of ``MotionGroup``'s direct non-motion path:
+        a wait sleeps, a write is routed to its owning motion group and set on that
+        group's controller. Used by :meth:`MultiMotionGroup.plan_and_execute` when
+        there is nothing to plan.
+        """
+        for action in actions:
+            if isinstance(action, WaitAction):
+                await asyncio.sleep(action.wait_for_in_seconds)
+            elif isinstance(action, WriteAction):
+                motion_group = self._motion_group_for_write(action)
+                await self._motion_groups[motion_group]._execute_direct_non_motion_actions([action])
+            else:
+                raise ValueError(f"Not a non-motion action: {type(action).__name__}")
+
+    def _motion_group_for_write(self, write: WriteAction) -> str:
+        """The single motion group whose stream fires this write, from the controller
+        index built in ``__init__``: the group on the write's controller, or the
+        first motion group for a cell-wide bus IO (all groups share the ``locations``
+        array, so which one carries it does not change the instant)."""
+        if write.origin is api.models.IOOrigin.BUS_IO:
+            return min(self._motion_groups)
+        if write.device_id is None:
+            if len(self._motion_groups_by_controller) > 1:
+                raise ValueError(
+                    f"The controller for IO '{write.key}' is ambiguous: the motion groups span "
+                    f"controllers {sorted(self._motion_groups_by_controller)}. Set the write's "
+                    "device_id explicitly."
+                )
+            return min(self._motion_groups)
+        on_controller = self._motion_groups_by_controller.get(write.device_id)
+        if not on_controller:
+            raise ValueError(
+                f"No motion group is on controller '{write.device_id}' for IO '{write.key}'; "
+                f"known controllers are {sorted(self._motion_groups_by_controller)}."
+            )
+        return on_controller[0]
+
     async def _run_execute_trajectory(self, name: str, cursor: TrajectoryCursor) -> None:
-        # Addressed through the group's own cell and gateway: executing does not
-        # assume the groups share either, only the IO barrier does.
         motion_group = self._motion_groups[name]
         await motion_group._api_client.trajectory_execution_api.execute_trajectory(
             cell=motion_group._cell,
             controller=motion_group._controller_id,
             client_request_generator=cursor.cntrl,  # ty: ignore[invalid-argument-type]
         )
-
-    @classmethod
-    def builder(
-        cls, motion_groups: Mapping[str, MotionGroup] | Iterable[MotionGroup]
-    ) -> "TrajectoryExecutorBuilder":
-        """Start fluent assembly: ``TrajectoryExecutor.builder(...)...build()``.
-
-        ``motion_groups`` is either a mapping of names to motion groups, or
-        just the motion groups — then their ids are the names.
-        """
-        return TrajectoryExecutorBuilder(motion_groups)
-
-
-class TrajectoryExecutorBuilder:
-    """Fluent assembly of a :class:`TrajectoryExecutor`.
-
-    The basic scenario is two calls — the motion groups and the sync IO:
-
-    ```python
-    executor = (
-        TrajectoryExecutor.builder([robot_mg, positioner_mg])
-        .sync_on_io("sync_out", controller="robot")
-        .build()
-    )
-    ```
-
-    :meth:`sync_on_io` states all three pieces of the barrier — the release
-    write, the clear write and every group's start condition — so nothing is
-    inferred later. :meth:`release_io`, :meth:`clear_io` and :meth:`watch`
-    state the same pieces one at a time, for topologies where they are not one
-    boolean IO; called after :meth:`sync_on_io` they replace what it set. A
-    drift monitor runs by default — :meth:`monitors` replaces it. A custom
-    :class:`SyncDriver` goes through the plain constructor instead.
-    """
-
-    def __init__(self, motion_groups: Mapping[str, MotionGroup] | Iterable[MotionGroup]):
-        self._motion_groups = (
-            dict(motion_groups)
-            if isinstance(motion_groups, Mapping)
-            else {motion_group.id: motion_group for motion_group in motion_groups}
-        )
-        if not self._motion_groups:
-            raise ValueError("At least one motion group is required")
-        self._release: WriteAction | None = None
-        self._clear: WriteAction | None = None
-        self._watch: dict[str, api.models.StartOnIO] = {}
-        self._monitors: tuple[SessionMonitor, ...] | None = None
-
-    def sync_on_io(
-        self,
-        io: str,
-        controller: str | None = None,
-        *,
-        origin: api.models.IOOrigin = api.models.IOOrigin.CONTROLLER,
-        release_value: bool = True,
-    ) -> Self:
-        """Synchronize on one boolean IO: releasing the barrier writes
-        ``release_value`` to it, clearing writes the other value, and every
-        group watches it for ``release_value``.
-
-        ``controller`` may be omitted when all motion groups share one; pass
-        ``origin=IOOrigin.BUS_IO`` for a cell-wide bus variable.
-        """
-        self._release = self._write(io, release_value, controller, origin)
-        self._clear = self._write(io, not release_value, controller, origin)
-        condition = api.models.StartOnIO(
-            io=api.models.IOBooleanValue(io=io, value=release_value),
-            comparator=api.models.Comparator.COMPARATOR_EQUALS,
-            io_origin=origin,
-        )
-        self._watch = {group: condition for group in self._motion_groups}
-        return self
-
-    def release_io(
-        self,
-        io: str,
-        value: bool,
-        controller: str | None = None,
-        *,
-        origin: api.models.IOOrigin = api.models.IOOrigin.CONTROLLER,
-    ) -> Self:
-        """Release the barrier with this write — the counterpart of
-        :meth:`clear_io` when the two are not one IO's two values."""
-        self._release = self._write(io, value, controller, origin)
-        return self
-
-    def clear_io(
-        self,
-        io: str,
-        value: bool,
-        controller: str | None = None,
-        *,
-        origin: api.models.IOOrigin = api.models.IOOrigin.CONTROLLER,
-    ) -> Self:
-        """Clear the barrier with this write — the counterpart of
-        :meth:`release_io`."""
-        self._clear = self._write(io, value, controller, origin)
-        return self
-
-    def watch(self, group: str, condition: api.models.StartOnIO) -> Self:
-        """Gate one group's start on this condition instead of on the release
-        write itself (e.g. the wired input the sync IO physically lands on)."""
-        if group not in self._motion_groups:
-            raise ValueError(
-                f"Unknown motion group '{group}'; known groups are {sorted(self._motion_groups)}"
-            )
-        self._watch[group] = condition
-        return self
-
-    def monitors(self, *monitors: SessionMonitor) -> Self:
-        """Replace the default session monitors (a :class:`SyncDriftMonitor`);
-        call with no arguments to run without any."""
-        self._monitors = monitors
-        return self
-
-    def build(self) -> TrajectoryExecutor:
-        if self._release is None:
-            raise ValueError("The barrier has no release write: call sync_on_io() or release_io()")
-        if self._clear is None:
-            raise ValueError("The barrier has no clear write: call sync_on_io() or clear_io()")
-        barrier_group = self._barrier_group()
-        return TrajectoryExecutor(
-            self._motion_groups,
-            IOSyncDriver(
-                clear=self._clear,
-                release=self._release,
-                watch=self._watch,
-                api_client=barrier_group._api_client,
-                cell=barrier_group._cell,
-            ),
-            self._monitors if self._monitors is not None else (SyncDriftMonitor(),),
-        )
-
-    def _barrier_group(self) -> MotionGroup:
-        """The motion group whose cell and gateway carry the IO barrier.
-
-        The IO barrier writes into a single cell — bus IO is cell-scoped, and a
-        controller output is addressed as (cell, controller) — so groups spanning
-        cells need a driver built for the cell that carries the sync IO.
-        """
-        cells = {motion_group._cell for motion_group in self._motion_groups.values()}
-        if len(cells) > 1:
-            raise ValueError(
-                f"The IO barrier writes into one cell but the motion groups span {sorted(cells)}. "
-                "Build an IOSyncDriver for the cell carrying the sync IO and pass it to "
-                "TrajectoryExecutor directly."
-            )
-        return next(iter(self._motion_groups.values()))
-
-    def _write(
-        self, io: str, value: bool, controller: str | None, origin: api.models.IOOrigin
-    ) -> WriteAction:
-        """Build a sync write, resolving its controller when it is unambiguous."""
-        if origin is not api.models.IOOrigin.BUS_IO and controller is None:
-            controllers = {
-                motion_group._controller_id for motion_group in self._motion_groups.values()
-            }
-            if len(controllers) > 1:
-                raise ValueError(
-                    f"The controller for sync IO '{io}' is ambiguous: the motion groups span "
-                    f"controllers {sorted(controllers)}. Pass the controller explicitly."
-                )
-            controller = next(iter(controllers))
-        return io_write(io, value, device_id=controller, origin=origin)

--- a/nova/utils/joint_trajectory.py
+++ b/nova/utils/joint_trajectory.py
@@ -26,3 +26,40 @@ def combine_trajectories(
         current_end_location = final_trajectory.locations[-1]
 
     return final_trajectory
+
+
+def combine_multi_trajectories(
+    trajectories: list[api.models.MultiJointTrajectory],
+) -> api.models.MultiJointTrajectory:
+    """Concatenate synchronized multi-motion-group trajectories end to end.
+
+    The multi-group counterpart of :func:`combine_trajectories`: every segment
+    shares one ``times``/``locations`` across all its groups, and the seam shifts
+    later segments to continue from the previous end — so the result keeps the
+    single shared parameterization synchronized execution rests on. All segments
+    must cover the same set of motion groups.
+    """
+    final_trajectory = trajectories[0]
+    keys = set(final_trajectory.joint_positions_by_motion_group_key)
+    current_end_time = final_trajectory.times[-1]
+    current_end_location = final_trajectory.locations[-1]
+
+    for trajectory in trajectories[1:]:
+        if set(trajectory.joint_positions_by_motion_group_key) != keys:
+            raise ValueError(
+                "All segments must cover the same motion groups; got "
+                f"{sorted(trajectory.joint_positions_by_motion_group_key)} vs {sorted(keys)}"
+            )
+
+        # Skip each segment's first point: it duplicates the previous seam.
+        final_trajectory.times.extend(t + current_end_time for t in trajectory.times[1:])
+        final_trajectory.locations.extend(
+            location + current_end_location for location in trajectory.locations[1:]
+        )
+        for key, samples in trajectory.joint_positions_by_motion_group_key.items():
+            final_trajectory.joint_positions_by_motion_group_key[key].extend(samples[1:])
+
+        current_end_time = final_trajectory.times[-1]
+        current_end_location = final_trajectory.locations[-1]
+
+    return final_trajectory

--- a/tests/actions/test_located_writes.py
+++ b/tests/actions/test_located_writes.py
@@ -1,0 +1,55 @@
+"""Tests for the shared IO-overlay helpers in ``nova.actions.container``.
+
+``located_writes`` anchors each write on the count of preceding motions (waits
+skipped); ``to_set_io`` builds on it and must keep its historical behavior."""
+
+from nova import api
+from nova.actions.container import CombinedActions, located_writes, write_to_set_io
+from nova.actions.io import io_write
+from nova.actions.mock import wait
+from nova.actions.motions import joint_ptp
+
+
+def _ptp(sample: float):
+    return joint_ptp((sample,) * 6)
+
+
+class TestLocatedWrites:
+    def test_index_counts_preceding_motions(self):
+        writes = located_writes(
+            [
+                io_write("OUT#0", True),  # 0 motions before
+                _ptp(1.0),
+                io_write("OUT#1", True),  # 1 motion before
+                _ptp(2.0),
+                _ptp(3.0),
+                io_write("OUT#3", True),  # 3 motions before
+            ]
+        )
+        assert [(index, w.key) for index, w in writes] == [(0, "OUT#0"), (1, "OUT#1"), (3, "OUT#3")]
+
+    def test_wait_does_not_advance_index(self):
+        writes = located_writes([_ptp(1.0), wait(0.5), io_write("OUT#1", True)])
+        assert [index for index, _ in writes] == [1]
+
+    def test_no_writes__empty(self):
+        assert located_writes([_ptp(1.0), wait(0.5)]) == []
+
+    def test_write_to_set_io_carries_value_location_and_origin(self):
+        write = io_write("OUT#1", True, origin=api.models.IOOrigin.BUS_IO)
+        set_io = write_to_set_io(write, 2)
+        assert set_io.location == 2
+        assert set_io.io_origin is api.models.IOOrigin.BUS_IO
+        assert set_io.io.io == "OUT#1"
+
+
+class TestToSetIoRegression:
+    def test_matches_located_writes_over_mixed_list(self):
+        items = [_ptp(1.0), io_write("OUT#1", True), wait(0.5), _ptp(2.0), io_write("OUT#2", False)]
+        combined = CombinedActions(items=tuple(items))
+
+        result = combined.to_set_io()
+
+        assert [s.location for s in result] == [1, 2]
+        assert [s.io.io for s in result] == ["OUT#1", "OUT#2"]
+        assert [s.io.value for s in result] == [True, False]

--- a/tests/cell/test_multi_motion_group.py
+++ b/tests/cell/test_multi_motion_group.py
@@ -1,0 +1,134 @@
+"""Tests for MultiMotionGroup: that its builder wires a planner and an executor
+over the same groups, and that it delegates plan/execute/plan_and_execute to the
+two halves (each covered end to end in its own suite)."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nova.actions.io import io_write
+from nova.actions.motions import multi_collision_free
+from nova.cell.multi_motion_group import MultiMotionGroup, MultiMotionGroupBuilder
+from nova.cell.trajectory_executor import GroupArgs, TrajectoryExecutor
+from tests.cell.multi_group_doubles import IOGateway, motion_group
+
+pytestmark = pytest.mark.asyncio
+
+
+def _half(keys: tuple[str, ...] = ("a", "b")) -> MagicMock:
+    half = MagicMock()
+    half.motion_groups = {key: MagicMock() for key in keys}
+    return half
+
+
+def _fake_executor(keys: tuple[str, ...] = ("a", "b")) -> MagicMock:
+    executor = _half(keys)
+    executor.execute = AsyncMock()
+    return executor
+
+
+def _fake_planner(keys: tuple[str, ...] = ("a", "b")) -> MagicMock:
+    planner = _half(keys)
+    planner.plan = AsyncMock(return_value="TRAJ")
+    return planner
+
+
+class TestBuilder:
+    def test_builder_returns_a_multi_motion_group_builder(self):
+        builder = MultiMotionGroup.builder({"a": motion_group(IOGateway())})
+        assert isinstance(builder, MultiMotionGroupBuilder)
+
+    def test_build_wires_a_planner_and_executor_over_the_same_groups(self):
+        gateway = IOGateway()
+        groups = {"a": motion_group(gateway), "b": motion_group(gateway)}
+
+        ensemble = (
+            MultiMotionGroup.builder(groups)
+            .sync_on_io("sync-io", controller="controller-a")
+            .build()
+        )
+
+        assert isinstance(ensemble, MultiMotionGroup)
+        assert isinstance(ensemble._executor, TrajectoryExecutor)
+        assert set(ensemble.motion_groups) == {"a", "b"}
+        assert set(ensemble._planner.motion_groups) == {"a", "b"}
+
+
+class TestConstruction:
+    def test_planner_and_executor_over_different_groups__raises(self):
+        with pytest.raises(ValueError, match="same motion groups"):
+            MultiMotionGroup(_fake_executor(("a", "b")), _fake_planner(("a", "c")))
+
+
+class TestDelegation:
+    async def test_plan_delegates_to_the_planner(self):
+        planner = _fake_planner()
+        ensemble = MultiMotionGroup(_fake_executor(), planner)
+        actions = [multi_collision_free({"a": (0.0,) * 6})]
+
+        result = await ensemble.plan(actions, tcp="flange", start_joint_position={"a": (0.1,) * 6})
+
+        planner.plan.assert_awaited_once_with(actions, "flange", {"a": (0.1,) * 6})
+        assert result == "TRAJ"
+
+    async def test_execute_delegates_to_the_executor(self):
+        executor = _fake_executor()
+        ensemble = MultiMotionGroup(executor, _fake_planner())
+        actions = [io_write("OUT#1", True, device_id="c")]
+        group_args = {"a": GroupArgs()}
+
+        await ensemble.execute("TRAJ", actions=actions, groups=group_args)
+
+        executor.execute.assert_awaited_once_with("TRAJ", actions=actions, groups=group_args)
+
+    async def test_attach_delegates_to_the_executor(self):
+        executor = _fake_executor()
+
+        @asynccontextmanager
+        async def fake_attach(trajectory, actions=None, groups=None):
+            fake_attach.args = (trajectory, actions, groups)
+            yield "CURSOR"
+
+        executor.attach = fake_attach
+        ensemble = MultiMotionGroup(executor, _fake_planner())
+        actions = [io_write("OUT#1", True, device_id="c")]
+
+        async with ensemble.attach("TRAJ", actions=actions) as cursor:
+            assert cursor == "CURSOR"
+        assert fake_attach.args == ("TRAJ", actions, None)
+
+    async def test_plan_and_execute_chains_the_same_actions_into_both_halves(self):
+        executor = _fake_executor()
+        planner = _fake_planner()
+        ensemble = MultiMotionGroup(executor, planner)
+        actions = [multi_collision_free({"a": (0.0,) * 6}), io_write("OUT#1", True, device_id="c")]
+
+        await ensemble.plan_and_execute(actions, tcp="flange")
+
+        planner.plan.assert_awaited_once_with(actions, "flange", None)
+        # the planned trajectory and the very same actions reach execute
+        executor.execute.assert_awaited_once_with("TRAJ", actions=actions, groups=None)
+
+    async def test_execute_does_not_touch_the_planner(self):
+        # An execute-only workflow drives the executor without planning.
+        planner = _fake_planner()
+        ensemble = MultiMotionGroup(_fake_executor(), planner)
+
+        await ensemble.execute("TRAJ")
+
+        planner.plan.assert_not_awaited()
+
+    async def test_plan_and_execute_only_writes__applies_directly_without_planning(self):
+        # An all-non-motion list sets IO directly, mirroring MotionGroup.
+        executor = _fake_executor()
+        executor.apply_non_motion_actions = AsyncMock()
+        planner = _fake_planner()
+        ensemble = MultiMotionGroup(executor, planner)
+        actions = [io_write("OUT#1", True, device_id="c")]
+
+        await ensemble.plan_and_execute(actions)
+
+        executor.apply_non_motion_actions.assert_awaited_once_with(actions)
+        planner.plan.assert_not_awaited()
+        executor.execute.assert_not_awaited()

--- a/tests/cell/test_multi_motion_group_planner.py
+++ b/tests/cell/test_multi_motion_group_planner.py
@@ -1,0 +1,261 @@
+"""Tests for MultiMotionGroupPlanner: how it batches an ensemble action list into
+the multi-RRT request(s) and interprets the response, over a faked gateway."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nova import api
+from nova.actions.io import ReadAction, io_write
+from nova.actions.mock import wait
+from nova.actions.motions import multi_collision_free
+from nova.cell.multi_motion_group_planner import MultiMotionGroupPlanner
+from nova.exceptions import NoInverseKinematicsSolutionFound, PlanTrajectoryFailed
+from nova.types import Pose
+
+pytestmark = pytest.mark.asyncio
+
+
+def _setup() -> api.models.MotionGroupSetup:
+    return api.models.MotionGroupSetup(motion_group_model="UniversalRobots_UR5e", cycle_time=4)
+
+
+def _multi_trajectory(*keys: str, sample: float = 0.0) -> api.models.MultiJointTrajectory:
+    return api.models.MultiJointTrajectory(
+        joint_positions_by_motion_group_key={key: [[sample] * 6] * 3 for key in keys},
+        times=[0.0, 1.0, 2.0],
+        locations=[0.0, 1.0, 2.0],
+    )
+
+
+def _gateway(
+    response: api.models.MultiSearchCollisionFreeResponse | None = None,
+    responses: list[api.models.MultiSearchCollisionFreeResponse] | None = None,
+) -> MagicMock:
+    gateway = MagicMock()
+    gateway.trajectory_planning_api = MagicMock()
+    gateway.trajectory_planning_api.search_collision_free_multi_motion_group = (
+        AsyncMock(side_effect=responses)
+        if responses is not None
+        else AsyncMock(return_value=response)
+    )
+    return gateway
+
+
+def _ok(*keys: str, sample: float = 0.0) -> api.models.MultiSearchCollisionFreeResponse:
+    return api.models.MultiSearchCollisionFreeResponse(
+        response=_multi_trajectory(*keys, sample=sample)
+    )
+
+
+def _motion_group(
+    api_client: MagicMock,
+    group_id: str,
+    current_joints: tuple[float, ...] = (0.0,) * 6,
+    ik_solutions: list[tuple[float, ...]] | None = None,
+    cell: str = "cell",
+) -> MagicMock:
+    group = MagicMock()
+    group.id = group_id
+    group._cell = cell
+    group._api_client = api_client
+    group.get_setup = AsyncMock(return_value=_setup())
+    group.joints = AsyncMock(return_value=current_joints)
+    group._inverse_kinematics = AsyncMock(return_value=[ik_solutions or []])
+    return group
+
+
+def _request_of(api_client: MagicMock, call_index: int = 0):
+    return (
+        api_client.trajectory_planning_api.search_collision_free_multi_motion_group.call_args_list[
+            call_index
+        ].kwargs["multi_search_collision_free_request"]
+    )
+
+
+class TestValidation:
+    async def test_no_groups__raises(self):
+        with pytest.raises(ValueError, match="At least one motion group"):
+            MultiMotionGroupPlanner({})
+
+    async def test_groups_span_cells__raises(self):
+        api_client = MagicMock()
+        with pytest.raises(ValueError, match="cell-scoped"):
+            MultiMotionGroupPlanner(
+                {
+                    "a": _motion_group(api_client, "a", cell="cell-1"),
+                    "b": _motion_group(api_client, "b", cell="cell-2"),
+                }
+            )
+
+    async def test_no_actions__raises(self):
+        api_client = _gateway(_ok("a"))
+        planner = MultiMotionGroupPlanner({"a": _motion_group(api_client, "a")})
+        with pytest.raises(ValueError, match="No actions"):
+            await planner.plan([])
+
+    async def test_targets_not_matching_groups__raises(self):
+        api_client = _gateway(_ok("a", "b"))
+        planner = MultiMotionGroupPlanner(
+            {"a": _motion_group(api_client, "a"), "b": _motion_group(api_client, "b")}
+        )
+        with pytest.raises(ValueError, match="must match the planner"):
+            await planner.plan(multi_collision_free({"a": (1.0,) * 6}))
+
+    async def test_unsupported_action__raises(self):
+        api_client = _gateway(_ok("a"))
+        planner = MultiMotionGroupPlanner({"a": _motion_group(api_client, "a")})
+        with pytest.raises(ValueError, match="not supported"):
+            await planner.plan(ReadAction(key="IN#1", device_id="ctrl"))
+
+    async def test_write_action_is_ignored__no_raise_and_pure_trajectory(self):
+        # A write is skipped, leaving the trajectory identical to the motion alone.
+        api_client = _gateway(_ok("a", sample=1.0))
+        planner = MultiMotionGroupPlanner({"a": _motion_group(api_client, "a")})
+
+        with_write = await planner.plan(
+            [io_write("OUT#1", True, device_id="ctrl"), multi_collision_free({"a": (1.0,) * 6})]
+        )
+
+        assert isinstance(with_write, api.models.MultiJointTrajectory)
+        # one RRT call, no extra samples from the write
+        assert (
+            api_client.trajectory_planning_api.search_collision_free_multi_motion_group.await_count
+            == 1
+        )
+        assert len(with_write.joint_positions_by_motion_group_key["a"]) == 3
+
+    async def test_only_writes__raises(self):
+        api_client = _gateway(_ok("a"))
+        planner = MultiMotionGroupPlanner({"a": _motion_group(api_client, "a")})
+        with pytest.raises(ValueError, match="no motion or wait"):
+            await planner.plan([io_write("OUT#1", True, device_id="ctrl")])
+
+
+class TestRequestAssembly:
+    async def test_joint_targets_build_path_definitions(self):
+        api_client = _gateway(_ok("a", "b"))
+        planner = MultiMotionGroupPlanner(
+            {
+                "a": _motion_group(api_client, "a", current_joints=(0.1,) * 6),
+                "b": _motion_group(api_client, "b", current_joints=(0.2,) * 6),
+            }
+        )
+
+        result = await planner.plan(
+            multi_collision_free({"a": (1.0,) * 6, "b": (2.0,) * 6}),
+            start_joint_position={"a": (0.5,) * 6},
+        )
+
+        assert isinstance(result, api.models.MultiJointTrajectory)
+        paths = _request_of(api_client).path_definitions_by_motion_group_key
+        assert set(paths) == {"a", "b"}
+        # explicit start honored for "a", current-joints fallback for "b"
+        assert tuple(paths["a"].start_joint_position) == (0.5,) * 6
+        assert tuple(paths["a"].target_joint_position) == (1.0,) * 6
+        assert tuple(paths["b"].start_joint_position) == (0.2,) * 6
+        assert tuple(paths["b"].target_joint_position) == (2.0,) * 6
+        assert set(_request_of(api_client).motion_group_setups_by_motion_group_key) == {"a", "b"}
+
+    async def test_shared_tcp_and_algorithm_on_action(self):
+        api_client = _gateway(_ok("a"))
+        group = _motion_group(api_client, "a")
+        planner = MultiMotionGroupPlanner({"a": group})
+
+        algorithm = api.models.RRTConnectAlgorithm(max_iterations=42)
+        await planner.plan(
+            multi_collision_free({"a": (1.0,) * 6}, algorithm=algorithm), tcp="flange"
+        )
+
+        group.get_setup.assert_awaited_once_with(tcp_name="flange")
+        assert _request_of(api_client).algorithm_settings.max_iterations == 42
+
+    async def test_pose_target_resolves_ik_nearest_to_start(self):
+        api_client = _gateway(_ok("a"))
+        far, near = (3.0,) * 6, (0.1,) * 6
+        group = _motion_group(api_client, "a", current_joints=(0.0,) * 6, ik_solutions=[far, near])
+        planner = MultiMotionGroupPlanner({"a": group})
+
+        await planner.plan(multi_collision_free({"a": Pose((1, 2, 3, 4, 5, 6))}), tcp="flange")
+
+        group._inverse_kinematics.assert_awaited_once()
+        target = tuple(
+            _request_of(api_client).path_definitions_by_motion_group_key["a"].target_joint_position
+        )
+        assert target == near
+
+    async def test_pose_target_without_tcp__raises(self):
+        api_client = _gateway(_ok("a"))
+        planner = MultiMotionGroupPlanner({"a": _motion_group(api_client, "a")})
+        with pytest.raises(ValueError, match="TCP is required"):
+            await planner.plan(multi_collision_free({"a": Pose((1, 2, 3, 4, 5, 6))}))
+
+    async def test_pose_target_no_ik_solution__raises(self):
+        api_client = _gateway(_ok("a"))
+        group = _motion_group(api_client, "a", ik_solutions=[])
+        planner = MultiMotionGroupPlanner({"a": group})
+        with pytest.raises(NoInverseKinematicsSolutionFound):
+            await planner.plan(multi_collision_free({"a": Pose((1, 2, 3, 4, 5, 6))}), tcp="flange")
+
+
+class TestBatching:
+    async def test_wait_between_motions_concatenates_segments(self):
+        # Two distinct RRT segments plus a hold in the middle.
+        api_client = _gateway(responses=[_ok("a", sample=1.0), _ok("a", sample=2.0)])
+        group = _motion_group(api_client, "a", current_joints=(0.0,) * 6)
+        planner = MultiMotionGroupPlanner({"a": group})
+
+        result = await planner.plan(
+            [
+                multi_collision_free({"a": (1.0,) * 6}),
+                wait(0.1),
+                multi_collision_free({"a": (2.0,) * 6}),
+            ]
+        )
+
+        # two RRT calls, one per motion; the wait is planned locally
+        assert (
+            api_client.trajectory_planning_api.search_collision_free_multi_motion_group.await_count
+            == 2
+        )
+        # 3 + (3 hold - 1 seam) + (3 - 1 seam) = 3 + 2 + 2 = 7 samples on the shared timeline
+        samples = result.joint_positions_by_motion_group_key["a"]
+        assert len(samples) == 7
+        assert len(result.times) == 7
+        # second motion's start joints = end of the hold = end of the first segment
+        second_start = tuple(
+            _request_of(api_client, 1)
+            .path_definitions_by_motion_group_key["a"]
+            .start_joint_position
+        )
+        assert second_start == (1.0,) * 6
+
+    async def test_wait_holds_current_joints(self):
+        api_client = _gateway(_ok("a"))
+        planner = MultiMotionGroupPlanner(
+            {"a": _motion_group(api_client, "a", current_joints=(0.7,) * 6)}
+        )
+        result = await planner.plan(wait(0.1))
+        samples = result.joint_positions_by_motion_group_key["a"]
+        assert all(tuple(s) == (0.7,) * 6 for s in samples)
+        assert all(loc == 0.0 for loc in result.locations)
+        api_client.trajectory_planning_api.search_collision_free_multi_motion_group.assert_not_awaited()
+
+
+class TestResponse:
+    async def test_failed_response__raises(self):
+        failure = api.models.PlanCollisionFreeFailedResponse(
+            error_feedback=api.models.ErrorMaxIterationsExceeded()
+        )
+        api_client = _gateway(api.models.MultiSearchCollisionFreeResponse(response=failure))
+        planner = MultiMotionGroupPlanner(
+            {"a": _motion_group(api_client, "a"), "b": _motion_group(api_client, "b")}
+        )
+        with pytest.raises(PlanTrajectoryFailed, match="a, b"):
+            await planner.plan(multi_collision_free({"a": (1.0,) * 6, "b": (1.0,) * 6}))
+
+    async def test_empty_response__raises(self):
+        api_client = _gateway(api.models.MultiSearchCollisionFreeResponse(response=None))
+        planner = MultiMotionGroupPlanner({"a": _motion_group(api_client, "a")})
+        with pytest.raises(ValueError, match="no trajectory"):
+            await planner.plan(multi_collision_free({"a": (1.0,) * 6}))

--- a/tests/cell/test_trajectory_executor.py
+++ b/tests/cell/test_trajectory_executor.py
@@ -13,7 +13,10 @@ import pytest
 
 from nova import api
 from nova.actions.io import io_write
-from nova.cell.multi_trajectory_cursor import IOSyncDriver, SyncDriver
+from nova.actions.mock import wait
+from nova.actions.motions import multi_collision_free
+from nova.cell.multi_motion_group import MultiMotionGroup
+from nova.cell.multi_trajectory_cursor import IOSyncDriver, MultiTrajectoryCursor, SyncDriver
 from nova.cell.session_monitor import SyncDriftError, SyncDriftMonitor
 from nova.cell.trajectory_executor import TrajectoryExecutor
 from tests.cell.multi_group_doubles import (
@@ -28,9 +31,14 @@ from tests.cell.multi_group_doubles import (
 pytestmark = pytest.mark.asyncio
 
 
-def _driver_of(executor: TrajectoryExecutor) -> SyncDriver:
+def _move():
+    """A synchronized motion — the overlay counts it, its targets are irrelevant here."""
+    return multi_collision_free({"a": (0.0,) * 6, "b": (0.0,) * 6})
+
+
+def _driver_of(ensemble: MultiMotionGroup) -> SyncDriver:
     """The driver the builder assembled — the one place these tests reach inside."""
-    return executor._sync
+    return ensemble._executor._sync
 
 
 class TestExecutorValidation:
@@ -70,18 +78,18 @@ class TestBuilder:
     async def test_build__derives_clear_and_watch_from_the_trigger(self):
         gateway = IOGateway()
 
-        executor = (
-            TrajectoryExecutor.builder(self._two_groups(gateway))
+        ensemble = (
+            MultiMotionGroup.builder(self._two_groups(gateway))
             .sync_on_io("sync-io", controller="controller-a", release_value=False)
             .build()
         )
 
-        conditions = _driver_of(executor).start_conditions()
+        conditions = _driver_of(ensemble).start_conditions()
         assert conditions["a"].io.io == "sync-io"
         assert conditions["a"].io.value is False
         assert conditions["a"] == conditions["b"]
-        await _driver_of(executor).clear()
-        await _driver_of(executor).release()
+        await _driver_of(ensemble).clear()
+        await _driver_of(ensemble).release()
         assert gateway.io_writes == [("sync-io", True), ("sync-io", False)]
 
     async def test_builder__plain_motion_groups__are_keyed_by_their_id(self):
@@ -91,51 +99,51 @@ class TestBuilder:
         positioner = motion_group(gateway)
         positioner.id = "0@positioner"
 
-        executor = (
-            TrajectoryExecutor.builder([robot, positioner])
+        ensemble = (
+            MultiMotionGroup.builder([robot, positioner])
             .sync_on_io("sync-io", controller="controller-a")
             .build()
         )
 
-        assert set(executor._motion_groups) == {"0@robot", "0@positioner"}
+        assert set(ensemble.motion_groups) == {"0@robot", "0@positioner"}
 
     async def test_build__watch_override_replaces_the_derived_condition(self):
         gateway = IOGateway()
         wired_input = watch_condition("wired-in", value=False)
 
-        executor = (
-            TrajectoryExecutor.builder(self._two_groups(gateway))
+        ensemble = (
+            MultiMotionGroup.builder(self._two_groups(gateway))
             .sync_on_io("sync-io", controller="controller-a")
             .watch("b", wired_input)
             .build()
         )
 
-        assert _driver_of(executor).start_conditions()["b"] is wired_input
-        assert _driver_of(executor).start_conditions()["a"].io.io == "sync-io"
+        assert _driver_of(ensemble).start_conditions()["b"] is wired_input
+        assert _driver_of(ensemble).start_conditions()["a"].io.io == "sync-io"
 
     async def test_build__writes_set_one_at_a_time__replace_what_sync_on_io_states(self):
         gateway = IOGateway()
 
-        executor = (
-            TrajectoryExecutor.builder(self._two_groups(gateway))
+        ensemble = (
+            MultiMotionGroup.builder(self._two_groups(gateway))
             .sync_on_io("sync-io", controller="controller-a")
             .release_io("release-io", True, controller="controller-a")
             .clear_io("clear-io", True, controller="controller-a")
             .build()
         )
 
-        await _driver_of(executor).clear()
-        await _driver_of(executor).release()
+        await _driver_of(ensemble).clear()
+        await _driver_of(ensemble).release()
         assert gateway.io_writes == [("clear-io", True), ("release-io", True)]
 
     async def test_build__without_a_release_write__raises(self):
-        builder = TrajectoryExecutor.builder(self._two_groups(IOGateway()))
+        builder = MultiMotionGroup.builder(self._two_groups(IOGateway()))
 
         with pytest.raises(ValueError, match="release write"):
             builder.clear_io("clear-io", False, controller="controller-a").build()
 
     async def test_build__without_a_clear_write__raises(self):
-        builder = TrajectoryExecutor.builder(self._two_groups(IOGateway()))
+        builder = MultiMotionGroup.builder(self._two_groups(IOGateway()))
 
         with pytest.raises(ValueError, match="clear write"):
             builder.release_io("release-io", True, controller="controller-a").build()
@@ -148,7 +156,7 @@ class TestBuilder:
         }
 
         with pytest.raises(ValueError, match="one cell"):
-            TrajectoryExecutor.builder(motion_groups).sync_on_io("sync-io").build()
+            MultiMotionGroup.builder(motion_groups).sync_on_io("sync-io").build()
 
     async def test_sync_on_io__ambiguous_controller__raises_on_the_call(self):
         gateway = IOGateway()
@@ -156,20 +164,20 @@ class TestBuilder:
             "a": motion_group(gateway, controller="controller-a"),
             "b": motion_group(gateway, controller="controller-b"),
         }
-        builder = TrajectoryExecutor.builder(motion_groups)
+        builder = MultiMotionGroup.builder(motion_groups)
 
         with pytest.raises(ValueError, match="ambiguous"):
             builder.sync_on_io("sync-io")
 
     async def test_watch__unknown_group__raises_on_the_call(self):
-        builder = TrajectoryExecutor.builder(self._two_groups(IOGateway()))
+        builder = MultiMotionGroup.builder(self._two_groups(IOGateway()))
 
         with pytest.raises(ValueError, match="Unknown motion group"):
             builder.watch("typo", watch_condition("in-a"))
 
     async def test_builder__without_motion_groups__raises(self):
         with pytest.raises(ValueError, match="At least one motion group"):
-            TrajectoryExecutor.builder([])
+            MultiMotionGroup.builder([])
 
 
 class TestIOSyncDriver:
@@ -229,6 +237,143 @@ class TestIOSyncDriver:
 
         gateway.bus_ios_api.set_bus_io_values.assert_awaited_once()
         assert gateway.bus_ios_api.get_bus_io_values.await_count == 2
+
+
+class TestIOOverlay:
+    def _executor(
+        self, gateway, controllers=("controller-a", "controller-b")
+    ) -> TrajectoryExecutor:
+        motion_groups = {
+            "a": motion_group(gateway, controller=controllers[0]),
+            "b": motion_group(gateway, controller=controllers[1]),
+        }
+        return TrajectoryExecutor(motion_groups, sync=sync_driver(gateway, groups=("a", "b")))
+
+    def test_no_actions__all_overlays_empty(self):
+        overlay = self._executor(IOGateway())._build_io_overlay([])
+        assert overlay == {"a": [], "b": []}
+
+    def test_write_anchored_on_preceding_motion_count(self):
+        overlay = self._executor(IOGateway())._build_io_overlay(
+            [_move(), _move(), io_write("OUT#1", True, device_id="controller-a")]
+        )
+        assert [s.location for s in overlay["a"]] == [2]
+        assert overlay["b"] == []
+
+    def test_wait_does_not_advance_the_location(self):
+        overlay = self._executor(IOGateway())._build_io_overlay(
+            [_move(), wait(0.5), io_write("OUT#1", True, device_id="controller-a")]
+        )
+        assert [s.location for s in overlay["a"]] == [1]
+
+    def test_controller_origin_routes_to_the_group_on_that_controller(self):
+        overlay = self._executor(IOGateway())._build_io_overlay(
+            [io_write("OUT#1", True, device_id="controller-b")]
+        )
+        assert overlay["a"] == []
+        assert [s.io.io for s in overlay["b"]] == ["OUT#1"]
+
+    def test_controller_origin_without_device_id__ambiguous__raises(self):
+        with pytest.raises(ValueError, match="ambiguous"):
+            self._executor(IOGateway())._build_io_overlay([io_write("OUT#1", True)])
+
+    def test_controller_origin_without_device_id__shared_controller__routes_to_one(self):
+        executor = self._executor(IOGateway(), controllers=("controller-a", "controller-a"))
+        overlay = executor._build_io_overlay([io_write("OUT#1", True)])
+        assert [s.io.io for s in overlay["a"]] == ["OUT#1"]
+        assert overlay["b"] == []
+
+    def test_controller_origin__no_matching_group__raises(self):
+        with pytest.raises(ValueError, match="No motion group is on controller"):
+            self._executor(IOGateway())._build_io_overlay(
+                [io_write("OUT#1", True, device_id="controller-x")]
+            )
+
+    def test_bus_origin__fires_once_on_one_group(self):
+        overlay = self._executor(IOGateway())._build_io_overlay(
+            [io_write("bus-var", True, origin=api.models.IOOrigin.BUS_IO)]
+        )
+        # exactly one group carries it — a shared instant, not duplicated
+        assert sum(len(entries) for entries in overlay.values()) == 1
+        assert [s.io.io for s in overlay["a"]] == ["bus-var"]
+        assert overlay["b"] == []
+
+
+class TestActionStepping:
+    def _multi(self, location: float, actions, end: float = 2.0) -> MultiTrajectoryCursor:
+        def cursor() -> MagicMock:
+            c = MagicMock()
+            c.current_location = location
+            c.end_location = end
+            return c
+
+        cursors = {"a": cursor(), "b": cursor()}
+        return MultiTrajectoryCursor(cursors, sync_driver(IOGateway()), actions=actions)
+
+    def test_current_action_maps_the_location_to_the_ensemble_motion(self):
+        first, second = _move(), _move()
+        cursor = self._multi(1.5, [first, second])
+        assert cursor.current_action_index == 1
+        assert cursor.current_action is second
+
+    def test_write_between_motions_does_not_get_a_location(self):
+        first, second = _move(), _move()
+        cursor = self._multi(0.5, [first, io_write("OUT#1", True, device_id="c"), second])
+        # only the two motions map to locations; the write is not an action stop
+        assert cursor.current_action_index == 0
+        assert cursor.current_action is first
+
+    def test_no_actions__current_action_is_none(self):
+        cursor = self._multi(0.5, [])
+        assert cursor.current_action_index is None
+        assert cursor.current_action is None
+
+    def test_end_location_not_matching_motion_count__raises(self):
+        with pytest.raises(ValueError, match="one location unit"):
+            self._multi(0.0, [_move()], end=2.0)  # 1 motion but end location 2.0
+
+    async def test_forward_to_next_action__steps_to_the_next_boundary(self):
+        cursor = self._multi(0.5, [_move(), _move()])
+        cursor.forward_to_next_action()
+        assert cursor._pending_intent is not None
+        assert cursor._pending_intent.target_location == 1.0
+
+    async def test_forward_to_next_action__at_the_end__returns_without_moving(self):
+        cursor = self._multi(2.0, [_move(), _move()], end=2.0)
+        result = await cursor.forward_to_next_action()
+        assert set(result) == {"a", "b"}
+        assert cursor._pending_intent is None  # no barrier armed
+
+
+class TestDirectNonMotionActions:
+    def _executor(self, controllers=("controller-a", "controller-b")) -> TrajectoryExecutor:
+        gateway = IOGateway()
+        motion_groups = {
+            "a": motion_group(gateway, controller=controllers[0]),
+            "b": motion_group(gateway, controller=controllers[1]),
+        }
+        for group in motion_groups.values():
+            group._execute_direct_non_motion_actions = AsyncMock()
+        return TrajectoryExecutor(motion_groups, sync=sync_driver(gateway, groups=("a", "b")))
+
+    async def test_write_is_set_on_its_owning_group(self):
+        executor = self._executor()
+        write = io_write("OUT#1", True, device_id="controller-b")
+
+        await executor.apply_non_motion_actions([write])
+
+        executor._motion_groups["b"]._execute_direct_non_motion_actions.assert_awaited_once_with(
+            [write]
+        )
+        executor._motion_groups["a"]._execute_direct_non_motion_actions.assert_not_awaited()
+
+    async def test_wait_sleeps_without_touching_the_groups(self):
+        executor = self._executor()
+
+        await executor.apply_non_motion_actions([wait(0.0)])
+
+        for group in executor._motion_groups.values():
+            group._execute_direct_non_motion_actions.assert_not_awaited()
 
 
 class TestSyncDriftMonitor:

--- a/tests/cell/test_trajectory_executor_session.py
+++ b/tests/cell/test_trajectory_executor_session.py
@@ -21,6 +21,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from nova import api
+from nova.actions.io import io_write
+from nova.actions.motions import multi_collision_free
+from nova.cell.multi_motion_group import MultiMotionGroup
 from nova.cell.session_monitor import SyncDriftError
 from nova.cell.trajectory_executor import GroupArgs, TrajectoryExecutor
 from tests.cell.multi_group_doubles import (
@@ -46,6 +49,7 @@ class _FakeGateway(IOGateway):
         self.start_requests: dict[str, list[api.models.StartMovementRequest]] = {}
         self.initialize_requests: dict[str, api.models.InitializeMovementRequest] = {}
         self.execution_cells: dict[str, str] = {}
+        self.execution_controllers: dict[str, str] = {}
         # Milestone counters the tests await, so they never depend on how many
         # event-loop ticks a barrier happens to take.
         self._counts = dict.fromkeys(("init", "start", "pause", "write"), 0)
@@ -80,6 +84,7 @@ class _FakeGateway(IOGateway):
             if isinstance(request, api.models.InitializeMovementRequest):
                 trajectory_id = request.trajectory.id
                 self.execution_cells[trajectory_id] = cell
+                self.execution_controllers[trajectory_id] = controller
                 self.initialize_requests[trajectory_id] = request
                 self._reach("init")
                 responses.put_nowait(api.models.InitializeMovementResponse())
@@ -98,12 +103,10 @@ async def _settle() -> None:
         await asyncio.sleep(0)
 
 
-def _two_group_executor(
-    gateway: _FakeGateway,
-) -> tuple[TrajectoryExecutor, dict[str, asyncio.Queue]]:
+def _two_group_executor(gateway: _FakeGateway) -> tuple[MultiMotionGroup, dict[str, asyncio.Queue]]:
     state_queues = {"a": asyncio.Queue(), "b": asyncio.Queue()}
     executor = (
-        TrajectoryExecutor.builder(
+        MultiMotionGroup.builder(
             {
                 "a": motion_group(gateway, state_queues["a"], trajectory_id="traj-a"),
                 "b": motion_group(gateway, state_queues["b"], trajectory_id="traj-b"),
@@ -134,18 +137,21 @@ class TestTrajectorySplitting:
 
 
 class TestExecutorAddressing:
-    async def test_attach__executes_each_group_through_its_own_cell(self):
+    async def test_attach__executes_each_group_through_its_own_controller(self):
+        # The groups share one cell (the sync barrier is cell-scoped) but sit on
+        # different controllers, each executed through its own.
         gateway = _FakeGateway()
         motion_groups = {
-            "a": motion_group(gateway, trajectory_id="traj-a", cell="cell-a"),
-            "b": motion_group(gateway, trajectory_id="traj-b", cell="cell-b"),
+            "a": motion_group(gateway, trajectory_id="traj-a", controller="ctrl-a"),
+            "b": motion_group(gateway, trajectory_id="traj-b", controller="ctrl-b"),
         }
         executor = TrajectoryExecutor(motion_groups, sync=sync_driver(gateway))
 
         async with executor.attach(multi_trajectory("a", "b")):
             await gateway.reached("init", 2)
 
-        assert gateway.execution_cells == {"traj-a": "cell-a", "traj-b": "cell-b"}
+        assert gateway.execution_controllers == {"traj-a": "ctrl-a", "traj-b": "ctrl-b"}
+        assert set(gateway.execution_cells.values()) == {"cell"}
 
 
 class TestSessionMonitors:
@@ -155,7 +161,7 @@ class TestSessionMonitors:
         gateway = _FakeGateway()
         state_queues = {"a": asyncio.Queue(), "b": asyncio.Queue()}
         executor = (
-            TrajectoryExecutor.builder(
+            MultiMotionGroup.builder(
                 {
                     "a": motion_group(gateway, state_queues["a"], trajectory_id="traj-a"),
                     "b": motion_group(gateway, state_queues["b"], trajectory_id="traj-b"),
@@ -384,3 +390,49 @@ class TestSynchronizedExecution:
             state_queues["b"].put_nowait(ended_state(2.0, at_milliseconds=80))
             await asyncio.wait_for(again, timeout=5)
             assert cursor.current_location >= 2.0 - 0.01
+
+
+class TestIOOverlayReachesTheController:
+    async def test_execute__write_rides_the_owning_groups_start_only(self):
+        # Arrange: two groups on distinct controllers; the write targets b's.
+        gateway = _FakeGateway()
+        state_queues = {"a": asyncio.Queue(), "b": asyncio.Queue()}
+        executor = (
+            MultiMotionGroup.builder(
+                {
+                    "a": motion_group(
+                        gateway, state_queues["a"], controller="ctrl-a", trajectory_id="traj-a"
+                    ),
+                    "b": motion_group(
+                        gateway, state_queues["b"], controller="ctrl-b", trajectory_id="traj-b"
+                    ),
+                }
+            )
+            .sync_on_io("sync-io", controller="ctrl-a")
+            .build()
+        )
+        # Two motions match the trajectory's end location (2.0); the write sits
+        # between them, at motion boundary 1.
+        move = multi_collision_free({"a": (0.0,) * 6, "b": (0.0,) * 6})
+        actions = [move, io_write("OUT#1", True, device_id="ctrl-b"), move]
+
+        # Act: run the barrier through to completion
+        execute_task = asyncio.create_task(
+            executor.execute(multi_trajectory("a", "b"), actions=actions)
+        )
+        await gateway.reached("start", 2)
+        state_queues["a"].put_nowait(wait_for_io_state(at_milliseconds=10))
+        state_queues["b"].put_nowait(wait_for_io_state(at_milliseconds=20))
+        await gateway.reached("write", 2)
+        state_queues["a"].put_nowait(ended_state(2.0, at_milliseconds=30))
+        state_queues["b"].put_nowait(ended_state(2.0, at_milliseconds=40))
+        await asyncio.wait_for(execute_task, timeout=5)
+
+        # Assert: b's start carries the overlay at the motion boundary (1 motion
+        # precedes the write); a's start carries none.
+        b_outputs = gateway.start_requests["traj-b"][0].set_outputs
+        assert b_outputs is not None
+        assert [s.io.io for s in b_outputs] == ["OUT#1"]
+        assert b_outputs[0].location == 1
+        assert b_outputs[0].io.value is True
+        assert not gateway.start_requests["traj-a"][0].set_outputs

--- a/tests/nova/cell/test_trajectory_executor_integration.py
+++ b/tests/nova/cell/test_trajectory_executor_integration.py
@@ -18,7 +18,7 @@ import pytest_asyncio
 
 from nova import Nova, api
 from nova.actions import jnt
-from nova.cell import GroupArgs, MotionGroup, TrajectoryExecutor
+from nova.cell import GroupArgs, MotionGroup, MultiMotionGroup
 
 CONTROLLER = "kuka-executor-integration"
 ROBOT, POSITIONER = f"0@{CONTROLLER}", f"1@{CONTROLLER}"
@@ -116,8 +116,8 @@ async def _ramp_from_here(groups: dict[str, MotionGroup]) -> api.models.MultiJoi
     )
 
 
-def _executor(groups: dict[str, MotionGroup]) -> TrajectoryExecutor:
-    return TrajectoryExecutor.builder(groups).sync_on_io(SYNC_IO, controller=CONTROLLER).build()
+def _ensemble(groups: dict[str, MotionGroup]) -> MultiMotionGroup:
+    return MultiMotionGroup.builder(groups).sync_on_io(SYNC_IO, controller=CONTROLLER).build()
 
 
 _GROUP_ARGS = {name: GroupArgs(tcp=tcp) for name, tcp in TCPS.items()}
@@ -138,7 +138,7 @@ async def test_execute_recorded_trajectory_starts_both_groups_in_one_tick(synchr
     ]
     try:
         await asyncio.wait_for(
-            _executor(groups).execute(trajectory, groups=_GROUP_ARGS), timeout=120
+            _ensemble(groups).execute(trajectory, groups=_GROUP_ARGS), timeout=120
         )
     finally:
         for watcher in watchers:
@@ -167,7 +167,7 @@ async def test_forward_to_intermediate_target_keeps_the_session_open(synchronize
     _, groups = synchronized_groups
     trajectory = await _ramp_from_here(groups)
 
-    async with _executor(groups).attach(trajectory, _GROUP_ARGS) as cursor:
+    async with _ensemble(groups).attach(trajectory, groups=_GROUP_ARGS) as cursor:
         await asyncio.wait_for(cursor.forward_to(1.0), timeout=60)
         assert 1.0 - 0.01 <= cursor.current_location < 2.0
 
@@ -187,7 +187,7 @@ async def test_pause_then_forward_rearms_the_barrier(synchronized_groups):
         for name, joints in trajectory.joint_positions_by_motion_group_key.items()
     }
 
-    async with _executor(groups).attach(trajectory, _GROUP_ARGS) as cursor:
+    async with _ensemble(groups).attach(trajectory, groups=_GROUP_ARGS) as cursor:
         forward = cursor.forward()
         while cursor.current_location <= 0.0:
             await asyncio.sleep(0.05)

--- a/tests/utils/test_joint_trajectory.py
+++ b/tests/utils/test_joint_trajectory.py
@@ -1,0 +1,28 @@
+"""Tests for combining synchronized multi-motion-group trajectories."""
+
+import pytest
+
+from nova import api
+from nova.utils.joint_trajectory import combine_multi_trajectories
+
+
+def _segment(*keys: str, end: float = 1.0) -> api.models.MultiJointTrajectory:
+    return api.models.MultiJointTrajectory(
+        joint_positions_by_motion_group_key={key: [[0.0] * 6, [0.0] * 6] for key in keys},
+        times=[0.0, end],
+        locations=[0.0, end],
+    )
+
+
+def test_segments_over_different_motion_groups__raises():
+    with pytest.raises(ValueError, match="same motion groups"):
+        combine_multi_trajectories([_segment("a", "b"), _segment("a", "c")])
+
+
+def test_concatenates_shifting_the_seam():
+    result = combine_multi_trajectories([_segment("a"), _segment("a")])
+    # each segment's first sample duplicates the previous seam and is dropped:
+    # 2 + (2 - 1) = 3 samples on one continuous 0..2 parameterization.
+    assert result.times == [0.0, 1.0, 2.0]
+    assert result.locations == [0.0, 1.0, 2.0]
+    assert len(result.joint_positions_by_motion_group_key["a"]) == 3


### PR DESCRIPTION
## What

`MultiMotionGroup` — the single primitive for several motion groups, mirroring `MotionGroup` for one: `plan` / `execute` / `plan_and_execute` and one builder. Built on the synchronized `TrajectoryExecutor` from #489 (now in `main`), which this PR also extends.

- **`MultiMotionGroupPlanner`** — the multi-group counterpart of `MotionGroup.plan`. Batches an ensemble action list (`multi_collision_free` / `wait` / `io_write`) into one synchronized `MultiJointTrajectory` via the multi-motion-group RRT endpoint (`search_collision_free_multi_motion_group`), returning a *pure* trajectory (writes carry no joint samples).
- **`MultiMotionGroup`** — the user-facing primitive. Wraps a planner and an executor over the same motion groups (pure DI; the constructor validates both cover the same groups). **One builder** — `MultiMotionGroup.builder(...).sync_on_io(...).build()` — states the sync barrier and wires both halves. A pre-planned trajectory runs through `execute` alone (planner idle), mirroring `MotionGroup.execute`; an all-non-motion list (only writes/waits) is applied directly without planning, the same short-circuit `MotionGroup.plan_and_execute` has.
- **`TrajectoryExecutor`** (extended) — enforces the single-cell invariant itself; carries location-anchored IO from the same `actions` list, routing each write to the owning motion group by its controller and anchoring it on the shared `locations`. The standalone `TrajectoryExecutorBuilder` is gone — assembly moved to `MultiMotionGroup.builder`.
- **`MultiTrajectoryCursor`** — takes the ensemble actions and exposes the single cursor's action stepping (`current_action` / `current_action_index` / `forward_to_next_action`) over the shared parameterization; validates the trajectory's end location matches the motion count, like the single cursor.
- Shared `located_writes` / `write_to_set_io` helpers extracted into `nova.actions.container`.
- Examples: `multi_motion_group.py` (run a recorded synchronized trajectory via `execute`) and `multi_motion_group_planning.py` (plan-and-execute a live collision-free ensemble from fixed joint configs, IO fired on the seam).

## Notes

- Built against api-client 26.7 (plain `list`/`dict`/`float` model shapes; `SetIO.io` unwrapped).
- The planning example is a commented `nova-run-examples` matrix entry — the multi-RRT endpoint is flaky on the CI virtual instance.
- Verified live on a real cluster: the multi-RRT endpoint returns unit-span-per-motion `locations` (so the end-location check holds), and a writes-only `plan` is rejected server-side (`FeedbackCommandsMissing`).

## Test

- New unit suites: `test_multi_motion_group_planner`, `test_multi_motion_group`, `test_located_writes`; plus IO-overlay, action-stepping, direct-non-motion and session coverage in the executor suites, and the live-cell integration test.
- `366 passed` across `tests/actions tests/cell tests/nova/cell`; `ruff format` / `ruff check` / `ty check` clean.