### PR TITLE
fix(examples): drop stale RootModel access in multi_motion_group

### DIFF
--- a/examples/multi_motion_group.py
+++ b/examples/multi_motion_group.py
@@ -15,7 +15,7 @@ _HERE = Path(__file__).parent
 
 
 def first_sample(group: str) -> list[float]:
-    return load_trajectory().joint_positions_by_motion_group_key.root[group].root[0].root
+    return load_trajectory().joint_positions_by_motion_group_key[group][0]
 
 
 def load_trajectory() -> api.models.MultiJointTrajectory:
@@ -48,10 +48,10 @@ async def multi_motion_group_trajectory(ctx: nova.ProgramContext):
     groups = {name: controller.motion_group(name) for name in TCPS}
 
     trajectory = load_trajectory()
-    samples = trajectory.joint_positions_by_motion_group_key.root
+    samples = trajectory.joint_positions_by_motion_group_key
     for name, group in groups.items():
         # A trajectory can only be executed from its own first sample.
-        await group.plan_and_execute([jnt(samples[name].root[0].root)], tcp=TCPS[name])
+        await group.plan_and_execute([jnt(samples[name][0])], tcp=TCPS[name])
 
     executor = (
         TrajectoryExecutor.builder(groups).sync_on_io(SYNC_IO_ID, controller=CONTROLLER).build()


### PR DESCRIPTION
## Summary
- Replace the three `RootModel` `.root` hops in `examples/multi_motion_group.py` with plain dict/list access.

## Why
With the pinned `wandelbots_api_client`, `MultiJointTrajectory.joint_positions_by_motion_group_key` is a plain dict of nested lists. The example still unwrapped it as nested RootModels and crashed immediately (`AttributeError: 'dict' object has no attribute 'root'`), failing the `test-integration (multi_motion_group)` check on every PR — first observed on #499, where the examples workflow ran for the first time since the model shape changed. The breakage is on `main` and independent of that stack.

## Benefits
- The CI examples run is green again for every PR; #499 (and anything else currently open) stops failing on an unrelated example.

## How
Access change only; the example's flow (per-group start move, IO-synchronized `TrajectoryExecutor.execute`) is untouched.

## Test plan
- [x] `python -c` smoke: `first_sample(ROBOT)` returns 6 joints, positioner samples load — the exact expressions that crashed in CI.
- [x] `uv run ruff check` / `uv run ty check` on the file — clean.
- [ ] `test-integration (multi_motion_group)` check on this PR (needs the CI cell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
