### PR TITLE
feat(cell): one shared motion-group state stream per motion group

### DIFF
--- a/nova/cell/motion_group.py
+++ b/nova/cell/motion_group.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-from contextlib import aclosing
 from functools import partial
 from typing import AsyncGenerator
 
@@ -547,20 +546,26 @@ class MotionGroup(AbstractRobot):
 
         This method provides a real-time stream of robot state information including
         joint positions and TCP pose data for the motion group.
+
+        All consumers of one motion group share a single underlying websocket per
+        gateway; this call only subscribes to it. The websocket is opened at the
+        rate of its first subscriber: a later subscriber asking for a slower rate
+        is downsampled client-side, one asking for a faster rate receives the
+        socket's (slower) rate and a warning is logged.
+
         Args:
             response_rate_msecs (int | None): The rate at which state updates are streamed
-                                             in milliseconds. Defaults to None for maximum rate.
+                                             in milliseconds. Defaults to None, which is the
+                                             server default of 200 ms.
         """
-        response_stream = self._api_client.motion_group_api.stream_motion_group_state(
-            cell=self._cell,
-            controller=self._controller_id,
-            motion_group=self.id,
-            response_rate=response_rate_msecs,
-        )
-
-        async with aclosing(response_stream) as response_stream:
-            async for response in response_stream:
-                yield response
+        subscription = self._api_client.motion_group_state_stream(
+            cell=self._cell, controller_id=self._controller_id, motion_group_id=self.id
+        ).subscribe(response_rate_msecs)
+        try:
+            async for state in subscription:
+                yield state
+        finally:
+            await subscription.aclose()
 
     async def joints(self) -> tuple[float, ...]:
         """Returns the current joint positions of the motion group."""

--- a/nova/cell/multi_trajectory_cursor.py
+++ b/nova/cell/multi_trajectory_cursor.py
@@ -5,11 +5,12 @@ import contextlib
 import logging
 from collections.abc import AsyncGenerator, AsyncIterable, Mapping
 from dataclasses import dataclass
-from typing import Generic, Protocol, TypeVar
+from typing import Protocol
 
 from nova import api
 from nova.actions.io import WriteAction
 from nova.cell.movement_controller.trajectory_cursor import OperationResult, TrajectoryCursor
+from nova.cell.state_stream import StreamBroadcaster
 from nova.core.gateway import ApiGateway
 
 logger = logging.getLogger(__name__)
@@ -18,12 +19,6 @@ logger = logging.getLogger(__name__)
 # the barrier gives up rather than waiting for a controller that never answers.
 _TRIGGER_CONFIRM_TIMEOUT = 5.0
 _IO_POLL_INTERVAL = 0.05
-
-# Same bound the cursor applies to its own state queue: a subscriber that is
-# never consumed must not grow without limit.
-_MAX_QUEUED_STATES = 1024
-
-T = TypeVar("T")
 
 
 class SyncDriver(Protocol):
@@ -147,68 +142,6 @@ class IOSyncDriver:
         logger.debug(f"Sync IO '{action.key}' set to {action.value}")
 
 
-class _QueueSentinel:
-    """Marker type used only as a sentinel for queue termination."""
-
-
-_QUEUE_SENTINEL = _QueueSentinel()
-
-
-class _StreamBroadcaster(Generic[T]):
-    """Broadcast a single async stream to multiple subscribers.
-
-    A cursor tees its states into one internal queue, so it supports exactly one
-    consumer; the session needs several (barrier arm-wait, drift monitors, user
-    streams). A subscriber that closes its stream stops being fed; a
-    subscriber that never consumes is bounded by dropping its oldest items.
-    Subscribing after the source ended yields an immediately-finished stream.
-    """
-
-    def __init__(self, source: AsyncIterable[T]):
-        self._source = source
-        self._queues: list[asyncio.Queue[T | _QueueSentinel]] = []
-        self._is_finished = False
-
-    def subscribe(self) -> AsyncGenerator[T, None]:
-        """Subscribe to every item emitted from now on."""
-        if self._is_finished:
-
-            async def ended_stream() -> AsyncGenerator[T, None]:
-                return
-                yield  # unreachable; makes this function an async generator
-
-            return ended_stream()
-        queue: asyncio.Queue[T | _QueueSentinel] = asyncio.Queue()
-        self._queues.append(queue)
-        return self._queue_iterator(queue)
-
-    async def run(self) -> None:
-        try:
-            async for item in self._source:
-                for queue in self._queues:
-                    if queue.qsize() >= _MAX_QUEUED_STATES:
-                        with contextlib.suppress(asyncio.QueueEmpty):
-                            queue.get_nowait()
-                    queue.put_nowait(item)
-        finally:
-            self._is_finished = True
-            for queue in self._queues:
-                queue.put_nowait(_QUEUE_SENTINEL)
-
-    async def _queue_iterator(
-        self, queue: asyncio.Queue[T | _QueueSentinel]
-    ) -> AsyncGenerator[T, None]:
-        try:
-            while True:
-                item = await queue.get()
-                if isinstance(item, _QueueSentinel):
-                    return
-                yield item
-        finally:
-            if queue in self._queues:
-                self._queues.remove(queue)
-
-
 async def _wait_until_waiting_for_io(states: AsyncIterable[api.models.MotionGroupState]) -> None:
     async for state in states:
         if state.execute is not None and isinstance(
@@ -260,7 +193,7 @@ class MultiTrajectoryCursor:
         # One fan-out per group: a cursor tees its states into a single queue, but
         # the session has several consumers (barrier arm-wait, drift monitors,
         # user streams).
-        self._broadcasters = {name: _StreamBroadcaster(cursor) for name, cursor in cursors.items()}
+        self._broadcasters = {name: StreamBroadcaster(cursor) for name, cursor in cursors.items()}
         # A pending intent not yet consumed is silently overwritten — only the
         # most recent one matters — and pause() may void it before it ever runs.
         self._pending_intent: _ForwardIntent | None = None

--- a/nova/cell/state_stream.py
+++ b/nova/cell/state_stream.py
@@ -176,6 +176,9 @@ class _PumpGeneration:
     )
     close_requested: asyncio.Event = field(default_factory=asyncio.Event)
     task: asyncio.Task | None = None
+    # The one pending linger countdown; rescheduled whenever the last
+    # subscriber leaves again, so an earlier countdown cannot fire early.
+    linger_task: asyncio.Task | None = None
 
 
 class SharedMotionGroupStateStream:
@@ -264,7 +267,12 @@ class SharedMotionGroupStateStream:
         if generation.queues or generation.close_requested.is_set():
             return
         if self._linger_secs > 0:
-            asyncio.create_task(
+            # One countdown per generation, measured from the *latest* departure:
+            # a stale countdown from an earlier leave/rejoin cycle would fire at
+            # the earlier deadline and cut the keep-alive short.
+            if generation.linger_task is not None:
+                generation.linger_task.cancel()
+            generation.linger_task = asyncio.create_task(
                 self._linger_then_close(generation), name=f"motion-group-state-linger-{self._name}"
             )
         else:
@@ -303,6 +311,11 @@ class SharedMotionGroupStateStream:
                         self._broadcast(generation, next_frame.result())
                 finally:
                     close_wait.cancel()
+                    # This generation stops serving here, but closing the
+                    # websocket below is an await point: a subscribe() landing
+                    # in that window must open a fresh generation instead of
+                    # joining this one moments before its queues are flushed.
+                    generation.close_requested.set()
             finally:
                 await stream.aclose()
         except StopAsyncIteration:
@@ -320,6 +333,11 @@ class SharedMotionGroupStateStream:
             queue.put_nowait(state)
 
     def _finish(self, generation: _PumpGeneration, error: BaseException | None) -> None:
+        # Covers the paths that never reach the pump loop (open_stream raising):
+        # a finished generation must never be joinable.
+        generation.close_requested.set()
+        if generation.linger_task is not None:
+            generation.linger_task.cancel()
         if error is not None:
             logger.warning(f"Motion group state stream '{self._name}' failed: {error!r}")
         for queue in generation.queues.values():

--- a/nova/cell/state_stream.py
+++ b/nova/cell/state_stream.py
@@ -1,0 +1,372 @@
+"""One shared motion-group state stream per motion group, fanned out to its subscribers.
+
+The SDK used to open a fresh ``stream_motion_group_state`` websocket for every
+consumer (the execute relay, the trajectory cursor, viewers, ...). Every extra
+socket is another full-rate stream the client must keep draining: a consumer
+that stops draining pauses the websocket transport, a paused transport never
+reads the server's close reply, and closing the socket then waits out the
+library's ``close_timeout`` — the end-of-motion stall.
+
+Here one pump task owns the websocket per motion group and only ever enqueues
+into per-subscriber queues, so the transport is always drained. The websocket
+is opened lazily on the first subscription and closed by the pump itself, in a
+context that is never externally cancelled — never in a subscriber ``finally``,
+a cancelled TaskGroup child, or a GC finalizer.
+"""
+
+import asyncio
+import contextlib
+import functools
+import logging
+from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Callable
+from dataclasses import dataclass, field
+from typing import Generic, TypeVar
+
+from nova import api
+from nova.utils.downsample import downsample_stream
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# What ``response_rate=None`` means server-side; used to order subscriber rates.
+_SERVER_DEFAULT_RATE_MSECS = 200
+
+# Bound per subscriber queue: a subscriber that is never consumed must not grow
+# without limit; oldest states are dropped first.
+_MAX_QUEUED_STATES = 1024
+
+
+class _QueueSentinel:
+    """Marker type used only as a sentinel for queue termination."""
+
+
+_QUEUE_SENTINEL = _QueueSentinel()
+
+
+class StreamBroadcaster(Generic[T]):
+    """Broadcast a single async stream to multiple subscribers.
+
+    A cursor tees its states into one internal queue, so it supports exactly one
+    consumer; the session needs several (barrier arm-wait, drift monitors, user
+    streams). A subscriber that closes its stream stops being fed; a
+    subscriber that never consumes is bounded by dropping its oldest items.
+    Subscribing after the source ended yields an immediately-finished stream.
+    """
+
+    def __init__(self, source: AsyncIterable[T]):
+        self._source = source
+        self._queues: list[asyncio.Queue[T | _QueueSentinel]] = []
+        self._is_finished = False
+
+    def subscribe(self) -> AsyncGenerator[T, None]:
+        """Subscribe to every item emitted from now on."""
+        if self._is_finished:
+
+            async def ended_stream() -> AsyncGenerator[T, None]:
+                return
+                yield  # unreachable; makes this function an async generator
+
+            return ended_stream()
+        queue: asyncio.Queue[T | _QueueSentinel] = asyncio.Queue()
+        self._queues.append(queue)
+        return self._queue_iterator(queue)
+
+    async def run(self) -> None:
+        try:
+            async for item in self._source:
+                for queue in self._queues:
+                    if queue.qsize() >= _MAX_QUEUED_STATES:
+                        with contextlib.suppress(asyncio.QueueEmpty):
+                            queue.get_nowait()
+                    queue.put_nowait(item)
+        finally:
+            self._is_finished = True
+            for queue in self._queues:
+                queue.put_nowait(_QUEUE_SENTINEL)
+
+    async def _queue_iterator(
+        self, queue: asyncio.Queue[T | _QueueSentinel]
+    ) -> AsyncGenerator[T, None]:
+        try:
+            while True:
+                item = await queue.get()
+                if isinstance(item, _QueueSentinel):
+                    return
+                yield item
+        finally:
+            if queue in self._queues:
+                self._queues.remove(queue)
+
+
+@dataclass
+class _EndOfStream:
+    """Terminal queue marker: the shared stream is over for this subscriber.
+
+    Carries the upstream error when there was one, so each subscription can
+    re-raise it; ``None`` means a graceful end (or the subscriber's own close).
+    """
+
+    error: BaseException | None = None
+
+
+class StateSubscription:
+    """One subscriber's live view of a shared motion-group state stream.
+
+    Async-iterate it for states. ``aclose()`` only deregisters — it is cheap,
+    idempotent, and safe while another task is blocked in ``__anext__``; the
+    websocket itself is owned by the shared stream's pump and closed there once
+    the last subscription is gone.
+    """
+
+    def __init__(
+        self,
+        deregister: Callable[["StateSubscription"], None],
+        queue: "asyncio.Queue[api.models.MotionGroupState | _EndOfStream]",
+        downsample_to_msecs: int | None = None,
+    ):
+        self._deregister = deregister
+        self._queue = queue
+        self._closed = False
+        stream: AsyncIterator[api.models.MotionGroupState] = self._drain_queue()
+        if downsample_to_msecs is not None:
+            stream = downsample_stream(stream, 1000.0 / downsample_to_msecs)
+        self._stream = stream
+
+    def __aiter__(self) -> AsyncIterator[api.models.MotionGroupState]:
+        return self
+
+    async def __anext__(self) -> api.models.MotionGroupState:
+        return await self._stream.__anext__()
+
+    async def aclose(self) -> None:
+        """Deregister from the shared stream.
+
+        Deliberately never touches the websocket, so it stays trivially safe to
+        call from a ``finally``, a cancelled task, or a GC-driven generator
+        finalizer. Contains no await point: it completes even when the calling
+        context is already cancelled.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        self._deregister(self)
+        # Wake a __anext__ blocked on the empty queue so it ends instead of hanging.
+        self._queue.put_nowait(_EndOfStream())
+
+    async def _drain_queue(self) -> AsyncGenerator[api.models.MotionGroupState, None]:
+        while True:
+            item = await self._queue.get()
+            if isinstance(item, _EndOfStream):
+                if not self._closed and item.error is not None:
+                    raise item.error
+                return
+            if self._closed:
+                return
+            yield item
+
+
+@dataclass
+class _PumpGeneration:
+    """One websocket lifetime: the pump task, its socket rate, its subscribers."""
+
+    rate_msecs: int | None
+    queues: "dict[StateSubscription, asyncio.Queue[api.models.MotionGroupState | _EndOfStream]]" = (
+        field(default_factory=dict)
+    )
+    close_requested: asyncio.Event = field(default_factory=asyncio.Event)
+    task: asyncio.Task | None = None
+
+
+class SharedMotionGroupStateStream:
+    """Fan one ``stream_motion_group_state`` websocket out to many subscribers.
+
+    The websocket opens lazily on the first :meth:`subscribe` and closes — in
+    the pump task's own, never externally cancelled context — when the last
+    subscription deregisters (after ``linger_secs``). A later subscribe reopens
+    it. The socket rate is fixed by the subscriber that opened it: a later
+    subscriber asking for a slower rate is downsampled client-side, one asking
+    for a faster rate gets the socket's slower rate and a warning.
+
+    An upstream error ends every subscription with that error; a graceful
+    upstream end just ends them. Either way the next subscribe opens a fresh
+    websocket.
+    """
+
+    def __init__(
+        self,
+        open_stream: Callable[[int | None], AsyncGenerator[api.models.MotionGroupState, None]],
+        name: str = "",
+        linger_secs: float = 0.0,
+    ):
+        self._open_stream = open_stream
+        self._name = name
+        self._linger_secs = linger_secs
+        self._generation: _PumpGeneration | None = None
+
+    def subscribe(self, response_rate_msecs: int | None = None) -> StateSubscription:
+        """Subscribe to every state emitted from now on.
+
+        Args:
+            response_rate_msecs: Rate at which this subscriber wants states, in
+                milliseconds. ``None`` means the server default of 200 ms.
+        """
+        generation = self._generation
+        if (
+            generation is None
+            or generation.close_requested.is_set()
+            or (generation.task is not None and generation.task.done())
+        ):
+            generation = _PumpGeneration(rate_msecs=response_rate_msecs)
+            generation.task = asyncio.create_task(
+                self._pump(generation), name=f"motion-group-state-pump-{self._name}"
+            )
+            self._generation = generation
+
+        socket_rate = (
+            generation.rate_msecs
+            if generation.rate_msecs is not None
+            else _SERVER_DEFAULT_RATE_MSECS
+        )
+        requested_rate = (
+            response_rate_msecs if response_rate_msecs is not None else _SERVER_DEFAULT_RATE_MSECS
+        )
+        downsample_to_msecs: int | None = None
+        if requested_rate < socket_rate:
+            logger.warning(
+                f"Motion group state stream '{self._name}' is already open at "
+                f"{socket_rate} ms; a new subscription asking for {requested_rate} ms "
+                f"cannot make it faster and will receive states at {socket_rate} ms."
+            )
+        elif requested_rate > socket_rate:
+            downsample_to_msecs = requested_rate
+
+        queue: asyncio.Queue[api.models.MotionGroupState | _EndOfStream] = asyncio.Queue()
+        subscription = StateSubscription(
+            deregister=functools.partial(self._deregister, generation),
+            queue=queue,
+            downsample_to_msecs=downsample_to_msecs,
+        )
+        generation.queues[subscription] = queue
+        return subscription
+
+    async def aclose(self) -> None:
+        """End all subscriptions and wait for the pump to close the websocket."""
+        generation = self._generation
+        if generation is None:
+            return
+        generation.close_requested.set()
+        if generation.task is not None:
+            await generation.task
+
+    def _deregister(self, generation: _PumpGeneration, subscription: StateSubscription) -> None:
+        generation.queues.pop(subscription, None)
+        if generation.queues or generation.close_requested.is_set():
+            return
+        if self._linger_secs > 0:
+            asyncio.create_task(
+                self._linger_then_close(generation), name=f"motion-group-state-linger-{self._name}"
+            )
+        else:
+            generation.close_requested.set()
+
+    async def _linger_then_close(self, generation: _PumpGeneration) -> None:
+        await asyncio.sleep(self._linger_secs)
+        if not generation.queues:
+            generation.close_requested.set()
+
+    async def _pump(self, generation: _PumpGeneration) -> None:
+        """Drain the websocket into the subscriber queues, then close it.
+
+        The pump is the only place the websocket is closed, and the pump is
+        never cancelled from outside — closing therefore never runs in a
+        subscriber ``finally``, a cancelled TaskGroup child, or a GC finalizer,
+        where a paused transport would turn it into a ``close_timeout`` wait
+        for the caller.
+        """
+        error: BaseException | None = None
+        try:
+            stream = self._open_stream(generation.rate_msecs)
+            try:
+                iterator = stream.__aiter__()
+                close_wait = asyncio.ensure_future(generation.close_requested.wait())
+                try:
+                    while True:
+                        next_frame = asyncio.ensure_future(iterator.__anext__())
+                        await asyncio.wait(
+                            {next_frame, close_wait}, return_when=asyncio.FIRST_COMPLETED
+                        )
+                        if generation.close_requested.is_set():
+                            next_frame.cancel()
+                            await asyncio.gather(next_frame, return_exceptions=True)
+                            break
+                        self._broadcast(generation, next_frame.result())
+                finally:
+                    close_wait.cancel()
+            finally:
+                await stream.aclose()
+        except StopAsyncIteration:
+            pass  # upstream ended gracefully
+        except Exception as e:
+            error = e
+        finally:
+            self._finish(generation, error)
+
+    def _broadcast(self, generation: _PumpGeneration, state: api.models.MotionGroupState) -> None:
+        for queue in generation.queues.values():
+            if queue.qsize() >= _MAX_QUEUED_STATES:
+                with contextlib.suppress(asyncio.QueueEmpty):
+                    queue.get_nowait()
+            queue.put_nowait(state)
+
+    def _finish(self, generation: _PumpGeneration, error: BaseException | None) -> None:
+        if error is not None:
+            logger.warning(f"Motion group state stream '{self._name}' failed: {error!r}")
+        for queue in generation.queues.values():
+            queue.put_nowait(_EndOfStream(error=error))
+        generation.queues.clear()
+        if self._generation is generation:
+            self._generation = None
+
+
+class MotionGroupStateStreamRegistry:
+    """The shared state streams of one gateway, keyed by (cell, controller, motion group).
+
+    Owned by the :class:`~nova.core.gateway.ApiGateway`, so every consumer that
+    reaches the API through one gateway converges on one websocket per motion
+    group. Keyed below ``MotionGroup`` because ``Controller.motion_group()``
+    constructs a fresh instance per call.
+    """
+
+    def __init__(
+        self,
+        open_stream: Callable[
+            [str, str, str, int | None], AsyncGenerator[api.models.MotionGroupState, None]
+        ],
+        linger_secs: float = 0.0,
+    ):
+        self._open_stream = open_stream
+        self._linger_secs = linger_secs
+        self._streams: dict[tuple[str, str, str], SharedMotionGroupStateStream] = {}
+
+    def stream(
+        self, cell: str, controller_id: str, motion_group_id: str
+    ) -> SharedMotionGroupStateStream:
+        """The shared stream for one motion group, created on first use."""
+        key = (cell, controller_id, motion_group_id)
+        shared = self._streams.get(key)
+        if shared is None:
+            shared = SharedMotionGroupStateStream(
+                open_stream=functools.partial(
+                    self._open_stream, cell, controller_id, motion_group_id
+                ),
+                name="/".join(key),
+                linger_secs=self._linger_secs,
+            )
+            self._streams[key] = shared
+        return shared
+
+    async def aclose(self) -> None:
+        """Close every shared stream; used by ``ApiGateway.close()``."""
+        for shared in self._streams.values():
+            await shared.aclose()

--- a/nova/config.py
+++ b/nova/config.py
@@ -38,6 +38,14 @@ class NovaConfig(BaseModel):
     host: str = Field(..., description="Nova API host.")
     access_token: str | None = Field(default=None, description="Access token for Nova API.")
     verify_ssl: bool = Field(default=True)
+    motion_group_state_stream_linger_secs: float = Field(
+        default=0.0,
+        description=(
+            "How long the shared motion-group state websocket stays open after its last "
+            "subscriber unsubscribed, in seconds. 0 closes it immediately; a positive value "
+            "avoids a close/reopen cycle between back-to-back executions."
+        ),
+    )
     nats_client_config: dict | None = Field(
         default=None,
         description="Client configuration to pass to the nats library. See: https://nats-io.github.io/nats.py/modules.html#nats.aio.client.Client.connect",

--- a/nova/core/gateway.py
+++ b/nova/core/gateway.py
@@ -7,6 +7,7 @@ from typing import TypeVar
 
 from nova import api
 from nova.cell.robot_cell import ConfigurablePeriphery, Device
+from nova.cell.state_stream import MotionGroupStateStreamRegistry, SharedMotionGroupStateStream
 from nova.config import NovaConfig
 from nova.version import version as pkg_version
 
@@ -75,6 +76,30 @@ class ApiGateway:
     def __init__(self, config: NovaConfig):
         self.config = config
         self._init_api_client()
+        # One shared state stream per motion group for every consumer of this
+        # gateway. Created once here (not in _init_api_client) so a client
+        # reinitialization cannot orphan running pumps; the opener resolves
+        # self.motion_group_api late for the same reason.
+        self._motion_group_state_streams = MotionGroupStateStreamRegistry(
+            open_stream=self._open_motion_group_state_stream,
+            linger_secs=config.motion_group_state_stream_linger_secs,
+        )
+
+    def _open_motion_group_state_stream(
+        self, cell: str, controller_id: str, motion_group_id: str, response_rate_msecs: int | None
+    ):
+        return self.motion_group_api.stream_motion_group_state(
+            cell=cell,
+            controller=controller_id,
+            motion_group=motion_group_id,
+            response_rate=response_rate_msecs,
+        )
+
+    def motion_group_state_stream(
+        self, cell: str, controller_id: str, motion_group_id: str
+    ) -> SharedMotionGroupStateStream:
+        """The shared motion-group state stream for one motion group of this gateway."""
+        return self._motion_group_state_streams.stream(cell, controller_id, motion_group_id)
 
     def _init_api_client(self):
         """Initialize or reinitialize the API client with current credentials"""
@@ -139,6 +164,7 @@ class ApiGateway:
         logger.debug(f"NOVA API client initialized with user agent {self._api_client.user_agent}")
 
     async def close(self):
+        await self._motion_group_state_streams.aclose()
         await self._api_client.close()
 
 

--- a/tests/cell/test_state_stream.py
+++ b/tests/cell/test_state_stream.py
@@ -1,0 +1,312 @@
+"""Unit tests for the shared motion-group state stream.
+
+The upstream websocket is faked by :class:`FakeUpstream`, which counts opens
+and acloses and can be fed states, ended gracefully, or failed — everything
+the pump-owns-the-socket contract is asserted against.
+"""
+
+import asyncio
+import logging
+
+import pytest
+
+from nova.cell.state_stream import (
+    _MAX_QUEUED_STATES,
+    MotionGroupStateStreamRegistry,
+    SharedMotionGroupStateStream,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class FakeUpstream:
+    """Stands in for the generated client's ``stream_motion_group_state``."""
+
+    def __init__(self):
+        self.open_rates: list[int | None] = []
+        self.aclose_count = 0
+        self.closed = asyncio.Event()
+        self._feed: asyncio.Queue = asyncio.Queue()
+
+    def feed(self, state) -> None:
+        self._feed.put_nowait(("state", state))
+
+    def end(self) -> None:
+        self._feed.put_nowait(("end", None))
+
+    def fail(self, error: Exception) -> None:
+        self._feed.put_nowait(("error", error))
+
+    def open(self, response_rate_msecs):
+        self.open_rates.append(response_rate_msecs)
+        return self._stream()
+
+    async def _stream(self):
+        try:
+            while True:
+                kind, value = await self._feed.get()
+                if kind == "state":
+                    yield value
+                elif kind == "end":
+                    return
+                else:
+                    raise value
+        finally:
+            self.aclose_count += 1
+            self.closed.set()
+
+
+@pytest.fixture
+def upstream():
+    return FakeUpstream()
+
+
+@pytest.fixture
+def shared(upstream):
+    return SharedMotionGroupStateStream(open_stream=upstream.open, name="cell/ctrl/0@ctrl")
+
+
+async def next_state(subscription, timeout: float = 1.0):
+    return await asyncio.wait_for(subscription.__anext__(), timeout)
+
+
+async def test_no_socket_before_first_subscribe(shared, upstream):
+    await asyncio.sleep(0)
+    assert upstream.open_rates == []
+
+
+async def test_one_socket_serves_many_subscribers(shared, upstream):
+    subscriptions = [shared.subscribe() for _ in range(3)]
+    upstream.feed("s1")
+    for subscription in subscriptions:
+        assert await next_state(subscription) == "s1"
+    assert upstream.open_rates == [None]
+    assert upstream.aclose_count == 0
+
+
+async def test_last_aclose_closes_upstream_in_the_pump(shared, upstream):
+    first = shared.subscribe()
+    second = shared.subscribe()
+    upstream.feed("s1")
+    assert await next_state(first) == "s1"
+
+    await first.aclose()
+    await asyncio.sleep(0)
+    assert upstream.aclose_count == 0, "socket must stay open while a subscriber remains"
+
+    await second.aclose()
+    await asyncio.wait_for(upstream.closed.wait(), 1.0)
+    assert upstream.aclose_count == 1
+
+
+async def test_aclose_is_idempotent_and_wakes_a_blocked_anext(shared, upstream):
+    subscription = shared.subscribe()
+    blocked = asyncio.ensure_future(next_state(subscription))
+    await asyncio.sleep(0)
+
+    await subscription.aclose()
+    await subscription.aclose()
+    with pytest.raises(StopAsyncIteration):
+        await blocked
+
+
+async def test_reopen_after_full_close(shared, upstream):
+    first = shared.subscribe()
+    upstream.feed("s1")
+    assert await next_state(first) == "s1"
+    await first.aclose()
+    await asyncio.wait_for(upstream.closed.wait(), 1.0)
+
+    second = shared.subscribe()
+    upstream.feed("s2")
+    assert await next_state(second) == "s2"
+    assert upstream.open_rates == [None, None]
+    await second.aclose()
+
+
+async def test_upstream_error_reaches_every_subscriber(shared, upstream):
+    subscriptions = [shared.subscribe() for _ in range(2)]
+    error = RuntimeError("connection lost")
+    upstream.fail(error)
+    for subscription in subscriptions:
+        with pytest.raises(RuntimeError, match="connection lost"):
+            await next_state(subscription)
+
+
+async def test_graceful_upstream_end_ends_subscriptions(shared, upstream):
+    subscription = shared.subscribe()
+    upstream.feed("s1")
+    upstream.end()
+    received = [state async for state in subscription]
+    assert received == ["s1"]
+
+
+async def test_subscribe_after_upstream_end_opens_a_fresh_socket(shared, upstream):
+    first = shared.subscribe()
+    upstream.end()
+    assert [state async for state in first] == []
+
+    second = shared.subscribe()
+    upstream.feed("s2")
+    assert await next_state(second) == "s2"
+    assert len(upstream.open_rates) == 2
+    await second.aclose()
+
+
+async def test_socket_rate_is_fixed_by_the_first_subscriber(shared, upstream):
+    first = shared.subscribe(500)
+    upstream.feed("s1")
+    assert await next_state(first) == "s1"
+    assert upstream.open_rates == [500]
+    await first.aclose()
+
+
+async def test_later_faster_subscriber_warns_and_keeps_the_socket(shared, upstream, caplog):
+    first = shared.subscribe(1000)
+    with caplog.at_level(logging.WARNING, logger="nova.cell.state_stream"):
+        second = shared.subscribe(100)
+    assert any("cannot make it faster" in message for message in caplog.messages)
+
+    upstream.feed("s1")
+    assert await next_state(second) == "s1"
+    assert upstream.open_rates == [1000]
+    await first.aclose()
+    await second.aclose()
+
+
+async def test_later_slower_subscriber_is_downsampled(shared, upstream):
+    fast = shared.subscribe()  # opens the socket at the server default (200 ms)
+    slow = shared.subscribe(60_000)  # one state a minute: a burst passes only its first state
+
+    for index in range(3):
+        upstream.feed(f"s{index}")
+    assert [await next_state(fast) for _ in range(3)] == ["s0", "s1", "s2"]
+
+    assert await next_state(slow) == "s0"
+    with pytest.raises(asyncio.TimeoutError):
+        await next_state(slow, timeout=0.05)
+
+    await fast.aclose()
+    await slow.aclose()
+
+
+async def test_cancelled_subscriber_leaves_the_socket_open_for_others(shared, upstream):
+    doomed = shared.subscribe()
+    survivor = shared.subscribe()
+
+    blocked = asyncio.ensure_future(next_state(doomed))
+    await asyncio.sleep(0)
+    blocked.cancel()
+    await asyncio.gather(blocked, return_exceptions=True)
+    await doomed.aclose()  # what a consumer's finally does after cancellation
+    await asyncio.sleep(0)
+
+    assert upstream.aclose_count == 0
+    upstream.feed("s1")
+    assert await next_state(survivor) == "s1"
+    await survivor.aclose()
+
+
+async def test_queue_is_bounded_dropping_oldest(shared, upstream):
+    subscription = shared.subscribe()
+    total = _MAX_QUEUED_STATES + 7
+    for index in range(total):
+        upstream.feed(index)
+    upstream.feed("last")
+    # Let the pump broadcast everything before consuming, so the subscriber
+    # queue actually hits its bound instead of being drained concurrently.
+    while not upstream._feed.empty():
+        await asyncio.sleep(0)
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    received = []
+    while (state := await next_state(subscription)) != "last":
+        received.append(state)
+    assert len(received) < _MAX_QUEUED_STATES  # "last" occupies one of the bounded slots
+    assert received[-1] == total - 1
+    assert received[0] > 0, "oldest states must have been dropped"
+    await subscription.aclose()
+
+
+async def test_stream_aclose_ends_subscriptions_and_closes_the_socket(shared, upstream):
+    subscription = shared.subscribe()
+    upstream.feed("s1")
+    assert await next_state(subscription) == "s1"
+
+    await shared.aclose()
+    assert upstream.aclose_count == 1
+    with pytest.raises(StopAsyncIteration):
+        await next_state(subscription)
+
+
+async def test_linger_keeps_the_socket_open_for_a_resubscriber(upstream):
+    shared = SharedMotionGroupStateStream(
+        open_stream=upstream.open, name="cell/ctrl/0@ctrl", linger_secs=0.05
+    )
+    first = shared.subscribe()
+    upstream.feed("s1")
+    assert await next_state(first) == "s1"
+    await first.aclose()
+
+    second = shared.subscribe()  # within the linger window: same socket
+    upstream.feed("s2")
+    assert await next_state(second) == "s2"
+    assert upstream.open_rates == [None]
+
+    await second.aclose()
+    await asyncio.wait_for(upstream.closed.wait(), 1.0)
+
+
+async def test_registry_shares_streams_per_motion_group():
+    upstream = FakeUpstream()
+    other_upstream = FakeUpstream()
+
+    def open_stream(cell, controller_id, motion_group_id, rate):
+        return (upstream if motion_group_id == "0@ctrl" else other_upstream).open(rate)
+
+    registry = MotionGroupStateStreamRegistry(open_stream=open_stream)
+    assert registry.stream("cell", "ctrl", "0@ctrl") is registry.stream("cell", "ctrl", "0@ctrl")
+    assert registry.stream("cell", "ctrl", "0@ctrl") is not registry.stream(
+        "cell", "ctrl", "1@ctrl"
+    )
+
+    subscription = registry.stream("cell", "ctrl", "0@ctrl").subscribe()
+    other = registry.stream("cell", "ctrl", "1@ctrl").subscribe()
+    upstream.feed("s1")
+    assert await next_state(subscription) == "s1"
+
+    await registry.aclose()
+    assert upstream.aclose_count == 1
+    assert other_upstream.aclose_count == 1
+    with pytest.raises(StopAsyncIteration):
+        await next_state(subscription)
+    with pytest.raises(StopAsyncIteration):
+        await next_state(other)
+
+
+async def test_gateway_close_drains_its_registry(monkeypatch):
+    from nova.config import NovaConfig
+    from nova.core.gateway import ApiGateway
+
+    gateway = ApiGateway(NovaConfig(host="http://localhost"))
+    upstream = FakeUpstream()
+    monkeypatch.setattr(
+        gateway,
+        "_open_motion_group_state_stream",
+        lambda cell, controller_id, motion_group_id, rate: upstream.open(rate),
+    )
+    monkeypatch.setattr(
+        gateway._motion_group_state_streams,
+        "_open_stream",
+        lambda cell, controller_id, motion_group_id, rate: upstream.open(rate),
+    )
+
+    subscription = gateway.motion_group_state_stream("cell", "ctrl", "0@ctrl").subscribe()
+    upstream.feed("s1")
+    assert await next_state(subscription) == "s1"
+
+    await gateway.close()
+    assert upstream.aclose_count == 1
+    with pytest.raises(StopAsyncIteration):
+        await next_state(subscription)

--- a/tests/cell/test_state_stream.py
+++ b/tests/cell/test_state_stream.py
@@ -240,6 +240,72 @@ async def test_stream_aclose_ends_subscriptions_and_closes_the_socket(shared, up
         await next_state(subscription)
 
 
+async def test_subscribe_during_pump_teardown_gets_a_fresh_socket(upstream):
+    """A subscribe landing while the pump is closing the old websocket must not
+    join the dying generation (it would end after zero states, with no reopen)."""
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+
+    class HoldOnClose:
+        """First socket only: closing it suspends until the test releases it."""
+
+        def __init__(self, inner):
+            self._inner = inner
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            return await self._inner.__anext__()
+
+        async def aclose(self):
+            close_started.set()
+            await release_close.wait()
+            await self._inner.aclose()
+
+    def open_stream(rate):
+        stream = upstream.open(rate)
+        return HoldOnClose(stream) if len(upstream.open_rates) == 1 else stream
+
+    shared = SharedMotionGroupStateStream(open_stream=open_stream, name="cell/ctrl/0@ctrl")
+    first = shared.subscribe()
+    upstream.end()
+    await asyncio.wait_for(close_started.wait(), 1.0)  # pump suspended in aclose
+
+    second = shared.subscribe()
+    upstream.feed("s2")
+    assert await next_state(second) == "s2"
+    assert len(upstream.open_rates) == 2, "the race-losing subscriber must get a fresh socket"
+
+    release_close.set()
+    with pytest.raises(StopAsyncIteration):
+        await next_state(first)
+    await second.aclose()
+
+
+async def test_linger_is_measured_from_the_latest_departure(upstream):
+    """A stale linger countdown from an earlier leave/rejoin cycle must not
+    close the socket early relative to the most recent departure."""
+    shared = SharedMotionGroupStateStream(
+        open_stream=upstream.open, name="cell/ctrl/0@ctrl", linger_secs=0.4
+    )
+    first = shared.subscribe()
+    upstream.feed("s1")
+    assert await next_state(first) == "s1"
+    await first.aclose()  # countdown 1: would fire 0.4 s from now
+
+    await asyncio.sleep(0.1)
+    second = shared.subscribe()  # rejoin within the window: same socket
+    await asyncio.sleep(0.1)
+    await second.aclose()  # countdown must restart from here (fires at ~0.6)
+
+    await asyncio.sleep(0.25)  # past countdown 1's stale deadline (~0.4)
+    assert not upstream.closed.is_set(), "the stale countdown must not close the socket"
+
+    await asyncio.wait_for(upstream.closed.wait(), 2.0)
+    assert upstream.open_rates == [None]
+
+
 async def test_linger_keeps_the_socket_open_for_a_resubscriber(upstream):
     shared = SharedMotionGroupStateStream(
         open_stream=upstream.open, name="cell/ctrl/0@ctrl", linger_secs=0.05


### PR DESCRIPTION
## Summary
- Add `nova/cell/state_stream.py`: one shared `stream_motion_group_state` websocket per motion group, owned by a pump task and fanned out to any number of subscribers through bounded per-subscriber queues.
- `MotionGroup.stream_state` now subscribes to that shared stream, so every existing consumer (execute relay, trajectory cursor, viewers/rerun bridge, tuner, `TrajectoryExecutor`) converges on one socket per motion group with zero call-site changes.

## Why
The SDK opened a fresh state websocket per consumer — `motion_group.execute()` alone opened three sockets (execute + two full-rate state streams). Python `websockets` pauses the transport once its receive queue exceeds `max_queue` (default 16) frames, a paused transport never reads the server's close reply, and `websocket.close()` then waits out the full `close_timeout` (default 10 s). That is the end-of-motion stall observed in production: on a probe cell, 6.2 % of executions stalled for exactly `close_timeout` (root-cause analysis in `cell-plc-simulation`, `nova/ir999r01/lab/FINDINGS.md`; server exonerated — a Rust client closes the same stream in milliseconds, 400/400).

## Benefits
- The pump only ever enqueues, so the transport is always drained and can never pause — the stall's precondition is structurally gone, independent of any `websockets` configuration.
- One state socket per motion group instead of one per consumer: less connection churn on the gateway and controller.
- The websocket is closed exactly once, by the pump, in a context that is never externally cancelled — never in a subscriber `finally`, a cancelled TaskGroup child, or a GC finalizer.

## How
- `SharedMotionGroupStateStream`: lazy open on first `subscribe(rate)`, refcounted; closes when the last subscription deregisters (optionally after `NovaConfig.motion_group_state_stream_linger_secs`, default 0). Upstream error is stored and re-raised per subscription; graceful end just ends them; the next subscribe reopens.
- Socket rate is fixed by the first subscriber: a later slower subscriber is downsampled client-side (`downsample_stream`), a later faster one gets the socket's rate plus a warning — no reopen. `None` keeps meaning the server default of 200 ms (the old docstring's "maximum rate" was wrong and is fixed).
- `StateSubscription.aclose()` only deregisters — cheap, idempotent, safe mid-`__anext__` and under cancellation (no await points).
- Registry keyed `(cell, controller, motion_group)`, owned by `ApiGateway`, drained in `ApiGateway.close()`.
- `StreamBroadcaster` is hoisted verbatim from `multi_trajectory_cursor.py`, which imports it back.

## Test plan
- [x] New suite `tests/cell/test_state_stream.py` (17 tests): lazy open, one socket for N subscribers, last-aclose-closes-in-pump, reopen after close, error/graceful-end propagation, fastest-wins + warning + downsampling, cancelled subscriber leaves the socket open, drop-oldest bound (1024), registry sharing, gateway close drains the registry.
- [x] `PYTHONPATH=. uv run pytest -m "not integration" tests` — 658 passed (cursor parity and multi-group suites unchanged).
- [x] `uv run ruff check .`, `uv run ty check` — clean (no new diagnostics vs `main`).
- [x] Integration against a virtual NOVA instance: `tests/nova/cell/motion_group/` movement, cursor, cancelation and pause-on-IO suites — 14 passed.
- [x] Stall probe (`zero_motion_loop.py`, 450 zero-motion executes, `max_queue` at the library default 16, i.e. mitigation off, run on this branch + its follow-up): 0 close-timeout stalls, 0 movement errors; a discriminator run at `close_timeout=8` shows no event above 1.8 s. Baseline on `main`: 25/400 stalls at exactly `close_timeout`. `lsof` during the run: ≤2 websockets per motion group.

## Notes for reviewers
- First of three stacked PRs; the follow-ups restructure `MotionGroup._execute`/cursor teardown onto this stream and surface the rate on the execution APIs.
- Deliberate follow-ups, not silently dropped: execute-socket teardown when a caller abandons `stream_execute` mid-flight; tuner explicit rate; TrajectoryExecutor session-level broadcaster collapse; `websocket_options` pass-through in the generated client (separate service-manager MR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
