### PR TITLE
fix(RB-4251): J5 transform for KR6 R1820

### DIFF
--- a/nova_rerun_bridge/dh_robot.py
+++ b/nova_rerun_bridge/dh_robot.py
@@ -3,19 +3,70 @@ import numpy as np
 from nova import api
 
 
+def _pose_to_matrix(pose: api.models.Pose) -> np.ndarray:
+    """
+    Convert a PlannerPose (with rotation-vector orientation) into a 4x4 homogeneous transformation matrix.
+    :param pose: A PlannerPose object with position: Vector3d and orientation: RotationVector.
+    :return: A 4x4 numpy array representing the transformation.
+    """
+    # Extract translation
+    if pose.position is None:
+        x, y, z = 0.0, 0.0, 0.0
+    else:
+        x, y, z = pose.position[0], pose.position[1], pose.position[2]
+
+    # Extract rotation vector (axis * angle)
+    if pose.orientation is None:
+        R = np.eye(3)
+    else:
+        rx, ry, rz = pose.orientation[0], pose.orientation[1], pose.orientation[2]
+        theta = np.linalg.norm([rx, ry, rz])
+
+        if theta < 1e-12:
+            R = np.eye(3)
+        else:
+            k = np.array([rx, ry, rz]) / theta
+            kx, ky, kz = k
+            K = np.array([[0.0, -kz, ky], [kz, 0.0, -kx], [-ky, kx, 0.0]])
+
+            sin_theta = np.sin(theta)
+            one_minus_cos = 1.0 - np.cos(theta)
+            # Rodrigues' rotation formula
+            R = np.eye(3) + sin_theta * K + one_minus_cos * (K @ K)
+
+    # Construct the full homogeneous transformation matrix
+    T = np.eye(4)
+    T[0:3, 0:3] = R
+    T[0:3, 3] = [x, y, z]
+
+    return T
+
+
 class DHRobot:
     """A class for handling DH parameters and computing joint positions."""
 
     def __init__(
-        self, dh_parameters: list[api.models.DHParameter], mounting: api.models.Pose
+        self,
+        dh_parameters: list[api.models.DHParameter],
+        mounting: api.models.Pose,
+        kinematic_chain_offset: api.models.Pose | None = None,
     ) -> None:
         """
         Initialize the DHRobot with DH parameters and a mounting pose.
         :param dh_parameters: List of DHParameter objects containing all joint configurations.
-        :param mounting: Pose object representing the mounting orientation and position.
+        :param mounting: Pose object representing the cell-specific placement of the motion
+            group's base frame (world -> base frame).
+        :param kinematic_chain_offset: Fixed transform between the base frame and the start
+            of the DH chain (base frame -> start of DH chain). Unlike ``mounting``, this is
+            intrinsic to the robot model itself, not to a particular installation -- it is
+            what :class:`api.models.MotionGroupDescription` calls ``kinematic_chain_offset``.
+            Defaults to identity when not given (most robot models don't need one).
         """
         self.dh_parameters = dh_parameters
         self.mounting = mounting
+        self.kinematic_chain_offset = kinematic_chain_offset or api.models.Pose(
+            position=(0, 0, 0), orientation=(0, 0, 0)
+        )
 
     def pose_to_matrix(self, pose: api.models.Pose) -> np.ndarray:
         """
@@ -23,37 +74,7 @@ class DHRobot:
         :param pose: A PlannerPose object with position: Vector3d and orientation: RotationVector.
         :return: A 4x4 numpy array representing the transformation.
         """
-        # Extract translation
-        if pose.position is None:
-            x, y, z = 0.0, 0.0, 0.0
-        else:
-            x, y, z = pose.position[0], pose.position[1], pose.position[2]
-
-        # Extract rotation vector (axis * angle)
-        if pose.orientation is None:
-            R = np.eye(3)
-        else:
-            rx, ry, rz = pose.orientation[0], pose.orientation[1], pose.orientation[2]
-            theta = np.linalg.norm([rx, ry, rz])
-
-            if theta < 1e-12:
-                R = np.eye(3)
-            else:
-                k = np.array([rx, ry, rz]) / theta
-                kx, ky, kz = k
-                K = np.array([[0.0, -kz, ky], [kz, 0.0, -kx], [-ky, kx, 0.0]])
-
-                sin_theta = np.sin(theta)
-                one_minus_cos = 1.0 - np.cos(theta)
-                # Rodrigues' rotation formula
-                R = np.eye(3) + sin_theta * K + one_minus_cos * (K @ K)
-
-        # Construct the full homogeneous transformation matrix
-        T = np.eye(4)
-        T[0:3, 0:3] = R
-        T[0:3, 3] = [x, y, z]
-
-        return T
+        return _pose_to_matrix(pose)
 
     def dh_transform(
         self, dh_param: api.models.DHParameter, joint_position: float | None
@@ -100,10 +121,11 @@ class DHRobot:
         :param joint_values: Object containing joint rotation values as a list in joint_values.joints.
         :return: A list of joint positions as [x, y, z].
         """
-        # Incorporate the mounting pose at the start
+        # First position is the base frame (mounting only); kinematic_chain_offset applies
+        # from the start of the DH chain onward, same as compute_forward_kinematics.
         accumulated_matrix = self.pose_to_matrix(self.mounting)
-
-        positions = [accumulated_matrix[:3, 3].tolist()]  # Base position after mounting is applied
+        positions = [accumulated_matrix[:3, 3].tolist()]
+        accumulated_matrix = accumulated_matrix @ self.pose_to_matrix(self.kinematic_chain_offset)
 
         for dh_param, joint_position in zip(self.dh_parameters, joint_positions, strict=False):
             transform = self.dh_transform(dh_param=dh_param, joint_position=joint_position)

--- a/nova_rerun_bridge/robot_visualizer.py
+++ b/nova_rerun_bridge/robot_visualizer.py
@@ -184,9 +184,15 @@ class RobotVisualizer:
 
     # TODO: this will not work yet
     def compute_forward_kinematics(self, joint_positions: list[float]):
-        """Compute link transforms using the robot's methods."""
+        """Compute link transforms using the robot's methods.
+
+        ``transforms[0]`` is the base frame (mounting only, no ``kinematic_chain_offset``
+        applied yet), matching the base-link mesh's own rest position -- the offset only
+        applies from the start of the DH chain onward, i.e. to ``transforms[1:]``.
+        """
         accumulated = self.robot.pose_to_matrix(self.robot.mounting)
         transforms = [accumulated.copy()]
+        accumulated = accumulated @ self.robot.pose_to_matrix(self.robot.kinematic_chain_offset)
         for dh_param, joint_position in zip(
             self.robot.dh_parameters, joint_positions, strict=False
         ):

--- a/nova_rerun_bridge/robot_visualizer.py
+++ b/nova_rerun_bridge/robot_visualizer.py
@@ -227,27 +227,31 @@ class RobotVisualizer:
     def get_dh_theta_mesh_correction(
         self, link_index: int, root_transform: np.ndarray, joint_transform: np.ndarray
     ) -> np.ndarray:
-        """Return the extra theta rotation needed after flattening a GLB link mesh.
+        """Return the extra rotation needed after flattening a GLB link mesh.
 
         The Rerun visualizer flattens GLB meshes and logs each mesh as its own Rerun
         entity. Once flattened, meshes no longer inherit the original GLB joint
         transforms, so the visualizer has to recreate the missing joint-to-mesh offset.
 
-        Some GLB joint frames already contain the DH theta offset. Applying the offset
-        again would rotate those meshes twice.
+        Some GLB joint frames already contain a DH theta offset (or some other
+        rest-pose rotation relative to their mesh geometry). Applying the offset again
+        would rotate those meshes twice.
 
-        Apply the extra DH theta correction only when static zero-pose frame checks show
-        that the flattened GLB mesh needs it:
+        Apply the extra correction only when static zero-pose frame checks show that
+        the flattened GLB mesh needs it:
         - if the DH zero-pose joint origin and GLB joint origin differ, do not rotate
           around the DH origin because that would move the mesh incorrectly;
-        - if the origins match, apply the theta correction only when it improves zero-pose
-          frame alignment with Rerun's coordinate system.
+        - if the origins match but the orientations differ, solve directly for the
+          rotation that reconciles the GLB rest-pose frame with the DH zero-pose frame,
+          rather than only ever testing a Z-axis rotation by the DH theta value. A
+          plain Z-axis test previously missed nodes whose rest-pose mismatch is exactly
+          180 degrees: rotating an already-180-degrees-off frame by another 180 degrees
+          around world Z does not generally cancel the mismatch unless the frames
+          happen to commute, so some wrist/flange nodes stayed uncorrected even though
+          a (non-Z-axis) rotation was needed and computable from the same data.
         """
         identity_transform = np.eye(4)
-        if len(self.robot.dh_parameters) <= link_index:
-            return identity_transform
-
-        if abs(theta := self.robot.dh_parameters[link_index].theta or 0.0) < 1e-12:
+        if link_index >= len(self.zero_link_transforms_without_mounting):
             return identity_transform
 
         root_rotation = root_transform[:3, :3]
@@ -256,18 +260,18 @@ class RobotVisualizer:
         if np.linalg.norm(zero_link_transform[:3, 3] - glb_joint_position) > 1.0:
             return identity_transform
 
-        theta_rotation = Rotation.from_euler("z", theta, degrees=False).as_matrix()
         base_rotation = root_rotation.T @ zero_link_transform[:3, :3]
         target_rotation = root_rotation @ joint_transform[:3, :3].T
-        current_error = Rotation.from_matrix(base_rotation @ target_rotation).magnitude()
-        corrected_error = Rotation.from_matrix(
-            base_rotation @ theta_rotation @ target_rotation
-        ).magnitude()
-        if corrected_error >= current_error - 1e-9:
+
+        # Exact rotation such that base_rotation @ correction @ target_rotation == I,
+        # i.e. the rotation that makes the flattened mesh's zero-pose orientation match
+        # the DH-predicted zero-pose orientation exactly, whatever that rotation is.
+        correction_rotation = base_rotation.T @ target_rotation.T
+        if Rotation.from_matrix(correction_rotation).magnitude() < 1e-6:
             return identity_transform
 
         correction_transform = np.eye(4)
-        correction_transform[:3, :3] = theta_rotation
+        correction_transform[:3, :3] = correction_rotation
         return correction_transform
 
     def get_transform_matrix(self):

--- a/nova_rerun_bridge/stream_state.py
+++ b/nova_rerun_bridge/stream_state.py
@@ -103,7 +103,9 @@ async def stream_motion_group(
             position=(0, 0, 0), orientation=(0, 0, 0)
         )
         robot = DHRobot(
-            dh_parameters=motion_group_description.dh_parameters or [], mounting=mounting
+            dh_parameters=motion_group_description.dh_parameters or [],
+            mounting=mounting,
+            kinematic_chain_offset=motion_group_description.kinematic_chain_offset,
         )
         rr.reset_time()
         rr.set_time(TIME_REALTIME_NAME, timestamp=time.time())

--- a/nova_rerun_bridge/trajectory.py
+++ b/nova_rerun_bridge/trajectory.py
@@ -112,7 +112,11 @@ async def log_motion(
     mounting = motion_group_setup.mounting or api.models.Pose(
         position=(0, 0, 0), orientation=(0, 0, 0)
     )
-    robot = DHRobot(dh_parameters=motion_group_description.dh_parameters, mounting=mounting)
+    robot = DHRobot(
+        dh_parameters=motion_group_description.dh_parameters,
+        mounting=mounting,
+        kinematic_chain_offset=motion_group_description.kinematic_chain_offset,
+    )
 
     # TODO: merge collision_setups
     collision_link_chain, collision_tcp = extract_link_chain_and_tcp(


### PR DESCRIPTION
<img width="617" height="265" alt="image" src="https://github.com/user-attachments/assets/dbe39daa-d94c-4a37-a463-bc9bdc352efe" />
this fixes the offset in the link_5 rotations for a bunch of kukas and a bunch of abbs. it reintroduces a fault in the hc10dtp but this gets fixed in parallel in the rdp: [https://code.wabo.run/robotics/robot-data-provider/-/merge_requests/280](https://code.wabo.run/robotics/robot-data-provider/-/merge_requests/280)

This also adds support for glbs with kinematic chain offset