### PR TITLE
fix(cell): tear down execute state streaming without cancel-into-close

### DIFF
--- a/nova/cell/motion_group.py
+++ b/nova/cell/motion_group.py
@@ -558,14 +558,18 @@ class MotionGroup(AbstractRobot):
                                              in milliseconds. Defaults to None, which is the
                                              server default of 200 ms.
         """
-        subscription = self._api_client.motion_group_state_stream(
-            cell=self._cell, controller_id=self._controller_id, motion_group_id=self.id
-        ).subscribe(response_rate_msecs)
+        subscription = self._state_stream().subscribe(response_rate_msecs)
         try:
             async for state in subscription:
                 yield state
         finally:
             await subscription.aclose()
+
+    def _state_stream(self):
+        """The shared state stream of this motion group on its gateway."""
+        return self._api_client.motion_group_state_stream(
+            cell=self._cell, controller_id=self._controller_id, motion_group_id=self.id
+        )
 
     async def joints(self) -> tuple[float, ...]:
         """Returns the current joint positions of the motion group."""
@@ -1032,21 +1036,20 @@ class MotionGroup(AbstractRobot):
                 motion_id=trajectory_id,
                 start_on_io=start_on_io,
                 pause_on_io=pause_on_io,
-                motion_group_state_stream_gen=self.stream_state,
+                # The cursor subscribes to the same shared stream this relay
+                # reads from: one state websocket per motion group, however many
+                # consumers an execution has.
+                motion_group_state_stream_gen=lambda: self._state_stream().subscribe(),
                 joint_trajectory=joint_trajectory,
             )
         )
 
-        class MotionGroupStateSentinel:
-            pass
-
-        states = asyncio.Queue[api.models.MotionGroupState | MotionGroupStateSentinel]()
-        SENTINEL = MotionGroupStateSentinel()
-
-        async def monitor_motion_group_state():
-            async for motion_group_state in self.stream_state():
-                if motion_group_state.execute:
-                    states.put_nowait(motion_group_state)
+        # The relay's own subscription. The execution task acloses it when the
+        # protocol ends, which ends the iteration below; the TaskGroup exits
+        # with all children already finished, so nothing is ever cancelled into
+        # a websocket teardown (the socket itself is closed by the shared
+        # stream's pump, in its own context).
+        subscription = self._state_stream().subscribe()
 
         async def execution():
             try:
@@ -1056,21 +1059,14 @@ class MotionGroup(AbstractRobot):
                     client_request_generator=controller,  # ty: ignore[invalid-argument-type]
                 )
             finally:
-                states.put_nowait(SENTINEL)
+                await subscription.aclose()
 
         async with asyncio.TaskGroup() as tg:
-            monitor_task = tg.create_task(monitor_motion_group_state())
-
             tg.create_task(execution(), name=f"execute_trajectory-{trajectory_id}-{self.id}")
 
-            while (motion_group_state_ := await states.get()) is not SENTINEL:
-                assert isinstance(motion_group_state_, api.models.MotionGroupState)
-                yield motion_group_state_to_motion_state(motion_group_state_)
-
-            # when the execution task finished
-            # task group will still wait for the monitoring task
-            # so we need to cancel it
-            monitor_task.cancel()
+            async for motion_group_state in subscription:
+                if motion_group_state.execute:
+                    yield motion_group_state_to_motion_state(motion_group_state)
 
     async def _tune_trajectory(
         self, joint_trajectory: api.models.JointTrajectory, tcp: str | None, actions: list[Action]

--- a/nova/cell/movement_controller/trajectory_cursor.py
+++ b/nova/cell/movement_controller/trajectory_cursor.py
@@ -45,6 +45,7 @@ Example usage:
 """
 
 import asyncio
+import contextlib
 import logging
 from collections.abc import AsyncIterator as AsyncIteratorABC
 from dataclasses import dataclass
@@ -1395,6 +1396,16 @@ class TrajectoryCursor:
             self.detach()
             # stop the cursor iterator (TODO is this the right place?)
             self._in_queue.put_nowait(_QUEUE_SENTINEL)
+            # Release the state stream. For a shared-stream subscription this
+            # only deregisters — cheap, idempotent, no websocket teardown here
+            # (the shared pump owns that); for a plain async generator it just
+            # closes the generator. Suppressing RuntimeError mirrors the
+            # session's broadcaster teardown: aclose() raises when the
+            # generator is still suspended in a sibling of a failed gather.
+            aclose = getattr(self._motion_group_state_stream, "aclose", None)
+            if aclose is not None:
+                with contextlib.suppress(RuntimeError):
+                    await aclose()
 
     async def _held_at_first_dispatch(
         self, stream: AsyncIterator[api.models.MotionGroupState]

--- a/nova/cell/state_stream.py
+++ b/nova/cell/state_stream.py
@@ -146,12 +146,19 @@ class StateSubscription:
         call from a ``finally``, a cancelled task, or a GC-driven generator
         finalizer. Contains no await point: it completes even when the calling
         context is already cancelled.
+
+        States already buffered at this point are still delivered to a consumer
+        that keeps iterating; the end marker enqueued *behind* them is what ends
+        the stream. That preserves at-least-the-buffered delivery for a consumer
+        whose subscription is closed by another task — the execute relay's
+        trailing frames must not be dropped by its own teardown.
         """
         if self._closed:
             return
         self._closed = True
         self._deregister(self)
-        # Wake a __anext__ blocked on the empty queue so it ends instead of hanging.
+        # Wake a __anext__ blocked on the empty queue so it ends instead of
+        # hanging; enqueued behind any buffered states so those still drain.
         self._queue.put_nowait(_EndOfStream())
 
     async def _drain_queue(self) -> AsyncGenerator[api.models.MotionGroupState, None]:
@@ -160,8 +167,6 @@ class StateSubscription:
             if isinstance(item, _EndOfStream):
                 if not self._closed and item.error is not None:
                     raise item.error
-                return
-            if self._closed:
                 return
             yield item
 

--- a/tests/cell/test_execute_shared_stream.py
+++ b/tests/cell/test_execute_shared_stream.py
@@ -185,7 +185,8 @@ async def test_cursor_subscription_is_released_when_the_monitor_ends():
     async with asyncio.timeout(5):
         async for _ in cursor.cntrl(responses()):
             pass
-        await operation
+        result = await operation
 
+    assert result.final_location == 2.0
     await asyncio.wait_for(upstream.closed.wait(), 1.0)
     assert upstream.aclose_count == 1

--- a/tests/cell/test_execute_shared_stream.py
+++ b/tests/cell/test_execute_shared_stream.py
@@ -1,0 +1,191 @@
+"""``MotionGroup._execute`` over the shared state stream.
+
+Asserts the structural properties that remove the end-of-motion stall: one
+state websocket per execution regardless of how many consumers it has (relay
+and cursor), teardown by deregistration instead of cancellation, and the
+websocket closed by the shared stream's pump once the execution is over.
+
+The ``executeTrajectory`` protocol fake mirrors the one proven in
+``test_trajectory_executor_session.py``; states flow through a real
+``MotionGroupStateStreamRegistry`` over a :class:`FakeUpstream`.
+"""
+
+import asyncio
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nova import api
+from nova.cell.motion_group import MotionGroup
+from nova.cell.state_stream import (
+    MotionGroupStateStreamRegistry,
+    SharedMotionGroupStateStream,
+    StateSubscription,
+)
+from nova.core.gateway import ApiGateway
+from tests.cell.multi_group_doubles import ended_state, running_state, state
+from tests.cell.test_state_stream import FakeUpstream
+
+pytestmark = pytest.mark.asyncio
+
+
+def _joint_trajectory() -> api.models.JointTrajectory:
+    return api.models.JointTrajectory(
+        joint_positions=[[0.0] * 6] * 3, times=[0.0, 1.0, 2.0], locations=[0.0, 1.0, 2.0]
+    )
+
+
+def _with_tcp(motion_group_state: api.models.MotionGroupState) -> api.models.MotionGroupState:
+    """The relay converts execute frames to MotionStates, which needs a TCP."""
+    return motion_group_state.model_copy(
+        update={
+            "tcp": "Flange",
+            "tcp_pose": api.models.Pose(position=[0.0] * 3, orientation=[0.0] * 3),
+        }
+    )
+
+
+class _ExecuteProtocolFake:
+    """The bidirectional ``executeTrajectory`` protocol with FIFO acks.
+
+    Feeds trajectory states into ``upstream`` as the protocol advances, the way
+    a controller starts reporting once it is commanded.
+    """
+
+    def __init__(self, upstream: FakeUpstream, fail_after_start: Exception | None = None):
+        self._upstream = upstream
+        self._fail_after_start = fail_after_start
+
+    async def __call__(self, cell, controller, client_request_generator):
+        responses: asyncio.Queue = asyncio.Queue()
+
+        async def response_stream() -> AsyncIterator[api.models.ExecuteTrajectoryResponse]:
+            while True:
+                yield await responses.get()
+
+        # A real motion-group stream is always live; an idle state satisfies
+        # the cursor's startup handshake before any trajectory progress.
+        self._upstream.feed(_with_tcp(state(True)))
+        async for request in client_request_generator(response_stream()):
+            if isinstance(request, api.models.InitializeMovementRequest):
+                responses.put_nowait(api.models.InitializeMovementResponse())
+            elif isinstance(request, api.models.StartMovementRequest):
+                responses.put_nowait(api.models.StartMovementResponse())
+                self._upstream.feed(_with_tcp(running_state(0.5)))
+                if self._fail_after_start is not None:
+                    self._upstream.fail(self._fail_after_start)
+                else:
+                    self._upstream.feed(_with_tcp(ended_state(2.0)))
+
+
+def _motion_group(upstream: FakeUpstream, fail_after_start: Exception | None = None) -> MotionGroup:
+    gateway = MagicMock(spec=ApiGateway)
+    registry = MotionGroupStateStreamRegistry(
+        open_stream=lambda cell, controller_id, motion_group_id, rate: upstream.open(rate)
+    )
+    gateway.motion_group_state_stream = registry.stream
+    gateway.trajectory_execution_api = MagicMock()
+    gateway.trajectory_execution_api.execute_trajectory = _ExecuteProtocolFake(
+        upstream, fail_after_start
+    )
+    motion_group = MotionGroup(
+        api_client=gateway, cell="cell", controller_id="ctrl", motion_group_id="0@ctrl"
+    )
+    motion_group._load_planned_motion = AsyncMock(return_value="traj-1")
+    return motion_group
+
+
+def _flatten(error: BaseException) -> list[BaseException]:
+    if isinstance(error, BaseExceptionGroup):
+        return [leaf for inner in error.exceptions for leaf in _flatten(inner)]
+    return [error]
+
+
+async def test_execute_uses_exactly_one_state_socket(monkeypatch):
+    upstream = FakeUpstream()
+    motion_group = _motion_group(upstream)
+
+    cancelled_anexts: list[BaseException] = []
+    original_anext = StateSubscription.__anext__
+
+    async def recording_anext(self):
+        try:
+            return await original_anext(self)
+        except asyncio.CancelledError as error:
+            cancelled_anexts.append(error)
+            raise
+
+    monkeypatch.setattr("nova.cell.state_stream.StateSubscription.__anext__", recording_anext)
+
+    motion_states = []
+    async with asyncio.timeout(5):
+        async for motion_state in motion_group.stream_execute(
+            _joint_trajectory(), tcp=None, actions=[]
+        ):
+            motion_states.append(motion_state)
+
+    assert upstream.open_rates == [None], "relay and cursor must share one websocket"
+    assert len(motion_states) == 2, "the running and the ended frame are relayed"
+    # The idle handshake frame has no execute block and is filtered out.
+
+    # Teardown is deregistration, never cancellation into a websocket close.
+    assert cancelled_anexts == []
+    await asyncio.wait_for(upstream.closed.wait(), 1.0)
+    assert upstream.aclose_count == 1, "the pump closes the websocket once, when refcount hits 0"
+
+
+async def test_execute_surfaces_a_state_stream_failure_mid_operation():
+    upstream = FakeUpstream()
+    motion_group = _motion_group(upstream, fail_after_start=RuntimeError("state stream died"))
+
+    with pytest.raises(BaseException) as excinfo:
+        async with asyncio.timeout(5):
+            async for _ in motion_group.stream_execute(_joint_trajectory(), tcp=None, actions=[]):
+                pass
+
+    leaves = _flatten(excinfo.value)
+    assert any(
+        isinstance(error, RuntimeError) and "state stream died" in str(error) for error in leaves
+    ), f"expected the upstream error to surface, got {leaves!r}"
+
+    # The failed socket is closed and a later execution would get a fresh one.
+    await asyncio.wait_for(upstream.closed.wait(), 1.0)
+
+
+async def test_cursor_subscription_is_released_when_the_monitor_ends():
+    """The cursor monitor acloses its shared-stream subscription in its finally.
+
+    Covered end-to-end by test_execute_uses_exactly_one_state_socket (the
+    refcount only reaches 0 because both subscriptions deregister); this pins
+    the seam directly: a cursor fed by a subscription releases it on detach.
+    """
+    upstream = FakeUpstream()
+    shared = SharedMotionGroupStateStream(open_stream=upstream.open, name="cell/ctrl/0@ctrl")
+
+    from nova.cell.movement_controller.trajectory_cursor import TrajectoryCursor
+
+    cursor = TrajectoryCursor(
+        motion_id="traj-1",
+        motion_group_state_stream=lambda: shared.subscribe(),
+        joint_trajectory=_joint_trajectory(),
+        detach_on_standstill=True,
+        emit_motion_events=False,
+    )
+
+    async def responses() -> AsyncIterator[api.models.ExecuteTrajectoryResponse]:
+        yield api.models.InitializeMovementResponse()
+        yield api.models.StartMovementResponse()
+
+    operation = cursor.forward()
+    upstream.feed(state(True))
+    upstream.feed(running_state(0.5))
+    upstream.feed(ended_state(2.0))
+
+    async with asyncio.timeout(5):
+        async for _ in cursor.cntrl(responses()):
+            pass
+        await operation
+
+    await asyncio.wait_for(upstream.closed.wait(), 1.0)
+    assert upstream.aclose_count == 1

--- a/tests/cell/test_state_stream.py
+++ b/tests/cell/test_state_stream.py
@@ -110,6 +110,23 @@ async def test_aclose_is_idempotent_and_wakes_a_blocked_anext(shared, upstream):
         await blocked
 
 
+async def test_states_buffered_before_a_cross_task_aclose_still_drain(shared, upstream):
+    """The execute relay's subscription is aclosed by the execution task while
+    the relay may still be draining: frames buffered before the close must be
+    delivered, with the end marker behind them ending the stream — the old
+    sentinel-queue design's guarantee."""
+    subscription = shared.subscribe()
+    upstream.feed("s1")
+    upstream.feed("s2")
+    while not upstream._feed.empty():
+        await asyncio.sleep(0)
+    for _ in range(3):
+        await asyncio.sleep(0)  # both states are broadcast into the queue now
+
+    await subscription.aclose()  # another task closes; nothing consumed yet
+    assert [state async for state in subscription] == ["s1", "s2"]
+
+
 async def test_reopen_after_full_close(shared, upstream):
     first = shared.subscribe()
     upstream.feed("s1")


### PR DESCRIPTION
Stacked on #499 (merge that first; this PR's diff is its last commit).

## Summary
- Restructure `MotionGroup._execute`: the MotionState relay and the trajectory cursor become two subscriptions to the motion group's shared state stream; the relay's sentinel queue, the monitor task and its `monitor_task.cancel()` are gone.
- The cursor's state monitor releases its stream source in the `finally` that already handles stream-gone teardown.

## Why
#499 removed the transport-pause precondition, but `_execute` still ended every motion by cancelling a task that held a state stream — the SDK's own teardown ran a websocket close inside a cancelled TaskGroup child, the exact shape the stall analysis identified (`cell-plc-simulation`, `nova/ir999r01/lab/FINDINGS.md`: "the TaskGroup waits for that cancelled task's cleanup — `await websocket.close()` — before `execute()` may return").

## Benefits
- `execute()` returns as soon as the protocol ends: teardown is deregistration (no await points), the TaskGroup exits with all children already finished, and the websocket is closed by the shared stream's pump in its own context. Nothing is ever cancelled into a socket close.
- One state websocket per execution regardless of consumer count (relay + cursor), verified by socket-counting tests and `lsof` on a live run.

## How
- The execution task `aclose()`s the relay's subscription in its `finally`, which ends the relaying iteration — replacing sentinel-queue-plus-cancel with plain completion.
- The cursor still receives a zero-arg stream factory (`lambda: self._state_stream().subscribe(rate)`), so the `MovementController`/`MotionGroupStateSource` seam and all ~40 existing test call sites are untouched. Its monitor's `finally` additionally acloses the source — a no-op deregistration for shared-stream subscriptions, a plain generator close for test iterators.
- Error semantics preserved: an upstream failure re-raises per subscription, so the execution fails and the cursor keeps its "stream ended before the movement completed" behavior.

## Test plan
- [x] New `tests/cell/test_execute_shared_stream.py`: exactly one state socket per `execute()` (relay + cursor shared, socket closed once by the pump when refcount hits 0); an instrumented `StateSubscription.__anext__` observes no `CancelledError`; an upstream failure mid-operation surfaces from `stream_execute`; a cursor releases its subscription on detach.
- [x] Unchanged suites green: `test_trajectory_cursor_parity.py` (~25 cases), `test_trajectory_cursor*.py`, multi-group suites over `multi_group_doubles.py`, `test_process_motion_group_state.py` — full run: 658 passed.
- [x] Integration against a virtual NOVA instance: movement, cursor, cancelation, pause-on-IO — 14 passed.
- [x] Stall probe (`zero_motion_loop.py`, 450 zero-motion executes, `max_queue` at the library default, `close_timeout=2`): 0 close-timeout stalls (baseline on `main`: 25/400). Discriminator run at `close_timeout=8`: max execute 1.77 s — no stall follows the timeout anymore. `lsof` during the run: ≤2 websockets per motion group.

## Notes for reviewers
- Exception shape at the `stream_execute` boundary: an error from the state stream now propagates as itself (or grouped with a concurrent execution error) instead of always arriving wrapped by the extra monitor task — strictly less nesting.
- Follow-up deliberately out of scope: execute-socket teardown when a caller abandons `stream_execute` mid-flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
