### PR TITLE
feat(cell): surface the state stream rate on execution APIs

### DIFF
--- a/nova/cell/motion_group.py
+++ b/nova/cell/motion_group.py
@@ -1026,7 +1026,7 @@ class MotionGroup(AbstractRobot):
             logger.info("Entering trajectory tuning mode...")
             try:
                 async for motion_group_state in self._tune_trajectory(
-                    joint_trajectory, tcp, actions
+                    joint_trajectory, tcp, actions, state_stream_rate_msecs=state_stream_rate
                 ):
                     yield motion_group_state_to_motion_state(motion_group_state)
             except (Exception, BaseException) as e:
@@ -1081,7 +1081,12 @@ class MotionGroup(AbstractRobot):
                     yield motion_group_state_to_motion_state(motion_group_state)
 
     async def _tune_trajectory(
-        self, joint_trajectory: api.models.JointTrajectory, tcp: str | None, actions: list[Action]
+        self,
+        joint_trajectory: api.models.JointTrajectory,
+        tcp: str | None,
+        actions: list[Action],
+        *,
+        state_stream_rate_msecs: int | None = None,
     ) -> AsyncGenerator[api.models.MotionGroupState, None]:
         start_joints = await self.joints()
 
@@ -1099,5 +1104,12 @@ class MotionGroup(AbstractRobot):
             controller=self._controller_id,
         )
         tuner = TrajectoryTuner(plan_fn, execute_fn)
-        async for response in tuner.tune(actions, self.stream_state):
+        # The tuner calls the factory zero-arg; binding the resolved rate here
+        # keeps that seam untouched (same pattern as the TrajectoryExecutor).
+        state_stream_source = (
+            partial(self.stream_state, state_stream_rate_msecs)
+            if state_stream_rate_msecs is not None
+            else self.stream_state
+        )
+        async for response in tuner.tune(actions, state_stream_source):
             yield response

--- a/nova/cell/motion_group.py
+++ b/nova/cell/motion_group.py
@@ -571,6 +571,13 @@ class MotionGroup(AbstractRobot):
             cell=self._cell, controller_id=self._controller_id, motion_group_id=self.id
         )
 
+    def _resolve_state_stream_rate(self, explicit_rate_msecs: int | None) -> int | None:
+        """Resolution: explicit parameter, then NovaConfig, then the server default (None)."""
+        if explicit_rate_msecs is not None:
+            return explicit_rate_msecs
+        config = getattr(self._api_client, "config", None)
+        return config.motion_group_state_rate_msecs if config is not None else None
+
     async def joints(self) -> tuple[float, ...]:
         """Returns the current joint positions of the motion group."""
         return (await self.get_state()).joints
@@ -1010,7 +1017,10 @@ class MotionGroup(AbstractRobot):
         movement_controller: MovementController | None,
         start_on_io: api.models.StartOnIO | None = None,
         pause_on_io: api.models.PauseOnIO | None = None,
+        *,
+        state_stream_rate_msecs: int | None = None,
     ) -> AsyncGenerator[MotionState, None]:
+        state_stream_rate = self._resolve_state_stream_rate(state_stream_rate_msecs)
         # This is the entrypoint for the trajectory tuning mode
         if ENABLE_TRAJECTORY_TUNING:
             logger.info("Entering trajectory tuning mode...")
@@ -1039,7 +1049,9 @@ class MotionGroup(AbstractRobot):
                 # The cursor subscribes to the same shared stream this relay
                 # reads from: one state websocket per motion group, however many
                 # consumers an execution has.
-                motion_group_state_stream_gen=lambda: self._state_stream().subscribe(),
+                motion_group_state_stream_gen=lambda: self._state_stream().subscribe(
+                    state_stream_rate
+                ),
                 joint_trajectory=joint_trajectory,
             )
         )
@@ -1049,7 +1061,7 @@ class MotionGroup(AbstractRobot):
         # with all children already finished, so nothing is ever cancelled into
         # a websocket teardown (the socket itself is closed by the shared
         # stream's pump, in its own context).
-        subscription = self._state_stream().subscribe()
+        subscription = self._state_stream().subscribe(state_stream_rate)
 
         async def execution():
             try:

--- a/nova/cell/robot_cell.py
+++ b/nova/cell/robot_cell.py
@@ -361,6 +361,8 @@ class AbstractRobot(Device):
         movement_controller: MovementController | None,
         start_on_io: api.models.StartOnIO | None = None,
         pause_on_io: api.models.PauseOnIO | None = None,
+        *,
+        state_stream_rate_msecs: int | None = None,
     ) -> AsyncGenerator[MotionState, None]:
         """Execute a planned motion
 
@@ -371,6 +373,9 @@ class AbstractRobot(Device):
             movement_controller (MovementController): The movement controller to be used. Defaults to move_forward
             start_on_io (StartOnIO | None): The start on IO. If none, does not wait for IO. Defaults to None.
             pause_on_io (PauseOnIO | None): The pause on IO. If none, does not pause on IO. Defaults to None.
+            state_stream_rate_msecs (int | None): Rate of the motion-group state stream that feeds
+                execution progress, in milliseconds. None falls back to
+                NovaConfig.motion_group_state_rate_msecs, then to the server default (200 ms).
         """
 
     async def stream_execute(
@@ -381,6 +386,8 @@ class AbstractRobot(Device):
         movement_controller: MovementController | None = None,
         start_on_io: api.models.StartOnIO | None = None,
         pause_on_io: api.models.PauseOnIO | None = None,
+        *,
+        state_stream_rate_msecs: int | None = None,
     ) -> AsyncGenerator[MotionState, None]:
         """Execute a planned motion
 
@@ -394,6 +401,9 @@ class AbstractRobot(Device):
             movement_controller (MovementController): The movement controller to be used. Defaults to move_forward
             start_on_io (StartOnIO | None): The start on IO. If none, does not wait for IO. Defaults to None.
             pause_on_io (PauseOnIO | None): The pause on IO. If none, does not pause on IO. Defaults to None.
+            state_stream_rate_msecs (int | None): Rate of the motion-group state stream that feeds
+                execution progress, in milliseconds. None falls back to
+                NovaConfig.motion_group_state_rate_msecs, then to the server default (200 ms).
         """
         actions_list = _normalize_actions(actions)
 
@@ -404,6 +414,7 @@ class AbstractRobot(Device):
             movement_controller=movement_controller,
             start_on_io=start_on_io,
             pause_on_io=pause_on_io,
+            state_stream_rate_msecs=state_stream_rate_msecs,
         )
 
         async with aclosing(motion_state_stream) as motion_state_stream:
@@ -418,6 +429,8 @@ class AbstractRobot(Device):
         movement_controller: MovementController | None = None,
         start_on_io: api.models.StartOnIO | None = None,
         pause_on_io: api.models.PauseOnIO | None = None,
+        *,
+        state_stream_rate_msecs: int | None = None,
     ) -> None:
         """Execute a planned motion
 
@@ -428,6 +441,9 @@ class AbstractRobot(Device):
             movement_controller (MovementController): The movement controller to be used. Defaults to move_forward
             start_on_io (StartOnIO | None): The start on IO. If none, does not wait for IO. Defaults to None.
             pause_on_io (PauseOnIO | None): The pause on IO. If none, does not pause on IO. Defaults to None.
+            state_stream_rate_msecs (int | None): Rate of the motion-group state stream that feeds
+                execution progress, in milliseconds. None falls back to
+                NovaConfig.motion_group_state_rate_msecs, then to the server default (200 ms).
         """
 
         motion_state_stream = self.stream_execute(
@@ -437,6 +453,7 @@ class AbstractRobot(Device):
             movement_controller=movement_controller,
             start_on_io=start_on_io,
             pause_on_io=pause_on_io,
+            state_stream_rate_msecs=state_stream_rate_msecs,
         )
         async with aclosing(motion_state_stream) as motion_state_stream:
             async for _ in motion_state_stream:
@@ -452,6 +469,8 @@ class AbstractRobot(Device):
         pause_on_io: api.models.PauseOnIO | None = None,
         payload_override: str | api.models.Payload | None = None,
         singularity_handling: api.models.SingularityHandling | None = None,
+        *,
+        state_stream_rate_msecs: int | None = None,
     ) -> AsyncIterable[MotionState]:
         """Plan and execute a trajectory for the given actions.
 
@@ -467,6 +486,9 @@ class AbstractRobot(Device):
             singularity_handling (api.models.SingularityHandling | None): Strategy for handling
                 wrist singularities along a cartesian path. If None, the API default (NONE) is
                 used. Experimental.
+            state_stream_rate_msecs (int | None): Rate of the motion-group state stream that feeds
+                execution progress, in milliseconds. None falls back to
+                NovaConfig.motion_group_state_rate_msecs, then to the server default (200 ms).
         """
         actions_list = _normalize_actions(actions)
 
@@ -488,6 +510,7 @@ class AbstractRobot(Device):
             movement_controller=movement_controller,
             start_on_io=start_on_io,
             pause_on_io=pause_on_io,
+            state_stream_rate_msecs=state_stream_rate_msecs,
         )
         async with aclosing(motion_state_stream) as motion_state_stream:
             async for motion_state in motion_state_stream:
@@ -503,6 +526,8 @@ class AbstractRobot(Device):
         pause_on_io: api.models.PauseOnIO | None = None,
         payload_override: str | api.models.Payload | None = None,
         singularity_handling: api.models.SingularityHandling | None = None,
+        *,
+        state_stream_rate_msecs: int | None = None,
     ) -> None:
         """Plan and execute a trajectory for the given actions.
 
@@ -518,6 +543,9 @@ class AbstractRobot(Device):
             singularity_handling (api.models.SingularityHandling | None): Strategy for handling
                 wrist singularities along a cartesian path. If None, the API default (NONE) is
                 used. Experimental.
+            state_stream_rate_msecs (int | None): Rate of the motion-group state stream that feeds
+                execution progress, in milliseconds. None falls back to
+                NovaConfig.motion_group_state_rate_msecs, then to the server default (200 ms).
 
         Raises:
             NoInverseKinematicsSolutionFound: When inverse kinematics cannot find a solution for a target
@@ -543,6 +571,7 @@ class AbstractRobot(Device):
             movement_controller=movement_controller,
             start_on_io=start_on_io,
             pause_on_io=pause_on_io,
+            state_stream_rate_msecs=state_stream_rate_msecs,
         )
 
     @abstractmethod

--- a/nova/cell/simulation.py
+++ b/nova/cell/simulation.py
@@ -255,6 +255,8 @@ class SimulatedRobot(ConfigurablePeriphery, AbstractRobot):
         movement_controller: MovementController | None,
         start_on_io: api.models.StartOnIO | None = None,
         pause_on_io: api.models.PauseOnIO | None = None,
+        *,
+        state_stream_rate_msecs: int | None = None,
     ) -> AsyncGenerator[MotionState, None]:
         """
         Executes the given joint_trajectory by simulating the robot's motion.

--- a/nova/cell/trajectory_executor.py
+++ b/nova/cell/trajectory_executor.py
@@ -38,6 +38,7 @@ Example:
 """
 
 import asyncio
+import functools
 from collections.abc import AsyncGenerator, Iterable, Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -75,10 +76,15 @@ class GroupArgs:
             limits, so skipping the check costs nothing here and is the only
             way to keep it as planned. Turn it off for a group whose trajectory
             was not planned by Nova.
+        state_stream_rate_msecs: Rate of this group's motion-group state
+            stream, in milliseconds. None means the server default (200 ms).
+            The shared stream is opened at the rate of its first subscriber;
+            see :meth:`MotionGroup.stream_state`.
     """
 
     tcp: str | None = None
     ignore_controller_limits: bool = True
+    state_stream_rate_msecs: int | None = None
 
 
 class TrajectoryExecutor:
@@ -148,9 +154,17 @@ class TrajectoryExecutor:
             trajectory_id = await motion_group._load_planned_motion(
                 joint_trajectory, group_args.tcp
             )
+            # Binding the rate keeps the cursor's zero-arg stream factory seam
+            # untouched; with no rate the bare bound method is passed, exactly
+            # as before.
+            state_stream_source = (
+                functools.partial(motion_group.stream_state, group_args.state_stream_rate_msecs)
+                if group_args.state_stream_rate_msecs is not None
+                else motion_group.stream_state
+            )
             cursors[name] = TrajectoryCursor(
                 motion_id=trajectory_id,
-                motion_group_state_stream=motion_group.stream_state,
+                motion_group_state_stream=state_stream_source,
                 joint_trajectory=joint_trajectory,
                 detach_on_standstill=False,
                 emit_motion_events=False,

--- a/nova/config.py
+++ b/nova/config.py
@@ -22,6 +22,13 @@ LOG_DATETIME_FORMAT: str = config("LOG_DATETIME_FORMAT", default="%Y-%m-%d %H:%M
 # Feature flags
 ENABLE_TRAJECTORY_TUNING = config("ENABLE_TRAJECTORY_TUNING", cast=bool, default=False)
 
+# Default response rate for the motion-group state stream driving executions,
+# in milliseconds; unset means the server default (200 ms).
+_MOTION_GROUP_STATE_RATE = config("NOVA_MOTION_GROUP_STATE_RATE_MSECS", default=None)
+MOTION_GROUP_STATE_RATE_MSECS: int | None = (
+    int(_MOTION_GROUP_STATE_RATE) if _MOTION_GROUP_STATE_RATE is not None else None
+)
+
 
 class NovaConfig(BaseModel):
     """
@@ -38,6 +45,15 @@ class NovaConfig(BaseModel):
     host: str = Field(..., description="Nova API host.")
     access_token: str | None = Field(default=None, description="Access token for Nova API.")
     verify_ssl: bool = Field(default=True)
+    motion_group_state_rate_msecs: int | None = Field(
+        default=MOTION_GROUP_STATE_RATE_MSECS,
+        description=(
+            "Response rate of the motion-group state stream driving executions, in "
+            "milliseconds; used when no explicit rate is passed to execute/stream_execute. "
+            "None means the server default (200 ms). Also settable via the "
+            "NOVA_MOTION_GROUP_STATE_RATE_MSECS environment variable."
+        ),
+    )
     motion_group_state_stream_linger_secs: float = Field(
         default=0.0,
         description=(

--- a/tests/cell/test_state_stream_rate.py
+++ b/tests/cell/test_state_stream_rate.py
@@ -1,0 +1,113 @@
+"""Surfacing of the motion-group state stream rate.
+
+Resolution order for one execution: explicit ``state_stream_rate_msecs``
+parameter, then ``NovaConfig.motion_group_state_rate_msecs`` (env:
+``NOVA_MOTION_GROUP_STATE_RATE_MSECS``), then the server default (``None``,
+200 ms). The TrajectoryExecutor surfaces the same knob per group through
+``GroupArgs``.
+"""
+
+import asyncio
+from collections.abc import AsyncIterator
+
+import pytest
+
+from nova import api
+from nova.cell.trajectory_executor import GroupArgs, TrajectoryExecutor
+from nova.config import NovaConfig
+from tests.cell.multi_group_doubles import motion_group as motion_group_double
+from tests.cell.multi_group_doubles import multi_trajectory, sync_driver
+from tests.cell.test_execute_shared_stream import _joint_trajectory, _motion_group
+from tests.cell.test_state_stream import FakeUpstream
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _run_execution(motion_group) -> None:
+    async with asyncio.timeout(5):
+        async for _ in motion_group.stream_execute(
+            _joint_trajectory(), tcp=None, actions=[], state_stream_rate_msecs=None
+        ):
+            pass
+
+
+async def test_explicit_rate_opens_the_socket_at_that_rate():
+    upstream = FakeUpstream()
+    motion_group = _motion_group(upstream)
+
+    async with asyncio.timeout(5):
+        async for _ in motion_group.stream_execute(
+            _joint_trajectory(), tcp=None, actions=[], state_stream_rate_msecs=100
+        ):
+            pass
+
+    assert upstream.open_rates == [100]
+
+
+async def test_nova_config_rate_is_the_fallback():
+    upstream = FakeUpstream()
+    motion_group = _motion_group(upstream)
+    motion_group._api_client.config = NovaConfig(
+        host="http://localhost", motion_group_state_rate_msecs=333
+    )
+
+    await _run_execution(motion_group)
+
+    assert upstream.open_rates == [333]
+
+
+async def test_explicit_rate_wins_over_nova_config():
+    upstream = FakeUpstream()
+    motion_group = _motion_group(upstream)
+    motion_group._api_client.config = NovaConfig(
+        host="http://localhost", motion_group_state_rate_msecs=333
+    )
+
+    async with asyncio.timeout(5):
+        async for _ in motion_group.stream_execute(
+            _joint_trajectory(), tcp=None, actions=[], state_stream_rate_msecs=50
+        ):
+            pass
+
+    assert upstream.open_rates == [50]
+
+
+async def test_without_rate_the_server_default_is_requested():
+    upstream = FakeUpstream()
+    motion_group = _motion_group(upstream)
+
+    await _run_execution(motion_group)
+
+    assert upstream.open_rates == [None]
+
+
+async def test_group_args_rate_reaches_each_groups_stream():
+    from tests.cell.test_trajectory_executor_session import _FakeGateway
+
+    gateway = _FakeGateway()
+    requested_rates: dict[str, list] = {"a": [], "b": []}
+
+    def make_group(name: str):
+        group = motion_group_double(gateway, trajectory_id=f"traj-{name}")
+        zero_arg_stream = group.stream_state
+
+        def stream_state(rate_msecs=None) -> AsyncIterator[api.models.MotionGroupState]:
+            requested_rates[name].append(rate_msecs)
+            return zero_arg_stream()
+
+        group.stream_state = stream_state
+        return group
+
+    executor = TrajectoryExecutor(
+        {"a": make_group("a"), "b": make_group("b")}, sync=sync_driver(gateway)
+    )
+
+    async with asyncio.timeout(5):
+        async with executor.attach(
+            multi_trajectory("a", "b"),
+            {"a": GroupArgs(state_stream_rate_msecs=250)},  # "b" keeps the default
+        ):
+            pass
+
+    assert requested_rates["a"] == [250]
+    assert requested_rates["b"] == [None]

--- a/tests/cell/test_state_stream_rate.py
+++ b/tests/cell/test_state_stream_rate.py
@@ -111,3 +111,46 @@ async def test_group_args_rate_reaches_each_groups_stream():
 
     assert requested_rates["a"] == [250]
     assert requested_rates["b"] == [None]
+
+
+async def test_tuning_mode_honors_the_resolved_rate(monkeypatch):
+    """ENABLE_TRAJECTORY_TUNING must not silently drop an explicit rate: the
+    tuner's zero-arg stream factory carries it, bound the same way as for the
+    TrajectoryExecutor."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from tests.cell.multi_group_doubles import state
+    from tests.cell.test_execute_shared_stream import _with_tcp
+
+    upstream = FakeUpstream()
+    motion_group = _motion_group(upstream)
+    motion_group._api_client.motion_group_api = MagicMock()
+    motion_group._api_client.motion_group_api.get_current_motion_group_state = AsyncMock(
+        return_value=_with_tcp(state(True))
+    )
+    monkeypatch.setattr("nova.cell.motion_group.ENABLE_TRAJECTORY_TUNING", True)
+
+    captured: dict = {}
+
+    class FakeTuner:
+        def __init__(self, plan_fn, execute_fn):
+            pass
+
+        async def tune(self, actions, motion_group_state_stream_fn):
+            captured["factory"] = motion_group_state_stream_fn
+            return
+            yield  # unreachable; makes this an async generator
+
+    monkeypatch.setattr("nova.cell.motion_group.TrajectoryTuner", FakeTuner)
+
+    async with asyncio.timeout(5):
+        async for _ in motion_group.stream_execute(
+            _joint_trajectory(), tcp=None, actions=[], state_stream_rate_msecs=77
+        ):
+            pass
+
+    stream = captured["factory"]()  # the tuner calls the factory zero-arg
+    upstream.feed(_with_tcp(state(True)))
+    await asyncio.wait_for(stream.__anext__(), 1.0)
+    assert upstream.open_rates == [77], "the tuning stream must carry the resolved rate"
+    await stream.aclose()


### PR DESCRIPTION
Stacked on #499 and #500 (merge those first; this PR's diff is its last commit).

## Summary
- Add keyword-only `state_stream_rate_msecs` to `AbstractRobot.stream_execute` / `execute` / `stream_plan_and_execute` / `plan_and_execute`, flowing into `MotionGroup._execute` for both the relay's and the cursor's subscription.
- Add `GroupArgs.state_stream_rate_msecs` for synchronized execution, and `NovaConfig.motion_group_state_rate_msecs` (env `NOVA_MOTION_GROUP_STATE_RATE_MSECS`) as the process-wide default.

## Why
With #499/#500 every execution reads one shared state stream, but its response rate was fixed at the server default (200 ms). Callers had no way to trade feedback latency against stream volume — neither per call, nor per motion group in a `TrajectoryExecutor` session, nor fleet-wide via configuration.

## Benefits
- A caller can slow the state stream (fewer frames per motion on constrained links) or speed it up (tighter progress feedback) without touching library internals or monkeypatching.
- Operators can set one environment variable to change the default for a whole deployment; explicit call-site values still win.

## How
- Resolution order: explicit parameter → `NovaConfig.motion_group_state_rate_msecs` → server default (`None`, 200 ms), resolved in `MotionGroup._execute`.
- `TrajectoryExecutor.attach` binds the group's rate into the cursor's stream factory with `functools.partial` — the zero-arg factory seam and the cursor stay untouched; with no rate the bare bound method is passed, exactly as before.
- `SimulatedRobot._execute` accepts and ignores the parameter (nothing streams there).

## Test plan
- [x] New `tests/cell/test_state_stream_rate.py`: explicit rate opens the socket at that rate; NovaConfig value is the fallback; explicit beats config; default remains `None`; `GroupArgs` rate reaches each group's stream through a real `TrajectoryExecutor.attach` (per-group, "b" untouched).
- [x] Full unit run `PYTHONPATH=. uv run pytest -m "not integration" tests` — 658 passed; `ruff` and `ty` clean.
- [x] Integration suites against a virtual NOVA instance ran green on this stack (movement, cursor, cancelation, pause-on-IO — 14 passed).

## Notes for reviewers
- The shared socket is opened at the rate of its first subscriber (see #499): within one `execute()` both subscriptions use the same resolved rate, so no downsampling or warning path is hit by default.
- Tuner explicit rate stays a documented follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
