### PR TITLE
fix(cell): treat an unset state stream rate as the controller step rate

### DIFF
--- a/nova/cell/motion_group.py
+++ b/nova/cell/motion_group.py
@@ -555,8 +555,9 @@ class MotionGroup(AbstractRobot):
 
         Args:
             response_rate_msecs (int | None): The rate at which state updates are streamed
-                                             in milliseconds. Defaults to None, which is the
-                                             server default of 200 ms.
+                                             in milliseconds. Defaults to None, which streams
+                                             at the controller's own step rate — the fastest
+                                             the server emits.
         """
         subscription = self._state_stream().subscribe(response_rate_msecs)
         try:
@@ -572,7 +573,7 @@ class MotionGroup(AbstractRobot):
         )
 
     def _resolve_state_stream_rate(self, explicit_rate_msecs: int | None) -> int | None:
-        """Resolution: explicit parameter, then NovaConfig, then the server default (None)."""
+        """Resolution: explicit parameter, then NovaConfig, then None (controller step rate)."""
         if explicit_rate_msecs is not None:
             return explicit_rate_msecs
         config = getattr(self._api_client, "config", None)

--- a/nova/cell/robot_cell.py
+++ b/nova/cell/robot_cell.py
@@ -375,7 +375,8 @@ class AbstractRobot(Device):
             pause_on_io (PauseOnIO | None): The pause on IO. If none, does not pause on IO. Defaults to None.
             state_stream_rate_msecs (int | None): Rate of the motion-group state stream that feeds
                 execution progress, in milliseconds. None falls back to
-                NovaConfig.motion_group_state_rate_msecs, then to the server default (200 ms).
+                NovaConfig.motion_group_state_rate_msecs, then to the controller's own step
+                rate (the server's behavior when no rate is requested).
         """
 
     async def stream_execute(
@@ -403,7 +404,8 @@ class AbstractRobot(Device):
             pause_on_io (PauseOnIO | None): The pause on IO. If none, does not pause on IO. Defaults to None.
             state_stream_rate_msecs (int | None): Rate of the motion-group state stream that feeds
                 execution progress, in milliseconds. None falls back to
-                NovaConfig.motion_group_state_rate_msecs, then to the server default (200 ms).
+                NovaConfig.motion_group_state_rate_msecs, then to the controller's own step
+                rate (the server's behavior when no rate is requested).
         """
         actions_list = _normalize_actions(actions)
 
@@ -443,7 +445,8 @@ class AbstractRobot(Device):
             pause_on_io (PauseOnIO | None): The pause on IO. If none, does not pause on IO. Defaults to None.
             state_stream_rate_msecs (int | None): Rate of the motion-group state stream that feeds
                 execution progress, in milliseconds. None falls back to
-                NovaConfig.motion_group_state_rate_msecs, then to the server default (200 ms).
+                NovaConfig.motion_group_state_rate_msecs, then to the controller's own step
+                rate (the server's behavior when no rate is requested).
         """
 
         motion_state_stream = self.stream_execute(
@@ -488,7 +491,8 @@ class AbstractRobot(Device):
                 used. Experimental.
             state_stream_rate_msecs (int | None): Rate of the motion-group state stream that feeds
                 execution progress, in milliseconds. None falls back to
-                NovaConfig.motion_group_state_rate_msecs, then to the server default (200 ms).
+                NovaConfig.motion_group_state_rate_msecs, then to the controller's own step
+                rate (the server's behavior when no rate is requested).
         """
         actions_list = _normalize_actions(actions)
 
@@ -545,7 +549,8 @@ class AbstractRobot(Device):
                 used. Experimental.
             state_stream_rate_msecs (int | None): Rate of the motion-group state stream that feeds
                 execution progress, in milliseconds. None falls back to
-                NovaConfig.motion_group_state_rate_msecs, then to the server default (200 ms).
+                NovaConfig.motion_group_state_rate_msecs, then to the controller's own step
+                rate (the server's behavior when no rate is requested).
 
         Raises:
             NoInverseKinematicsSolutionFound: When inverse kinematics cannot find a solution for a target

--- a/nova/cell/state_stream.py
+++ b/nova/cell/state_stream.py
@@ -29,8 +29,11 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
-# What ``response_rate=None`` means server-side; used to order subscriber rates.
-_SERVER_DEFAULT_RATE_MSECS = 200
+# ``response_rate=None`` means the controller's own step rate server-side —
+# the fastest the server emits (measured ~3-12 ms depending on controller) —
+# so for rate ordering ``None`` counts as faster than any explicit rate.
+# (The API documentation's "default is 200 ms" is wrong; verified empirically.)
+_STEP_RATE_ORDERING_MSECS = 0
 
 # Bound per subscriber queue: a subscriber that is never consumed must not grow
 # without limit; oldest states are dropped first.
@@ -194,7 +197,9 @@ class SharedMotionGroupStateStream:
     subscription deregisters (after ``linger_secs``). A later subscribe reopens
     it. The socket rate is fixed by the subscriber that opened it: a later
     subscriber asking for a slower rate is downsampled client-side, one asking
-    for a faster rate gets the socket's slower rate and a warning.
+    for a faster rate gets the socket's slower rate and a warning. A rate of
+    ``None`` means the controller's own step rate — the fastest the server
+    emits — so it opens the socket at full rate and is never downsampled.
 
     An upstream error ends every subscription with that error; a graceful
     upstream end just ends them. Either way the next subscribe opens a fresh
@@ -217,7 +222,8 @@ class SharedMotionGroupStateStream:
 
         Args:
             response_rate_msecs: Rate at which this subscriber wants states, in
-                milliseconds. ``None`` means the server default of 200 ms.
+                milliseconds. ``None`` means the controller's own step rate —
+                the fastest the server emits.
         """
         generation = self._generation
         if (
@@ -231,23 +237,31 @@ class SharedMotionGroupStateStream:
             )
             self._generation = generation
 
-        socket_rate = (
+        socket_order = (
             generation.rate_msecs
             if generation.rate_msecs is not None
-            else _SERVER_DEFAULT_RATE_MSECS
+            else _STEP_RATE_ORDERING_MSECS
         )
-        requested_rate = (
-            response_rate_msecs if response_rate_msecs is not None else _SERVER_DEFAULT_RATE_MSECS
+        requested_order = (
+            response_rate_msecs if response_rate_msecs is not None else _STEP_RATE_ORDERING_MSECS
         )
         downsample_to_msecs: int | None = None
-        if requested_rate < socket_rate:
+        if requested_order < socket_order:
+            # socket_order > requested_order >= 0 implies an explicit socket rate.
+            requested_label = (
+                "the controller step rate"
+                if response_rate_msecs is None
+                else f"{response_rate_msecs} ms"
+            )
             logger.warning(
                 f"Motion group state stream '{self._name}' is already open at "
-                f"{socket_rate} ms; a new subscription asking for {requested_rate} ms "
-                f"cannot make it faster and will receive states at {socket_rate} ms."
+                f"{generation.rate_msecs} ms; a new subscription asking for "
+                f"{requested_label} cannot make it faster and will receive states "
+                f"at {generation.rate_msecs} ms."
             )
-        elif requested_rate > socket_rate:
-            downsample_to_msecs = requested_rate
+        elif requested_order > socket_order:
+            # requested_order > 0 implies an explicit requested rate.
+            downsample_to_msecs = response_rate_msecs
 
         queue: asyncio.Queue[api.models.MotionGroupState | _EndOfStream] = asyncio.Queue()
         subscription = StateSubscription(

--- a/nova/cell/trajectory_executor.py
+++ b/nova/cell/trajectory_executor.py
@@ -77,9 +77,10 @@ class GroupArgs:
             way to keep it as planned. Turn it off for a group whose trajectory
             was not planned by Nova.
         state_stream_rate_msecs: Rate of this group's motion-group state
-            stream, in milliseconds. None means the server default (200 ms).
-            The shared stream is opened at the rate of its first subscriber;
-            see :meth:`MotionGroup.stream_state`.
+            stream, in milliseconds. None means the controller's own step
+            rate — the fastest the server emits. The shared stream is opened
+            at the rate of its first subscriber; see
+            :meth:`MotionGroup.stream_state`.
     """
 
     tcp: str | None = None

--- a/nova/config.py
+++ b/nova/config.py
@@ -23,7 +23,8 @@ LOG_DATETIME_FORMAT: str = config("LOG_DATETIME_FORMAT", default="%Y-%m-%d %H:%M
 ENABLE_TRAJECTORY_TUNING = config("ENABLE_TRAJECTORY_TUNING", cast=bool, default=False)
 
 # Default response rate for the motion-group state stream driving executions,
-# in milliseconds; unset means the server default (200 ms).
+# in milliseconds; unset means the controller's own step rate (the server's
+# behavior when no rate is requested).
 _MOTION_GROUP_STATE_RATE = config("NOVA_MOTION_GROUP_STATE_RATE_MSECS", default=None)
 MOTION_GROUP_STATE_RATE_MSECS: int | None = (
     int(_MOTION_GROUP_STATE_RATE) if _MOTION_GROUP_STATE_RATE is not None else None
@@ -50,7 +51,8 @@ class NovaConfig(BaseModel):
         description=(
             "Response rate of the motion-group state stream driving executions, in "
             "milliseconds; used when no explicit rate is passed to execute/stream_execute. "
-            "None means the server default (200 ms). Also settable via the "
+            "None means the controller's own step rate — the fastest the server emits, "
+            "its behavior when no rate is requested. Also settable via the "
             "NOVA_MOTION_GROUP_STATE_RATE_MSECS environment variable."
         ),
     )

--- a/tests/cell/test_state_stream.py
+++ b/tests/cell/test_state_stream.py
@@ -191,8 +191,25 @@ async def test_later_faster_subscriber_warns_and_keeps_the_socket(shared, upstre
     await second.aclose()
 
 
+async def test_none_subscriber_is_never_downsampled(shared, upstream, caplog):
+    """``None`` means the controller step rate — the fastest — so a ``None``
+    subscriber joining an explicit-rate socket wants MORE than the socket
+    delivers: it gets the warning and the socket's full feed, never a
+    downsample to some assumed 200 ms default."""
+    explicit = shared.subscribe(100)
+    with caplog.at_level(logging.WARNING, logger="nova.cell.state_stream"):
+        unrated = shared.subscribe()
+    assert any("cannot make it faster" in message for message in caplog.messages)
+
+    for index in range(3):
+        upstream.feed(f"s{index}")
+    assert [await next_state(unrated) for _ in range(3)] == ["s0", "s1", "s2"]
+    await explicit.aclose()
+    await unrated.aclose()
+
+
 async def test_later_slower_subscriber_is_downsampled(shared, upstream):
-    fast = shared.subscribe()  # opens the socket at the server default (200 ms)
+    fast = shared.subscribe()  # opens the socket at the controller step rate (full rate)
     slow = shared.subscribe(60_000)  # one state a minute: a burst passes only its first state
 
     for index in range(3):

--- a/tests/cell/test_state_stream_rate.py
+++ b/tests/cell/test_state_stream_rate.py
@@ -2,9 +2,9 @@
 
 Resolution order for one execution: explicit ``state_stream_rate_msecs``
 parameter, then ``NovaConfig.motion_group_state_rate_msecs`` (env:
-``NOVA_MOTION_GROUP_STATE_RATE_MSECS``), then the server default (``None``,
-200 ms). The TrajectoryExecutor surfaces the same knob per group through
-``GroupArgs``.
+``NOVA_MOTION_GROUP_STATE_RATE_MSECS``), then ``None`` — the controller's own
+step rate, the server's behavior when no rate is requested. The
+TrajectoryExecutor surfaces the same knob per group through ``GroupArgs``.
 """
 
 import asyncio
@@ -72,7 +72,7 @@ async def test_explicit_rate_wins_over_nova_config():
     assert upstream.open_rates == [50]
 
 
-async def test_without_rate_the_server_default_is_requested():
+async def test_without_rate_the_controller_step_rate_is_requested():
     upstream = FakeUpstream()
     motion_group = _motion_group(upstream)
 


### PR DESCRIPTION
## Summary
- Correct every doc block from #499/#500/#501 that described `response_rate=None` as "the server default of 200 ms": `None` actually streams at the controller's own step rate — the fastest the server emits.
- Fix the one place that assumption leaked into behavior: `subscribe()`'s fastest-wins ordering now treats `None` as faster than any explicit rate.

## Why
The NOVA API documentation states the state stream's `response_rate` "Default is 200 ms". Measured against a live instance, that is wrong: omitting the parameter yields ~3.3 ms median inter-frame intervals on a KUKA (its step rate), while `response_rate=200`/`500` track the requested values (~200/~503 ms means). The recent shared-state-stream PRs replicated the documented-but-wrong default into docstrings — and into `subscribe()`'s rate ordering, where `None` counted as 200 ms.

## Benefits
- Docstrings on `stream_execute`/`execute`/`plan_and_execute`/`stream_plan_and_execute`, `stream_state`, `GroupArgs`, and `NovaConfig` now tell callers the truth about what an unset rate costs (full-rate stream) and delivers (fastest feedback).
- A `None` subscriber joining an explicit-rate socket now gets the cannot-make-it-faster warning and the socket's full feed, instead of being silently downsampled to an assumed 200 ms — a consumer that asked for maximum rate is never throttled client-side.

## How
`_SERVER_DEFAULT_RATE_MSECS = 200` is gone; `None` orders as 0 (fastest) in the fastest-wins comparison, with the warning message naming "the controller step rate" instead of a fabricated number. No change to which subscriber fixes the socket rate, downsampling of explicitly-slower subscribers, or any teardown behavior.

Measurement (python `websockets` against the k8s testing instance, 25 frames each):

| request | mean interval | median |
|---|---|---|
| no `response_rate` | 3.7 ms | 3.3 ms |
| `response_rate=200` | 199.8 ms | 198.7 ms |
| `response_rate=500` | 503.2 ms | 502.1 ms |

## Test plan
- [x] New `test_none_subscriber_is_never_downsampled`: a `None` subscriber after an explicit-rate opener receives every frame of a fast burst (fails on the previous ordering, which downsampled it to 200 ms).
- [x] `test_without_rate_the_server_default_is_requested` renamed to `..._the_controller_step_rate_is_requested`; wording fixed in the other tests.
- [x] `PYTHONPATH=. uv run pytest -m "not integration" tests/cell tests/core` — 290 passed; `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
